### PR TITLE
Made {X},{Y},{Z} customizable in derived tile sources for tile URL

### DIFF
--- a/vtm/src/org/oscim/tiling/source/UrlTileSource.java
+++ b/vtm/src/org/oscim/tiling/source/UrlTileSource.java
@@ -174,6 +174,30 @@ public abstract class UrlTileSource extends TileSource {
         return mHttpFactory.create(this);
     }
 
+    /**
+     * @param tileX
+     * @return
+     */
+    public int tileXToUrlX(int tileX) {
+        return tileX;
+    }
+
+    /**
+     * @param tileY
+     * @return
+     */
+    public int tileYToUrlY(int tileY) {
+        return tileY;
+    }
+
+    /**
+     * @param tileZ
+     * @return
+     */
+    public int tileZToUrlZ(int tileZ) {
+        return tileZ;
+    }
+
     static class DefaultTileUrlFormatter implements TileUrlFormatter {
         @Override
         public String formatTilePath(UrlTileSource tileSource, Tile tile) {
@@ -183,13 +207,13 @@ public abstract class UrlTileSource extends TileSource {
                 if (b.length() == 1) {
                     switch (b.charAt(0)) {
                         case 'X':
-                            sb.append(tile.tileX);
+                            sb.append(tileSource.tileXToUrlX(tile.tileX));
                             continue;
                         case 'Y':
-                            sb.append(tile.tileY);
+                            sb.append(tileSource.tileYToUrlY(tile.tileY));
                             continue;
                         case 'Z':
-                            sb.append(tile.zoomLevel);
+                            sb.append(tileSource.tileZToUrlZ(tile.zoomLevel));
                             continue;
                         default:
                             break;


### PR DESCRIPTION
TMS servers use negative y-axis in URL ( http://wiki.openstreetmap.org/wiki/TMS ) . This PR is to enable negative {Y} by overriding `tileYToUrlY` in derived classes.