### PR TITLE
Mapbox (Mapzen): Render capital cities early

### DIFF
--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -1016,7 +1016,7 @@
 
         <!-- place -->
         <m k="kind">
-            <m v="locality" zoom-min="13">
+            <m v="locality">
                 <caption style="bold" fill="#606060" k="name" priority="5" size="14"
                     stroke="#ffffff" stroke-width="2.0" />
             </m>


### PR DESCRIPTION
This PR allows to render capitals earlier using the Mapbox tile format.

A captial is provided like this:
```
{
type: "Point",
properties: {
kind: "locality",
name: "Mumbai",
region_capital: true,
source: "naturalearthdata.com",
min_zoom: 2,
id: 7281,
population: 18978000
},
coordinates: [
975,
3550
]
},
```
or like this:
```
{
type: "Point",
properties: {
kind: "locality",
name: "Algiers",
source: "naturalearthdata.com",
min_zoom: 4,
country_capital: true,
id: 7219,
population: 3354000
},
coordinates: [
555,
3189
]
},
```

I completely removed the min_zoom for locality. I don't know if there might be other side effects, I could not see any.

WDYT?