### PR TITLE
fix Androids canvas.fillColor()

### DIFF
--- a/vtm-android-example/build.gradle
+++ b/vtm-android-example/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
+    compile project(':vtm')
     compile project(':vtm-android')
     compile project(':vtm-extras')
     compile project(':vtm-http')

--- a/vtm-android-example/src/org/oscim/android/test/AtlasMultiTextureActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/AtlasMultiTextureActivity.java
@@ -76,8 +76,8 @@ public class AtlasMultiTextureActivity extends MarkerOverlayActivity {
         paint.setStrokeWidth(2 * scale);
         paint.setColor(Color.BLACK);
         List<MarkerItem> pts = new ArrayList<>();
-        for (double lat = -90; lat <= 90; lat += 5) {
-            for (double lon = -180; lon <= 180; lon += 5) {
+        for (double lat = -90; lat <= 90; lat += 10) {
+            for (double lon = -180; lon <= 180; lon += 10) {
                 String title = lat + "/" + lon;
                 pts.add(new MarkerItem(title, "", new GeoPoint(lat, lon)));
 

--- a/vtm-android/src/org/oscim/android/canvas/AndroidCanvas.java
+++ b/vtm-android/src/org/oscim/android/canvas/AndroidCanvas.java
@@ -74,7 +74,7 @@ public class AndroidCanvas implements Canvas {
 
     @Override
     public void fillColor(int color) {
-        canvas.drawColor(color, PorterDuff.Mode.CLEAR);
+        canvas.drawColor(color, PorterDuff.Mode.SRC);
     }
 
     @Override


### PR DESCRIPTION
Here was a bug in AndroidCanvas.fillColor ()!
It has never worked under Android yet, but is probably not noticed yet!


In AtlasMultiTextureActivity I had to halve the number of generated items because I had an OOM with my Galaxy Note 4.

And I had to add again the dependency to the vtm-project, because my Gradle has grouse under IntelliJ!