### PR TITLE
Fix zoom animation not executed sometimes

### DIFF
--- a/vtm/src/org/oscim/map/Animator.java
+++ b/vtm/src/org/oscim/map/Animator.java
@@ -187,6 +187,8 @@ public class Animator {
 
         mStartPos.copy(mCurPos);
         scaleBy = mMap.viewport().limitScale(scaleBy);
+        if (scaleBy == 0.0)
+            return;
 
         mDeltaPos.scale = scaleBy - mStartPos.scale;
 
@@ -254,7 +256,7 @@ public class Animator {
             return;
         }
 
-        float adv = clamp(1.0f - millisLeft / mDuration, 0, 1);
+        float adv = clamp(1.0f - millisLeft / mDuration, 1E-6f, 1);
         // Avoid redundant calculations in case of linear easing
         if (mEasingType != Easing.Type.LINEAR) {
             adv = Easing.ease(0, (long) (adv * Long.MAX_VALUE), Long.MAX_VALUE, mEasingType);


### PR DESCRIPTION
While debugging gestures I've noticed that sometimes zoom animation did not start when the gesture was processed. Further investigation showed that if processing is very fast `millisLeft` is equal to `mDuration` leading to zero advance and infinite animation loop.

Also I have found out that trying to zoom beyond limitations also caused infinite animation loop.