### PR TITLE
Do not try to calculate zero length great circle path

### DIFF
--- a/vtm/src/org/oscim/layers/PathLayer.java
+++ b/vtm/src/org/oscim/layers/PathLayer.java
@@ -153,6 +153,8 @@ public class PathLayer extends Layer {
 
             /* add one point for every 100kms of the great circle path */
             int numberOfPoints = (int) (length / 100000);
+            if (numberOfPoints == 0)
+                return;
 
             addGreatCircle(startPoint, endPoint, numberOfPoints);
         }


### PR DESCRIPTION
If distance is too short calculation becomes broken and point(0,0) is added to the path.