### PR TITLE
A viewport should also be considered changed if its dimensions have changed.

### DIFF
--- a/vtm/src/org/oscim/map/Viewport.java
+++ b/vtm/src/org/oscim/map/Viewport.java
@@ -389,6 +389,8 @@ public class Viewport {
     }
 
     protected boolean copy(Viewport viewport) {
+        boolean sizeChanged = mHeight != viewport.mHeight || mWidth != viewport.mWidth;
+
         mHeight = viewport.mHeight;
         mWidth = viewport.mWidth;
         mProjMatrix.copy(viewport.mProjMatrix);
@@ -399,7 +401,7 @@ public class Viewport {
         mRotationMatrix.copy(viewport.mRotationMatrix);
         mViewMatrix.copy(viewport.mViewMatrix);
         mViewProjMatrix.copy(viewport.mViewProjMatrix);
-        return viewport.getMapPosition(mPos);
+        return viewport.getMapPosition(mPos) || sizeChanged;
     }
 
     public double getMaxScale() {


### PR DESCRIPTION
This will cause the tile layer to be rendered correctly (fill the entire viewport) after an orientation change.