### PR TITLE
Update OSMIndoorLayer.java

### DIFF
--- a/vtm-jeo/src/org/oscim/layers/OSMIndoorLayer.java
+++ b/vtm-jeo/src/org/oscim/layers/OSMIndoorLayer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2014 Hannes Janetzek
  * Copyright 2016-2017 devemux86
+ * Copyright 2017 Akarsh Seggemu
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -168,6 +169,12 @@ public class OSMIndoorLayer extends JeoVectorLayer {
                 }
             }
         }
+        
+        Object o_1 = f.get("level");
+        if (o_1 instanceof String){
+            return Integer.parseInt((String) o_1);
+        }
+        
         return 0;
     }
 


### PR DESCRIPTION
The getlevel method does not work for geojson files created without @relations tags.
Here is the example of two levels 1 & 2 file:https://gist.githubusercontent.com/akarsh/a92d1c3be234ab1ff7d2469d511ad03a/raw/f483daa278647c5353a784f0081423474cfc7f17/bothlevels.geojson

Created using JOSM and following simple indoor tagging.