### PR TITLE
Fix NaN in distance calculation

### DIFF
--- a/vtm/src/org/oscim/core/GeoPoint.java
+++ b/vtm/src/org/oscim/core/GeoPoint.java
@@ -150,21 +150,14 @@ public class GeoPoint implements Comparable<GeoPoint> {
         return result;
     }
 
-    // ===========================================================
-    // Methods from osmdroid
-    // Copyright 2012 osmdroid authors: Nicolas Gramlich,
-    // Theodore Hong
-    // ===========================================================
-
     public static final float DEG2RAD = (float) (Math.PI / 180.0);
     public static final float RAD2DEG = (float) (180.0 / Math.PI);
-    // http://en.wikipedia.org/wiki/Earth_radius#Equatorial_radius
-    public static final int RADIUS_EARTH_METERS = 6378137;
 
     /**
-     * @param other ...
+     * Calculates the distance between two points on the surface of a spheroid.
+     *
+     * @param other point to calculate distance to
      * @return distance in meters
-     * @see "http://www.geocities.com/DrChengalva/GPSDistance.html"
      */
     public double distanceTo(GeoPoint other) {
         return distance(latitudeE6 / 1E6,
@@ -173,24 +166,65 @@ public class GeoPoint implements Comparable<GeoPoint> {
                 other.longitudeE6 / 1E6);
     }
 
+    /**
+     * Calculates the distance between two points on the surface of a spheroid using Vincenty's
+     * inverse formula.
+     *
+     * @param lat1 latitude of point 1
+     * @param lon1 longitude of point 1
+     * @param lat2 latitude of point 2
+     * @param lon2 longitude of point 2
+     * @return distance in meters
+     * @see "https://en.wikipedia.org/wiki/Vincenty%27s_formulae"
+     */
     public static double distance(double lat1, double lon1, double lat2, double lon2) {
+        // WGS-84 ellipsoid
+        double a = 6378137;
+        double b = 6356752.314245;
+        double f = 1 / 298.257223563;
+        double L = DEG2RAD * (lon2 - lon1);
+        double U1 = Math.atan((1 - f) * Math.tan(DEG2RAD * lat1));
+        double U2 = Math.atan((1 - f) * Math.tan(DEG2RAD * lat2));
+        double sinU1 = Math.sin(U1);
+        double cosU1 = Math.cos(U1);
+        double sinU2 = Math.sin(U2);
+        double cosU2 = Math.cos(U2);
 
-        double a1 = DEG2RAD * lat1;
-        double a2 = DEG2RAD * lon1;
-        double b1 = DEG2RAD * lat2;
-        double b2 = DEG2RAD * lon2;
+        double lambda = L, lambdaP, iterLimit = 100;
+        double sigma, cosSqAlpha, sinSigma, cosSigma, cos2SigmaM;
 
-        double cosa1 = Math.cos(a1);
-        double cosb1 = Math.cos(b1);
+        do {
+            double sinLambda = Math.sin(lambda);
+            double cosLambda = Math.cos(lambda);
+            sinSigma = Math.sqrt((cosU2 * sinLambda) * (cosU2 * sinLambda)
+                    + (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda)
+                    * (cosU1 * sinU2 - sinU1 * cosU2 * cosLambda));
+            if (sinSigma == 0) return 0;  // co-incident points
+            cosSigma = sinU1 * sinU2 + cosU1 * cosU2 * cosLambda;
+            sigma = Math.atan2(sinSigma, cosSigma);
+            double sinAlpha = cosU1 * cosU2 * sinLambda / sinSigma;
+            cosSqAlpha = 1 - sinAlpha * sinAlpha;
+            try {
+                cos2SigmaM = cosSigma - 2 * sinU1 * sinU2 / cosSqAlpha;
+            } catch (ArithmeticException e) {
+                cos2SigmaM = 0;  // equatorial line: cosSqAlpha=0
+            }
+            double C = f / 16 * cosSqAlpha * (4 + f * (4 - 3 * cosSqAlpha));
+            lambdaP = lambda;
+            lambda = L + (1 - C) * f * sinAlpha * (sigma + C * sinSigma
+                    * (cos2SigmaM + C * cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM)));
+        }
+        while (Math.abs(lambda - lambdaP) > 1e-12 && --iterLimit > 0);
 
-        double t1 = cosa1 * Math.cos(a2) * cosb1 * Math.cos(b2);
-        double t2 = cosa1 * Math.sin(a2) * cosb1 * Math.sin(b2);
+        if (iterLimit == 0) return Double.NaN;  // formula failed to converge
 
-        double t3 = Math.sin(a1) * Math.sin(b1);
-
-        double tt = Math.acos(t1 + t2 + t3);
-
-        return (RADIUS_EARTH_METERS * tt);
+        double uSq = cosSqAlpha * (a * a - b * b) / (b * b);
+        double A = 1 + uSq / 16384 * (4096 + uSq * (-768 + uSq * (320 - 175 * uSq)));
+        double B = uSq / 1024 * (256 + uSq * (-128 + uSq * (74 - 47 * uSq)));
+        double deltaSigma = B * sinSigma * (cos2SigmaM + B / 4
+                * (cosSigma * (-1 + 2 * cos2SigmaM * cos2SigmaM) - B / 6 * cos2SigmaM
+                * (-3 + 4 * sinSigma * sinSigma) * (-3 + 4 * cos2SigmaM * cos2SigmaM)));
+        return b * A * (sigma - deltaSigma);
     }
 
     public double bearingTo(GeoPoint other) {


### PR DESCRIPTION
Existing implementation produces NaN for some points. Reference URL gives 404 and can not be checked anymore. Provided implementation can produce NaN too (by design) but works for all my tested cases (about million points). Compared by execution time methods are nearly equal - several milliseconds for 30000 points.