### PR TITLE
Cluster marker is clipped, fixed by reducing radius

### DIFF
--- a/vtm/src/org/oscim/layers/marker/utils/ScreenUtils.java
+++ b/vtm/src/org/oscim/layers/marker/utils/ScreenUtils.java
@@ -75,11 +75,12 @@ public class ScreenUtils {
 
         private void draw(Canvas canvas) {
             int halfsize = mSize >> 1;
+            final int noneClippingRadius = halfsize - getPixels(2);
 
             // fill
-            canvas.drawCircle(halfsize, halfsize, halfsize - 2, mPaintCircle);
+            canvas.drawCircle(halfsize, halfsize, noneClippingRadius, mPaintCircle);
             // outline
-            canvas.drawCircle(halfsize, halfsize, halfsize - 2, mPaintBorder);
+            canvas.drawCircle(halfsize, halfsize, noneClippingRadius, mPaintBorder);
             // draw the number at the center
             canvas.drawText(mText,
                     (canvas.getWidth() - mPaintText.getTextWidth(mText)) * 0.5f,

--- a/vtm/src/org/oscim/layers/marker/utils/ScreenUtils.java
+++ b/vtm/src/org/oscim/layers/marker/utils/ScreenUtils.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2017 nebular
  * Copyright 2017 devemux86
+ * Copyright 2017 Wolfgang Schramm
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -75,10 +76,10 @@ public class ScreenUtils {
         private void draw(Canvas canvas) {
             int halfsize = mSize >> 1;
 
-            // outline
-            canvas.drawCircle(halfsize, halfsize, halfsize, mPaintCircle);
             // fill
-            canvas.drawCircle(halfsize, halfsize, halfsize, mPaintBorder);
+            canvas.drawCircle(halfsize, halfsize, halfsize - 2, mPaintCircle);
+            // outline
+            canvas.drawCircle(halfsize, halfsize, halfsize - 2, mPaintBorder);
             // draw the number at the center
             canvas.drawText(mText,
                     (canvas.getWidth() - mPaintText.getTextWidth(mText)) * 0.5f,


### PR DESCRIPTION
Fixed also comments, swaped fill <-> outline


with default radius

![default-radius](https://user-images.githubusercontent.com/1283445/28500008-07079fd2-6fc2-11e7-93d0-54bc5693517c.png)

with fixed radius

![default-radius-2](https://user-images.githubusercontent.com/1283445/28500014-0c63b10a-6fc2-11e7-8c94-d9d87cfc94a3.png)
