### PR TITLE
ItemizedLayer, PathLayer API enhancements

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,6 +2,10 @@
 
 ## Version 0.6.X
 
+**Version 0.6.0-rc3 (2016-10-22)**
+
+- Minor improvements and bug fixes
+
 **Version 0.6.0-rc2 (2016-10-16)**
 
 - Location layer [#171](https://github.com/mapsforge/vtm/issues/171)

--- a/vtm-jts/src/org/oscim/layers/vector/PathLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/PathLayer.java
@@ -27,6 +27,7 @@ import org.oscim.map.Map;
 import org.oscim.utils.geom.GeomBuilder;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -68,7 +69,7 @@ public class PathLayer extends VectorLayer {
         updatePoints();
     }
 
-    public void setPoints(List<GeoPoint> pts) {
+    public void setPoints(Collection<? extends GeoPoint> pts) {
         mPoints.clear();
         mPoints.addAll(pts);
         updatePoints();
@@ -81,6 +82,11 @@ public class PathLayer extends VectorLayer {
 
     public void addPoint(int latitudeE6, int longitudeE6) {
         mPoints.add(new GeoPoint(latitudeE6, longitudeE6));
+        updatePoints();
+    }
+
+    public void addPoints(Collection<? extends GeoPoint> pts) {
+        mPoints.addAll(pts);
         updatePoints();
     }
 

--- a/vtm/src/org/oscim/layers/PathLayer.java
+++ b/vtm/src/org/oscim/layers/PathLayer.java
@@ -35,6 +35,7 @@ import org.oscim.utils.async.SimpleWorker;
 import org.oscim.utils.geom.LineClipper;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -86,7 +87,7 @@ public class PathLayer extends Layer {
         updatePoints();
     }
 
-    public void setPoints(List<GeoPoint> pts) {
+    public void setPoints(Collection<? extends GeoPoint> pts) {
         synchronized (mPoints) {
             mPoints.clear();
             mPoints.addAll(pts);
@@ -104,6 +105,13 @@ public class PathLayer extends Layer {
     public void addPoint(int latitudeE6, int longitudeE6) {
         synchronized (mPoints) {
             mPoints.add(new GeoPoint(latitudeE6, longitudeE6));
+        }
+        updatePoints();
+    }
+
+    public void addPoints(Collection<? extends GeoPoint> pts) {
+        synchronized (mPoints) {
+            mPoints.addAll(pts);
         }
         updatePoints();
     }

--- a/vtm/src/org/oscim/layers/marker/ItemizedLayer.java
+++ b/vtm/src/org/oscim/layers/marker/ItemizedLayer.java
@@ -31,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class ItemizedLayer<Item extends MarkerInterface> extends MarkerLayer<Item>
@@ -87,17 +88,17 @@ public class ItemizedLayer<Item extends MarkerInterface> extends MarkerLayer<Ite
         return Math.min(mItemList.size(), mDrawnItemsLimit);
     }
 
-    public boolean addItem(Item item) {
+    public <T extends Item> boolean addItem(T item) {
         final boolean result = mItemList.add(item);
         populate();
         return result;
     }
 
-    public void addItem(int location, Item item) {
+    public <T extends Item> void addItem(int location, T item) {
         mItemList.add(location, item);
     }
 
-    public boolean addItems(List<Item> items) {
+    public boolean addItems(Collection<? extends Item> items) {
         final boolean result = mItemList.addAll(items);
         populate();
         return result;
@@ -118,7 +119,7 @@ public class ItemizedLayer<Item extends MarkerInterface> extends MarkerLayer<Ite
         }
     }
 
-    public boolean removeItem(Item item) {
+    public <T extends Item> boolean removeItem(T item) {
         final boolean result = mItemList.remove(item);
         populate();
         return result;
@@ -141,7 +142,7 @@ public class ItemizedLayer<Item extends MarkerInterface> extends MarkerLayer<Ite
     //    public boolean onTap(MotionEvent event, MapPosition pos) {
     //        return activateSelectedItems(event, mActiveItemSingleTap);
     //    }
-    protected boolean onSingleTapUpHelper(int index, Item item) {
+    protected <T extends Item> boolean onSingleTapUpHelper(int index, T item) {
         return mOnItemGestureListener.onItemSingleTapUp(index, item);
     }
 


### PR DESCRIPTION
This changes allows ItemizedLayer to add multiple Items of any collections.

Explanation:
if I have this code (CustomMarkerItem extends MarkerItem):
`ItemizedLayer<MarkerItem> markerLayer = new ItemizedLayer<>(map, symbol);
LinkedList<CustomMarkerItem> myIconsList = new LinkedList<>();
`

I can't add my Icon list to the ItemizedLayer:
`markerLayer.addItems(myIconsList);`
