### PR TITLE
Do not catch exception too early

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/LineTexActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/LineTexActivity.java
@@ -28,6 +28,7 @@ import org.oscim.layers.vector.geometries.Style;
 import org.oscim.map.Map;
 import org.oscim.renderer.bucket.TextureItem;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -45,8 +46,13 @@ public class LineTexActivity extends SimpleMapActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        TextureItem tex = new TextureItem(CanvasAdapter.getBitmapAsset("", "patterns/pike.png"));
-        tex.mipmap = true;
+        TextureItem tex = null;
+        try {
+            tex = new TextureItem(CanvasAdapter.getBitmapAsset("", "patterns/pike.png"));
+            tex.mipmap = true;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
 
         for (double lat = -90; lat <= 90; lat += 5) {
             int c = Color.fade(Color.rainbow((float) (lat + 90) / 180), 0.5f);

--- a/vtm-android/src/org/oscim/android/canvas/AndroidGraphics.java
+++ b/vtm-android/src/org/oscim/android/canvas/AndroidGraphics.java
@@ -59,23 +59,13 @@ public final class AndroidGraphics extends CanvasAdapter {
     }
 
     @Override
-    public Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) {
-        try {
-            return new AndroidSvgBitmap(inputStream, width, height, percent);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) throws IOException {
+        return new AndroidSvgBitmap(inputStream, width, height, percent);
     }
 
     @Override
-    public Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) {
-        try {
-            return createBitmap(relativePathPrefix, src, width, height, percent);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return null;
+    public Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) throws IOException {
+        return createBitmap(relativePathPrefix, src, width, height, percent);
     }
 
     @Override

--- a/vtm-desktop/src/org/oscim/awt/AwtGraphics.java
+++ b/vtm-desktop/src/org/oscim/awt/AwtGraphics.java
@@ -104,32 +104,17 @@ public class AwtGraphics extends CanvasAdapter {
     }
 
     @Override
-    public Bitmap decodeBitmapImpl(InputStream inputStream) {
-        try {
-            return new AwtBitmap(inputStream);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public Bitmap decodeBitmapImpl(InputStream inputStream) throws IOException {
+        return new AwtBitmap(inputStream);
     }
 
     @Override
-    public Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) {
-        try {
-            return new AwtSvgBitmap(inputStream, width, height, percent);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    public Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) throws IOException {
+        return new AwtSvgBitmap(inputStream, width, height, percent);
     }
 
     @Override
-    public Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) {
-        try {
-            return createBitmap(relativePathPrefix, src, width, height, percent);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return null;
+    public Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) throws IOException {
+        return createBitmap(relativePathPrefix, src, width, height, percent);
     }
 }

--- a/vtm-ios/src/org/oscim/ios/backend/IosGraphics.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosGraphics.java
@@ -55,32 +55,17 @@ public class IosGraphics extends CanvasAdapter {
     }
 
     @Override
-    protected Bitmap decodeBitmapImpl(InputStream inputStream) {
-        try {
-            return new IosBitmap(inputStream);
-        } catch (IOException e) {
-            log.error("decodeBitmapImpl", e);
-            return null;
-        }
+    protected Bitmap decodeBitmapImpl(InputStream inputStream) throws IOException {
+        return new IosBitmap(inputStream);
     }
 
     @Override
-    protected Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) {
-        try {
-            return new IosSvgBitmap(inputStream, width, height, percent);
-        } catch (IOException e) {
-            log.error("decodeSvgBitmapImpl", e);
-            return null;
-        }
+    protected Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) throws IOException {
+        return new IosSvgBitmap(inputStream, width, height, percent);
     }
 
     @Override
-    protected Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) {
-        try {
-            return createBitmap(relativePathPrefix, src, width, height, percent);
-        } catch (IOException e) {
-            log.error("loadBitmapAssetImpl", e);
-            return null;
-        }
+    protected Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) throws IOException {
+        return createBitmap(relativePathPrefix, src, width, height, percent);
     }
 }

--- a/vtm/src/org/oscim/backend/CanvasAdapter.java
+++ b/vtm/src/org/oscim/backend/CanvasAdapter.java
@@ -111,9 +111,9 @@ public abstract class CanvasAdapter {
      * @param inputStream the input stream
      * @return the bitmap
      */
-    protected abstract Bitmap decodeBitmapImpl(InputStream inputStream);
+    protected abstract Bitmap decodeBitmapImpl(InputStream inputStream) throws IOException;
 
-    public static Bitmap decodeBitmap(InputStream inputStream) {
+    public static Bitmap decodeBitmap(InputStream inputStream) throws IOException {
         return g.decodeBitmapImpl(inputStream);
     }
 
@@ -123,9 +123,9 @@ public abstract class CanvasAdapter {
      * @param inputStream the input stream
      * @return the SVG bitmap
      */
-    protected abstract Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent);
+    protected abstract Bitmap decodeSvgBitmapImpl(InputStream inputStream, int width, int height, int percent) throws IOException;
 
-    public static Bitmap decodeSvgBitmap(InputStream inputStream, int width, int height, int percent) {
+    public static Bitmap decodeSvgBitmap(InputStream inputStream, int width, int height, int percent) throws IOException {
         return g.decodeSvgBitmapImpl(inputStream, width, height, percent);
     }
 
@@ -136,13 +136,13 @@ public abstract class CanvasAdapter {
      * @param src                the resource
      * @return the bitmap
      */
-    protected abstract Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent);
+    protected abstract Bitmap loadBitmapAssetImpl(String relativePathPrefix, String src, int width, int height, int percent) throws IOException;
 
-    public static Bitmap getBitmapAsset(String relativePathPrefix, String src) {
+    public static Bitmap getBitmapAsset(String relativePathPrefix, String src) throws IOException {
         return getBitmapAsset(relativePathPrefix, src, 0, 0, 100);
     }
 
-    public static Bitmap getBitmapAsset(String relativePathPrefix, String src, int width, int height, int percent) {
+    public static Bitmap getBitmapAsset(String relativePathPrefix, String src, int width, int height, int percent) throws IOException {
         return g.loadBitmapAssetImpl(relativePathPrefix, src, width, height, percent);
     }
 

--- a/vtm/src/org/oscim/theme/XmlMapsforgeThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlMapsforgeThemeBuilder.java
@@ -1034,7 +1034,7 @@ public class XmlMapsforgeThemeBuilder extends DefaultHandler {
                 try {
                     b.bitmap = CanvasAdapter.getBitmapAsset(mTheme.getRelativePathPrefix(), symbol, b.symbolWidth, b.symbolHeight, b.symbolPercent);
                 } catch (Exception e) {
-                    log.debug(e.getMessage());
+                    log.error("{}: {}", symbol, e.getMessage());
                 }
             } else
                 b.texture = getAtlasRegion(symbol);
@@ -1127,7 +1127,7 @@ public class XmlMapsforgeThemeBuilder extends DefaultHandler {
                 if (bitmap != null)
                     return buildSymbol(b, src, bitmap);
             } catch (Exception e) {
-                log.debug(e.getMessage());
+                log.error("{}: {}", src, e.getMessage());
             }
             return null;
         }

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -1014,7 +1014,7 @@ public class XmlThemeBuilder extends DefaultHandler {
                 try {
                     b.bitmap = CanvasAdapter.getBitmapAsset(mTheme.getRelativePathPrefix(), symbol, b.symbolWidth, b.symbolHeight, b.symbolPercent);
                 } catch (Exception e) {
-                    log.debug(e.getMessage());
+                    log.error("{}: {}", symbol, e.getMessage());
                 }
             } else
                 b.texture = getAtlasRegion(symbol);
@@ -1107,7 +1107,7 @@ public class XmlThemeBuilder extends DefaultHandler {
                 if (bitmap != null)
                     return buildSymbol(b, src, bitmap);
             } catch (Exception e) {
-                log.debug(e.getMessage());
+                log.error("{}: {}", src, e.getMessage());
             }
             return null;
         }

--- a/vtm/src/org/oscim/utils/Utils.java
+++ b/vtm/src/org/oscim/utils/Utils.java
@@ -61,7 +61,7 @@ public final class Utils {
                 return new TextureItem(bitmap, true);
             }
         } catch (Exception e) {
-            log.debug("missing file / {}", e.getMessage());
+            log.error("{}: missing file / {}", src, e.getMessage());
         }
         return null;
     }


### PR DESCRIPTION
SVG parsing error was caught too early making it impossible to know what resource produced this error.