### PR TITLE
vtm-ios: remove slf4j-simple dependency

### DIFF
--- a/vtm-ios/build.gradle
+++ b/vtm-ios/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     compile "com.badlogicgames.gdx:gdx-backend-robovm:$gdxVersion"
     compile "com.mobidevelop.robovm:robovm-rt:$roboVMVersion"
     compile "com.mobidevelop.robovm:robovm-cocoatouch:$roboVMVersion"
-    compile 'org.slf4j:slf4j-simple:1.7.21'
+    compile 'org.slf4j:slf4j-api:1.7.21'
 }
 
 task copyVtmResources(type: Copy) {


### PR DESCRIPTION
I wondering from where the Logger coms on my project