### PR TITLE
Fix event listener unbinding

### DIFF
--- a/vtm/src/org/oscim/event/EventDispatcher.java
+++ b/vtm/src/org/oscim/event/EventDispatcher.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2013 Hannes Janetzek
+ * Copyright 2016 Andrey Novikov
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.event;
 
 import org.oscim.utils.pool.LList;
@@ -26,7 +43,7 @@ public abstract class EventDispatcher<E extends EventListener, T> {
         if (LList.find(mListeners, listener) != null) {
             return;
         }
-        mListeners = LList.push(mListeners, new LList<E>(listener));
+        mListeners = LList.push(mListeners, listener);
     }
 
     /**

--- a/vtm/src/org/oscim/utils/pool/LList.java
+++ b/vtm/src/org/oscim/utils/pool/LList.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2016 Andrey Novikov
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -36,18 +37,19 @@ public class LList<T> extends Inlist<LList<T>> {
             return list.next;
 
         LList<T> prev = list;
-        for (LList<T> l = list.next; l != null; l = l.next)
+        for (LList<T> l = list.next; l != null; l = l.next) {
             if (l.data == item) {
                 prev.next = l.next;
                 break;
             }
-
+            prev = l;
+        }
         return list;
     }
 
-    public static <T extends LList<T>> LList<T> push(LList<T> list, T item) {
-        item.next = list;
-        return item;
+    public static <E extends LList<T>, T> LList<T> push(LList<T> list, T item) {
+        LList<T> prev = new LList<T>(item);
+        prev.next = list;
+        return prev;
     }
-
 }


### PR DESCRIPTION
Unbinding logic was completely broken. If a map layer was dynamically removed, some remaining layers stopped getting events.