### PR TITLE
Support TextureRegion to be used for MarkerSymbol

### DIFF
--- a/vtm/src/org/oscim/layers/marker/MarkerRenderer.java
+++ b/vtm/src/org/oscim/layers/marker/MarkerRenderer.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2016 Izumi Kawashima
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -161,7 +162,11 @@ public class MarkerRenderer extends BucketRenderer {
                 marker = mDefaultMarker;
 
             SymbolItem s = SymbolItem.pool.get();
-            s.set(it.x, it.y, marker.getBitmap(), true);
+            if (marker.isBitmap()) {
+                s.set(it.x, it.y, marker.getBitmap(), true);
+            } else {
+                s.set(it.x, it.y, marker.getTextureRegion(), true);
+            }
             s.offset = marker.getHotspot();
             s.billboard = marker.isBillboard();
             mSymbolLayer.pushSymbol(s);

--- a/vtm/src/org/oscim/layers/marker/MarkerSymbol.java
+++ b/vtm/src/org/oscim/layers/marker/MarkerSymbol.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016 devemux86
+ * Copyright 2016 Izumi Kawashima
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -19,6 +20,7 @@ package org.oscim.layers.marker;
 
 import org.oscim.backend.canvas.Bitmap;
 import org.oscim.core.PointF;
+import org.oscim.renderer.atlas.TextureRegion;
 
 public class MarkerSymbol {
     /**
@@ -34,11 +36,63 @@ public class MarkerSymbol {
     }
 
     final Bitmap mBitmap;
+    final TextureRegion mTextureRegion;
+
     /**
      * Hotspot offset
      */
     final PointF mOffset;
     final boolean mBillboard;
+
+    public MarkerSymbol(TextureRegion textureRegion, float relX, float relY) {
+        this(textureRegion, relX, relY, true);
+    }
+
+    public MarkerSymbol(TextureRegion textureRegion, float relX, float relY, boolean billboard) {
+        mBitmap = null;
+        mTextureRegion = textureRegion;
+        mOffset = new PointF(relX, relY);
+        mBillboard = billboard;
+    }
+
+    public MarkerSymbol(TextureRegion textureRegion, HotspotPlace hotspot) {
+        this(textureRegion, hotspot, true);
+    }
+
+    public MarkerSymbol(TextureRegion textureRegion, HotspotPlace hotspot, boolean billboard) {
+        mBitmap = null;
+        mTextureRegion = textureRegion;
+        switch (hotspot) {
+            case BOTTOM_CENTER:
+                mOffset = new PointF(0.5f, 1);
+                break;
+            case TOP_CENTER:
+                mOffset = new PointF(0.5f, 0);
+                break;
+            case RIGHT_CENTER:
+                mOffset = new PointF(1, 0.5f);
+                break;
+            case LEFT_CENTER:
+                mOffset = new PointF(0, 0.5f);
+                break;
+            case UPPER_RIGHT_CORNER:
+                mOffset = new PointF(1, 0);
+                break;
+            case LOWER_RIGHT_CORNER:
+                mOffset = new PointF(1, 1);
+                break;
+            case UPPER_LEFT_CORNER:
+                mOffset = new PointF(0, 0);
+                break;
+            case LOWER_LEFT_CORNER:
+                mOffset = new PointF(0, 1);
+                break;
+            default:
+                mOffset = new PointF(0.5f, 0.5f);
+        }
+
+        mBillboard = billboard;
+    }
 
     public MarkerSymbol(Bitmap bitmap, float relX, float relY) {
         this(bitmap, relX, relY, true);
@@ -48,6 +102,7 @@ public class MarkerSymbol {
         mBitmap = bitmap;
         mOffset = new PointF(relX, relY);
         mBillboard = billboard;
+        mTextureRegion = null;
     }
 
     public MarkerSymbol(Bitmap bitmap, HotspotPlace hotspot) {
@@ -87,6 +142,7 @@ public class MarkerSymbol {
 
         mBitmap = bitmap;
         mBillboard = billboard;
+        mTextureRegion = null;
     }
 
     public boolean isBillboard() {
@@ -97,14 +153,28 @@ public class MarkerSymbol {
         return mOffset;
     }
 
+    public boolean isBitmap() {
+        return mBitmap != null;
+    }
+
     public Bitmap getBitmap() {
         return mBitmap;
     }
 
+    public TextureRegion getTextureRegion() {
+        return mTextureRegion;
+    }
+
     public boolean isInside(float dx, float dy) {
         /* TODO handle no-billboard */
-        int w = mBitmap.getWidth();
-        int h = mBitmap.getHeight();
+        int w, h;
+        if (isBitmap()) {
+            w = mBitmap.getWidth();
+            h = mBitmap.getHeight();
+        } else {
+            w = mTextureRegion.rect.w;
+            h = mTextureRegion.rect.h;
+        }
         float ox = -w * mOffset.x;
         float oy = -h * (1 - mOffset.y);
 


### PR DESCRIPTION
MarkerSymbol currently supports Bitmap only, but TextureRegion might be a better choice if the marker image size is not the power of 2.