### PR TITLE
PathLayer, VectorLayer (polygon) overlays touch events

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,8 @@
 - Mapsforge themes compatibility [#100](https://github.com/mapsforge/vtm/issues/100)
 - Render themes: line symbol [#124](https://github.com/mapsforge/vtm/issues/124)
 - Render themes: stroke dash array [#131](https://github.com/mapsforge/vtm/issues/131)
+- PathLayer overlay touch events [#316](https://github.com/mapsforge/vtm/issues/316)
+- VectorLayer (polygon) overlay touch events [#424](https://github.com/mapsforge/vtm/issues/424)
 - Two finger tap zoom out gesture [#423](https://github.com/mapsforge/vtm/issues/423)
 - POI Search example [#394](https://github.com/mapsforge/vtm/issues/394)
 - Mapsforge Reverse Geocoding [#383](https://github.com/mapsforge/vtm/issues/383)

--- a/vtm-android-example/src/org/oscim/android/test/PathOverlayActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/PathOverlayActivity.java
@@ -18,10 +18,14 @@
 package org.oscim.android.test;
 
 import android.os.Bundle;
+import android.widget.Toast;
 
+import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.MapPosition;
 import org.oscim.event.Event;
+import org.oscim.event.Gesture;
+import org.oscim.event.MotionEvent;
 import org.oscim.layers.vector.PathLayer;
 import org.oscim.map.Map.UpdateListener;
 
@@ -44,7 +48,18 @@ public class PathOverlayActivity extends SimpleMapActivity {
 
         for (double lat = -90; lat <= 90; lat += 5) {
             int c = Color.fade(Color.rainbow((float) (lat + 90) / 180), 0.5f);
-            PathLayer pathLayer = new PathLayer(mMap, c, 6);
+            PathLayer pathLayer = new PathLayer(mMap, c, 6 * CanvasAdapter.getScale()) {
+                @Override
+                public boolean onGesture(Gesture g, MotionEvent e) {
+                    if (g instanceof Gesture.Tap) {
+                        if (contains(e.getX(), e.getY())) {
+                            Toast.makeText(PathOverlayActivity.this, "PathLayer tap\n" + mMap.viewport().fromScreenPoint(e.getX(), e.getY()), Toast.LENGTH_SHORT).show();
+                            return true;
+                        }
+                    }
+                    return false;
+                }
+            };
             mMap.layers().add(pathLayer);
             mPathLayers.add(pathLayer);
         }

--- a/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
@@ -26,9 +26,13 @@ import com.vividsolutions.jts.simplify.DouglasPeuckerSimplifier;
 
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.Box;
+import org.oscim.core.GeoPoint;
 import org.oscim.core.GeometryBuffer;
 import org.oscim.core.MapPosition;
 import org.oscim.core.Tile;
+import org.oscim.event.Gesture;
+import org.oscim.event.GestureListener;
+import org.oscim.event.MotionEvent;
 import org.oscim.layers.vector.geometries.Drawable;
 import org.oscim.layers.vector.geometries.LineDrawable;
 import org.oscim.layers.vector.geometries.PointDrawable;
@@ -41,6 +45,7 @@ import org.oscim.theme.styles.LineStyle;
 import org.oscim.utils.FastMath;
 import org.oscim.utils.QuadTree;
 import org.oscim.utils.SpatialIndex;
+import org.oscim.utils.geom.GeomBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +62,7 @@ import static org.oscim.core.MercatorProjection.longitudeToX;
  * package and
  * JTS geometries together with a GeometryStyle
  */
-public class VectorLayer extends AbstractVectorLayer<Drawable> {
+public class VectorLayer extends AbstractVectorLayer<Drawable> implements GestureListener {
 
     public static final Logger log = LoggerFactory.getLogger(VectorLayer.class);
 
@@ -350,5 +355,20 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> {
             g.addPoint((float) (x + radius * Math.cos(i * step)),
                     (float) (y + radius * Math.sin(i * step)));
         }
+    }
+
+    public synchronized boolean contains(float x, float y) {
+        GeoPoint geoPoint = mMap.viewport().fromScreenPoint(x, y);
+        Point point = new GeomBuilder().point(geoPoint.getLongitude(), geoPoint.getLatitude()).toPoint();
+        for (Drawable drawable : tmpDrawables) {
+            if (drawable.getGeometry().contains(point))
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean onGesture(Gesture g, MotionEvent e) {
+        return false;
     }
 }

--- a/vtm-playground/src/org/oscim/test/PathLayerTest.java
+++ b/vtm-playground/src/org/oscim/test/PathLayerTest.java
@@ -20,6 +20,8 @@ import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeoPoint;
 import org.oscim.core.MapPosition;
 import org.oscim.event.Event;
+import org.oscim.event.Gesture;
+import org.oscim.event.MotionEvent;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
@@ -92,7 +94,18 @@ public class PathLayerTest extends GdxMapApp {
             PathLayer pathLayer;
             if (init) {
                 int c = Color.fade(Color.rainbow((float) (lat + 90) / 180), 0.5f);
-                pathLayer = new PathLayer(mMap, c, 6);
+                pathLayer = new PathLayer(mMap, c, 6) {
+                    @Override
+                    public boolean onGesture(Gesture g, MotionEvent e) {
+                        if (g instanceof Gesture.Tap) {
+                            if (contains(e.getX(), e.getY())) {
+                                System.out.println("PathLayer tap " + mMap.viewport().fromScreenPoint(e.getX(), e.getY()));
+                                return true;
+                            }
+                        }
+                        return false;
+                    }
+                };
                 mMap.layers().add(pathLayer);
                 mPathLayers.add(pathLayer);
             } else {

--- a/vtm/src/org/oscim/utils/GeoPointUtils.java
+++ b/vtm/src/org/oscim/utils/GeoPointUtils.java
@@ -15,12 +15,14 @@
 package org.oscim.utils;
 
 import org.oscim.core.GeoPoint;
+import org.oscim.core.Point;
 
 public final class GeoPointUtils {
 
     /**
-     * Find if the given point lies within this polygon.<br/>
-     * See http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
+     * Find if the given point lies within this polygon.
+     * <p>
+     * http://www.ecse.rpi.edu/Homepages/wrf/Research/Short_Notes/pnpoly.html
      *
      * @return true if this polygon contains the given point, false otherwise.
      */
@@ -37,12 +39,38 @@ public final class GeoPointUtils {
     }
 
     /**
+     * Returns the distance between the given segment and point.
+     * <p>
+     * libGDX (Apache 2.0)
+     */
+    public static double distanceSegmentPoint(double startX, double startY, double endX, double endY, double pointX, double pointY) {
+        Point nearest = nearestSegmentPoint(startX, startY, endX, endY, pointX, pointY);
+        return Math.hypot(nearest.x - pointX, nearest.y - pointY);
+    }
+
+    /**
      * Find if this way is closed.
      *
      * @return true if this way is closed, false otherwise.
      */
     public static boolean isClosedWay(GeoPoint[] geoPoints) {
         return geoPoints[0].distance(geoPoints[geoPoints.length - 1]) < 0.000000001;
+    }
+
+    /**
+     * Returns a point on the segment nearest to the specified point.
+     * <p>
+     * libGDX (Apache 2.0)
+     */
+    public static Point nearestSegmentPoint(double startX, double startY, double endX, double endY, double pointX, double pointY) {
+        double xDiff = endX - startX;
+        double yDiff = endY - startY;
+        double length2 = xDiff * xDiff + yDiff * yDiff;
+        if (length2 == 0) return new Point(startX, startY);
+        double t = ((pointX - startX) * (endX - startX) + (pointY - startY) * (endY - startY)) / length2;
+        if (t < 0) return new Point(startX, startY);
+        if (t > 1) return new Point(endX, endY);
+        return new Point(startX + t * (endX - startX), startY + t * (endY - startY));
     }
 
     private GeoPointUtils() {


### PR DESCRIPTION
Fixes #316, fixes #424.

Implement touch events for `PathLayer`, `VectorLayer` (polygon) overlays.