### PR TITLE
Do not fling if map move is disabled

### DIFF
--- a/vtm/src/org/oscim/layers/MapEventLayer2.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer2.java
@@ -227,7 +227,8 @@ public class MapEventLayer2 extends AbstractMapEventLayer implements InputListen
                     vy *= t * t;
                     vx *= t * t;
                 }
-                doFling(vx, vy);
+                if (mEnableMove)
+                    doFling(vx, vy);
             }
 
             if (time - mStartDown > LONG_PRESS_THRESHOLD) {


### PR DESCRIPTION
If map movement is disabled (locked) fling gesture should not ocure.