### PR TITLE
fix bug: import javax.annotation.CheckReturnValue cannot be resolved

### DIFF
--- a/vtm/build.gradle
+++ b/vtm/build.gradle
@@ -5,7 +5,7 @@ configurations { providedCompile }
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.21'
-    providedCompile 'com.google.code.findbugs:annotations:2.0.1'
+   	compile 'com.google.code.findbugs:jsr305:3.0.1'
 }
 
 sourceSets {


### PR DESCRIPTION
There are some CheckReturnValue errors which I could fix with this change

![2016-11-02_145834](https://cloud.githubusercontent.com/assets/1283445/19931576/4ec6b724-a10d-11e6-9de5-425fa73bcb84.png)
