### PR TITLE
BuildingLayer: Support extrusions in Mapzen Layer

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/S3DBMapActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/S3DBMapActivity.java
@@ -19,7 +19,6 @@ package org.oscim.android.test;
 import android.os.Bundle;
 
 import org.oscim.android.cache.TileCache;
-import org.oscim.layers.tile.TileLayer;
 import org.oscim.layers.tile.buildings.S3DBLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.theme.VtmThemes;
@@ -47,8 +46,8 @@ public class S3DBMapActivity extends BaseMapActivity {
             mS3dbCache.setCacheSize(512 * (1 << 10));
             ts.setCache(mS3dbCache);
         }
-        TileLayer tl = new S3DBLayer(mMap, ts, true, false);
-        mMap.layers().add(tl);
+
+        mMap.layers().add(new S3DBLayer(mMap, ts));
         mMap.layers().add(new LabelLayer(mMap, mBaseLayer));
     }
 

--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -560,13 +560,25 @@
           </m> -->
 
         <!-- building -->
-        <m k="building">
-            <m zoom-min="14">
-                <m closed="yes">
-                    <area fade="14" use="building" />
+        <m k="building|building:part">
+            <m k="building">
+                <m zoom-min="14">
+                    <m closed="yes">
+                        <area fade="14" use="building" />
+                    </m>
+                    <m closed="no">
+                        <line fade="14" use="building" />
+                    </m>
                 </m>
-                <m closed="no">
-                    <line fade="14" use="building" />
+            </m>
+            <m k="building:part">
+                <m zoom-min="16">
+                    <m closed="yes">
+                        <area fade="16" use="building" />
+                    </m>
+                    <m closed="no">
+                        <line fade="16" use="building" />
+                    </m>
                 </m>
             </m>
             <m zoom-min="17">

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -557,13 +557,25 @@
           </m> -->
 
         <!-- building -->
-        <m k="kind" v="building">
-            <m zoom-min="14">
-                <m closed="yes">
-                    <area fade="14" use="building" />
+        <m k="kind" v="building|building_part">
+            <m v="building">
+                <m zoom-min="14">
+                    <m closed="yes">
+                        <area fade="14" use="building" />
+                    </m>
+                    <m closed="no">
+                        <line fade="14" use="building" />
+                    </m>
                 </m>
-                <m closed="no">
-                    <line fade="14" use="building" />
+            </m>
+            <m v="building_part">
+                <m zoom-min="16">
+                    <m closed="yes">
+                        <area fade="16" use="building" />
+                    </m>
+                    <m closed="no">
+                        <line fade="16" use="building" />
+                    </m>
                 </m>
             </m>
             <m zoom-min="17">

--- a/vtm-web/src/com/badlogic/gdx/backends/Gdx.gwt.xml
+++ b/vtm-web/src/com/badlogic/gdx/backends/Gdx.gwt.xml
@@ -3,6 +3,7 @@
     "http://google-web-toolkit.googlecode.com/svn/tags/2.5.1/distro-source/core/src/gwt-module.dtd">
 <module rename-to='com.badlogic.gdx.backends.gwt'>
     <inherits name='com.google.gwt.user.User' />
+    <inherits name='com.google.gwt.i18n.I18N' />
     <!-- Inherit edited chrome theme ("gwt"-prefixed classes only) for a little bit of default styling in the text input dialogs -->
     <inherits name='com.badlogic.gdx.backends.gwt.theme.chrome.Chrome' />
     <inherits name="com.google.gwt.http.HTTP" />

--- a/vtm-web/src/org/oscim/gdx/VtmWeb.gwt.xml
+++ b/vtm-web/src/org/oscim/gdx/VtmWeb.gwt.xml
@@ -15,6 +15,7 @@
     <!-- <inherits name="com.badlogic.gdx.backends.gdx_backends_gwt" /> -->
     <inherits name="com.badlogic.gdx.backends.Gdx" />
     <inherits name="com.google.gwt.user.theme.chrome.Chrome" />
+    <inherits name="com.google.gwt.i18n.I18N" />
 
 
     <!--   <extend-configuration-property name="gdx.reflect.include" value="com.badlogic.gdx.scenes.scene2d" />

