### PR TITLE
Link to new native folder. Don't copy to build folder

### DIFF
--- a/vtm-ios/build.gradle
+++ b/vtm-ios/build.gradle
@@ -38,11 +38,6 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-ios"
 }
 
-task copyLibs(type: Copy) {
-    from("natives")
-    into("${buildDir}/natives")
-}
-
 task copyVtmResources(type: Copy) {
     from("../vtm/resources")
     into("${buildDir}")
@@ -53,9 +48,6 @@ task copyVtmThemesResources(type: Copy) {
     into("${buildDir}")
 }
 
-tasks.withType(org.gradle.api.tasks.compile.JavaCompile) {
-    compileTask -> compileTask.dependsOn copyLibs
-}
 
 tasks.withType(org.gradle.api.tasks.compile.JavaCompile) {
     compileTask -> compileTask.dependsOn copyVtmResources

--- a/vtm-ios/robovm.xml
+++ b/vtm-ios/robovm.xml
@@ -33,7 +33,7 @@
         <pattern>org.apache.harmony.security.provider.crypto.CryptoProvider</pattern>
     </forceLinkClasses>
     <libs>
-        <lib>build/natives/libvtm-jni.a</lib>
+        <lib>natives/libvtm-jni.a</lib>
     </libs>
     <frameworks>
         <framework>UIKit</framework>


### PR DESCRIPTION
We can link to new native folder at the robovm.xml. Don't copy(unzip) to build folder