### PR TITLE
OSMIndoorLayer: read levels with fractional values

### DIFF
--- a/vtm-jeo/src/org/oscim/layers/OSMIndoorLayer.java
+++ b/vtm-jeo/src/org/oscim/layers/OSMIndoorLayer.java
@@ -172,7 +172,8 @@ public class OSMIndoorLayer extends JeoVectorLayer {
 
         o = f.get("level");
         if (o instanceof String) {
-            return Integer.parseInt((String) o);
+            double doubleLevelValue = Double.parseDouble((String) o);
+            return (int) doubleLevelValue;
         }
 
         return 0;


### PR DESCRIPTION
The get level method does not parse levels with double type i.e. 0.5.
The app crashes at the time of loading. The solution to this issue, is
parsing double and then converting it into integer value.
e.g. level 0.5 to level 0