--- a/vtm/src/org/oscim/core/Tag.java
+++ b/vtm/src/org/oscim/core/Tag.java
@@ -51,6 +51,7 @@ public class Tag {
     public static final String KEY_LANDUSE = "landuse";
     public static final String KEY_HEIGHT = "height";
     public static final String KEY_MIN_HEIGHT = "min_height";
+    public static final String KEY_LEVELS = "levels";
 
     public static final String VALUE_YES = "yes";
     public static final String VALUE_NO = "no";

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -45,6 +45,10 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
 
     private static final Object BUILDING_DATA = BuildingLayer.class.getName();
 
+    /**
+     * @param map       Stores map workaround
+     * @param tileLayer Manages loading of vector tiles for rendering
+     */
     public BuildingLayer(Map map, VectorTileLayer tileLayer) {
         this(map, tileLayer, MIN_ZOOM, MAX_ZOOM);
     }
@@ -74,18 +78,24 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
 
         ExtrusionStyle extrusion = (ExtrusionStyle) style.current();
 
-        int height = 0;
-        int minHeight = 0;
+        int height = 0; // in cm
+        int minHeight = 0; // in cm
 
         String v = element.tags.getValue(Tag.KEY_HEIGHT);
-        if (v != null)
-            height = (int) Float.parseFloat(v);
+        if (v == null) {
+            // FIXME load from theme or decode tags to generalize level/height tags
+            if ((v = element.tags.getValue(Tag.KEY_BUILDING + ":" + Tag.KEY_LEVELS)) != null) {
+                height = (int) (Float.parseFloat(v) * 280); // 2.8m level height
+            }
+        } else
+            height = (int) Float.parseFloat(v) * 100;
 
         v = element.tags.getValue(Tag.KEY_MIN_HEIGHT);
         if (v != null)
-            minHeight = (int) Float.parseFloat(v);
+            minHeight = (int) Float.parseFloat(v) * 100;
 
         if (height == 0)
+            // FIXME ignore buildings containing building parts
             height = extrusion.defaultHeight * 100;
 
         ExtrusionBuckets ebs = get(tile);

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2012-2017 mapsforge
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.layers.tile.buildings;
 
 import org.oscim.layers.tile.MapTile;

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -1,17 +1,28 @@
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2016 Andrey Novikov
+ * Copyright 2016 devemux86
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.layers.tile.buildings;
 
-import org.oscim.backend.canvas.Color;
 import org.oscim.layers.tile.TileLayer;
 import org.oscim.layers.tile.TileManager;
-import org.oscim.layers.tile.TileRenderer;
+import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.map.Map;
-import org.oscim.renderer.GLViewport;
-import org.oscim.renderer.LayerRenderer;
-import org.oscim.renderer.OffscreenRenderer;
-import org.oscim.renderer.OffscreenRenderer.Mode;
 import org.oscim.tiling.TileSource;
-import org.oscim.utils.ColorUtil;
-import org.oscim.utils.ColorsCSS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,11 +30,11 @@ public class S3DBLayer extends TileLayer {
     static final Logger log = LoggerFactory.getLogger(S3DBLayer.class);
 
     private final static int MAX_CACHE = 32;
-    private final static int SRC_ZOOM = 16;
+
+    private final static int MIN_ZOOM = 16;
+    private final static int MAX_ZOOM = 16;
 
     /* TODO get from theme */
-    private final static double HSV_S = 0.7;
-    private final static double HSV_V = 1.2;
 
     private final TileSource mTileSource;
 
@@ -31,11 +42,19 @@ public class S3DBLayer extends TileLayer {
         this(map, tileSource, true, false);
     }
 
+    /**
+     * Simple-3D-Buildings Layer
+     *
+     * @param map        Stored map workaround
+     * @param tileSource Source of loaded tiles in {@link VectorTileLayer}
+     * @param fxaa       Switch on Fast Approximate Anti-Aliasing
+     * @param ssao       Switch on Screen Space Ambient Occlusion
+     */
     public S3DBLayer(Map map, TileSource tileSource, boolean fxaa, boolean ssao) {
         super(map, new TileManager(map, MAX_CACHE));
-        setRenderer(new S3DBRenderer(fxaa, ssao));
+        setRenderer(new S3DBRenderer(MIN_ZOOM, MAX_ZOOM, fxaa, ssao));
 
-        mTileManager.setZoomLevel(SRC_ZOOM, SRC_ZOOM);
+        mTileManager.setZoomLevel(MIN_ZOOM, MAX_ZOOM);
         mTileSource = tileSource;
         initLoader(2);
     }
@@ -43,145 +62,5 @@ public class S3DBLayer extends TileLayer {
     @Override
     protected S3DBTileLoader createLoader() {
         return new S3DBTileLoader(getManager(), mTileSource);
-    }
-
-    public static class S3DBRenderer extends TileRenderer {
-        LayerRenderer mRenderer;
-
-        public S3DBRenderer(boolean fxaa, boolean ssao) {
-            mRenderer = new BuildingRenderer(this, SRC_ZOOM, SRC_ZOOM, true, false);
-
-            if (fxaa || ssao) {
-                Mode mode = Mode.FXAA;
-                if (fxaa && ssao)
-                    mode = Mode.SSAO_FXAA;
-                else if (ssao)
-                    mode = Mode.SSAO;
-                mRenderer = new OffscreenRenderer(mode, mRenderer);
-            }
-        }
-
-        @Override
-        public synchronized void update(GLViewport v) {
-            super.update(v);
-            mRenderer.update(v);
-            setReady(mRenderer.isReady());
-        }
-
-        @Override
-        public synchronized void render(GLViewport v) {
-            mRenderer.render(v);
-        }
-
-        @Override
-        public boolean setup() {
-            mRenderer.setup();
-            return super.setup();
-        }
-    }
-
-    static int getColor(String color, boolean roof) {
-
-        if (color.charAt(0) == '#') {
-            int c = Color.parseColor(color, Color.CYAN);
-            /* hardcoded colors are way too saturated for my taste */
-            return ColorUtil.modHsv(c, 1.0, 0.4, HSV_V, true);
-        }
-
-        if (roof) {
-            if ("brown".equals(color))
-                return Color.get(120, 110, 110);
-            if ("red".equals(color))
-                return Color.get(235, 140, 130);
-            if ("green".equals(color))
-                return Color.get(150, 200, 130);
-            if ("blue".equals(color))
-                return Color.get(100, 50, 200);
-        }
-        if ("white".equals(color))
-            return Color.get(240, 240, 240);
-        if ("black".equals(color))
-            return Color.get(86, 86, 86);
-        if ("grey".equals(color) || "gray".equals(color))
-            return Color.get(120, 120, 120);
-        if ("red".equals(color))
-            return Color.get(255, 190, 190);
-        if ("green".equals(color))
-            return Color.get(190, 255, 190);
-        if ("blue".equals(color))
-            return Color.get(190, 190, 255);
-        if ("yellow".equals(color))
-            return Color.get(255, 255, 175);
-        if ("darkgray".equals(color) || "darkgrey".equals(color))
-            return Color.DKGRAY;
-        if ("lightgray".equals(color) || "lightgrey".equals(color))
-            return Color.LTGRAY;
-
-        if ("transparent".equals(color))
-            return Color.get(0, 1, 1, 1);
-
-        Integer css = ColorsCSS.get(color);
-
-        if (css != null)
-            return ColorUtil.modHsv(css, 1.0, HSV_S, HSV_V, true);
-
-        log.debug("unknown color:{}", color);
-        return 0;
-    }
-
-    static int getMaterialColor(String material, boolean roof) {
-
-        if (roof) {
-            if ("glass".equals(material))
-                return Color.fade(Color.get(130, 224, 255), 0.9f);
-        }
-        if ("roof_tiles".equals(material))
-            return Color.get(216, 167, 111);
-        if ("tile".equals(material))
-            return Color.get(216, 167, 111);
-
-        if ("concrete".equals(material) ||
-                "cement_block".equals(material))
-            return Color.get(210, 212, 212);
-
-        if ("metal".equals(material))
-            return 0xFFC0C0C0;
-        if ("tar_paper".equals(material))
-            return 0xFF969998;
-        if ("eternit".equals(material))
-            return Color.get(216, 167, 111);
-        if ("tin".equals(material))
-            return 0xFFC0C0C0;
-        if ("asbestos".equals(material))
-            return Color.get(160, 152, 141);
-        if ("glass".equals(material))
-            return Color.get(130, 224, 255);
-        if ("slate".equals(material))
-            return 0xFF605960;
-        if ("zink".equals(material))
-            return Color.get(180, 180, 180);
-        if ("gravel".equals(material))
-            return Color.get(170, 130, 80);
-        if ("copper".equals(material))
-            // same as roof color:green
-            return Color.get(150, 200, 130);
-        if ("wood".equals(material))
-            return Color.get(170, 130, 80);
-        if ("grass".equals(material))
-            return 0xFF50AA50;
-        if ("stone".equals(material))
-            return Color.get(206, 207, 181);
-        if ("plaster".equals(material))
-            return Color.get(236, 237, 181);
-        if ("brick".equals(material))
-            return Color.get(255, 217, 191);
-        if ("stainless_steel".equals(material))
-            return Color.get(153, 157, 160);
-        if ("gold".equals(material))
-            return 0xFFFFD700;
-
-        log.debug("unknown material:{}", material);
-
-        return 0;
     }
 }

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBRenderer.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2016 devemux86
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.layers.tile.buildings;
+
+import org.oscim.backend.canvas.Color;
+import org.oscim.layers.tile.TileRenderer;
+import org.oscim.renderer.GLViewport;
+import org.oscim.renderer.LayerRenderer;
+import org.oscim.renderer.OffscreenRenderer;
+import org.oscim.renderer.OffscreenRenderer.Mode;
+import org.oscim.utils.ColorUtil;
+import org.oscim.utils.ColorsCSS;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class S3DBRenderer extends TileRenderer {
+    static final Logger log = LoggerFactory.getLogger(S3DBLayer.class);
+
+    private final static double HSV_S = 0.7;
+    private final static double HSV_V = 1.2;
+    public static int DEFAULT_HEIGHT = 12;
+
+    LayerRenderer mRenderer;
+
+    public S3DBRenderer(int zoomMin, int zoomMax, boolean fxaa, boolean ssao) {
+        mRenderer = new BuildingRenderer(this, zoomMin, zoomMax, true, false);
+
+        if (fxaa || ssao) {
+            Mode mode = Mode.FXAA;
+            if (fxaa && ssao)
+                mode = Mode.SSAO_FXAA;
+            else if (ssao)
+                mode = Mode.SSAO;
+            mRenderer = new OffscreenRenderer(mode, mRenderer);
+        }
+    }
+
+    @Override
+    public synchronized void update(GLViewport v) {
+        super.update(v);
+        mRenderer.update(v);
+        setReady(mRenderer.isReady());
+    }
+
+    @Override
+    public synchronized void render(GLViewport v) {
+        mRenderer.render(v);
+    }
+
+    @Override
+    public boolean setup() {
+        mRenderer.setup();
+        return super.setup();
+    }
+
+    static int getColor(String color, boolean roof) {
+
+        if (color.charAt(0) == '#') {
+            int c = Color.parseColor(color, Color.CYAN);
+            /* hardcoded colors are way too saturated for my taste */
+            return ColorUtil.modHsv(c, 1.0, 0.4, HSV_V, true);
+        }
+
+        if (roof) {
+            if ("brown".equals(color))
+                return Color.get(120, 110, 110);
+            if ("red".equals(color))
+                return Color.get(235, 140, 130);
+            if ("green".equals(color))
+                return Color.get(150, 200, 130);
+            if ("blue".equals(color))
+                return Color.get(100, 50, 200);
+        }
+        if ("white".equals(color))
+            return Color.get(240, 240, 240);
+        if ("black".equals(color))
+            return Color.get(86, 86, 86);
+        if ("grey".equals(color) || "gray".equals(color))
+            return Color.get(120, 120, 120);
+        if ("red".equals(color))
+            return Color.get(255, 190, 190);
+        if ("green".equals(color))
+            return Color.get(190, 255, 190);
+        if ("blue".equals(color))
+            return Color.get(190, 190, 255);
+        if ("yellow".equals(color))
+            return Color.get(255, 255, 175);
+        if ("darkgray".equals(color) || "darkgrey".equals(color))
+            return Color.DKGRAY;
+        if ("lightgray".equals(color) || "lightgrey".equals(color))
+            return Color.LTGRAY;
+
+        if ("transparent".equals(color))
+            return Color.get(0, 1, 1, 1);
+
+        Integer css = ColorsCSS.get(color);
+
+        if (css != null)
+            return ColorUtil.modHsv(css, 1.0, HSV_S, HSV_V, true);
+
+        log.debug("unknown color:{}", color);
+        return 0;
+    }
+
+    static int getMaterialColor(String material, boolean roof) {
+
+        if (roof) {
+            if ("glass".equals(material))
+                return Color.fade(Color.get(130, 224, 255), 0.9f);
+        }
+        if ("roof_tiles".equals(material))
+            return Color.get(216, 167, 111);
+        if ("tile".equals(material))
+            return Color.get(216, 167, 111);
+
+        if ("concrete".equals(material) ||
+                "cement_block".equals(material))
+            return Color.get(210, 212, 212);
+
+        if ("metal".equals(material))
+            return 0xFFC0C0C0;
+        if ("tar_paper".equals(material))
+            return 0xFF969998;
+        if ("eternit".equals(material))
+            return Color.get(216, 167, 111);
+        if ("tin".equals(material))
+            return 0xFFC0C0C0;
+        if ("asbestos".equals(material))
+            return Color.get(160, 152, 141);
+        if ("glass".equals(material))
+            return Color.get(130, 224, 255);
+        if ("slate".equals(material))
+            return 0xFF605960;
+        if ("zink".equals(material))
+            return Color.get(180, 180, 180);
+        if ("gravel".equals(material))
+            return Color.get(170, 130, 80);
+        if ("copper".equals(material))
+            // same as roof color:green
+            return Color.get(150, 200, 130);
+        if ("wood".equals(material))
+            return Color.get(170, 130, 80);
+        if ("grass".equals(material))
+            return 0xFF50AA50;
+        if ("stone".equals(material))
+            return Color.get(206, 207, 181);
+        if ("plaster".equals(material))
+            return Color.get(236, 237, 181);
+        if ("brick".equals(material))
+            return Color.get(255, 217, 191);
+        if ("stainless_steel".equals(material))
+            return Color.get(153, 157, 160);
+        if ("gold".equals(material))
+            return 0xFFFFD700;
+
+        log.debug("unknown material:{}", material);
+
+        return 0;
+    }
+}

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014-2015 Hannes Janetzek
+ * Copyright 2016-2017 devemux86
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.layers.tile.buildings;
 
 import org.oscim.backend.canvas.Color;
@@ -15,8 +32,6 @@ import org.oscim.tiling.QueryResult;
 import org.oscim.tiling.TileSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.oscim.layers.tile.buildings.S3DBLayer.getMaterialColor;
 
 class S3DBTileLoader extends TileLoader {
     static final Logger log = LoggerFactory.getLogger(S3DBTileLoader.class);
@@ -115,11 +130,11 @@ class S3DBTileLoader extends TileLoader {
 
         int c = 0;
         if (element.tags.containsKey(COLOR_KEY)) {
-            c = S3DBLayer.getColor(element.tags.getValue(COLOR_KEY), isRoof);
+            c = S3DBRenderer.getColor(element.tags.getValue(COLOR_KEY), isRoof);
         }
 
         if (c == 0 && element.tags.containsKey(MATERIAL_KEY)) {
-            c = getMaterialColor(element.tags.getValue(MATERIAL_KEY), isRoof);
+            c = S3DBRenderer.getMaterialColor(element.tags.getValue(MATERIAL_KEY), isRoof);
         }
 
         if (c == 0) {

--- a/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
+++ b/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
@@ -29,6 +29,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
 
 public class TileDecoder extends PbfDecoder {
     static final Logger log = LoggerFactory.getLogger(TileDecoder.class);
@@ -220,13 +223,18 @@ public class TileDecoder extends PbfDecoder {
             // FIXME filter out all variable tags
             // might depend on theme though
             if (Tag.KEY_NAME.equals(key)
-                    || Tag.KEY_HEIGHT.equals(key)
-                    || Tag.KEY_MIN_HEIGHT.equals(key)
                     || Tag.KEY_HOUSE_NUMBER.equals(key)
                     || Tag.KEY_REF.equals(key)
                     || Tag.KEY_ELE.equals(key))
                 tag = new Tag(key, val, false);
-            else
+            else if (Tag.KEY_NAME.equals(key)
+                    || Tag.KEY_HEIGHT.equals(key)
+                    || Tag.KEY_MIN_HEIGHT.equals(key)) {
+                // reformat values to established meters in osm
+                DecimalFormat df = (DecimalFormat) NumberFormat.getNumberInstance(Locale.US);
+                df.applyPattern("0.##");
+                tag = new Tag(key, df.format(Float.valueOf(val) / 100));
+            } else
                 tag = new Tag(key, val, false, true);
 
             mTileTags.add(tag);


### PR DESCRIPTION
- Tag: add "levels"
- BuildingLayer: support extrusions with height and levels, tag unit in meters
- Add some copyrights
- Adapt S3DB Layer / reorganized code
- Support height for Mapzen building_parts
- Support of building parts in default and mapzen themes

This is a first approach of support for extrusions in other layers than OscimMap4 in VTM. Therefore a unification of tags is necessary and support of S3DB tags in mapsforge maps. I reorganized some code, but only for clarity. There are some hardcoded calculations on height for mapzen layer, because this tag is derived from the area and volume (usually for building_parts). Criticism is welcome ;D