### PR TITLE
TagSet: numTags and tag array as private

### DIFF
--- a/vtm-extras/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
+++ b/vtm-extras/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
@@ -135,7 +135,7 @@ public class GeoJsonTileDecoder implements ITileDecoder {
 
         //add tag information
         mTileSource.decodeTags(mMapElement, mTagMap);
-        if (mMapElement.tags.numTags == 0)
+        if (mMapElement.tags.size() == 0)
             return;
 
         mTileSource.postGeomHook(mMapElement);

--- a/vtm-extras/src/org/oscim/tiling/source/oscimap2/OSciMap2TileSource.java
+++ b/vtm-extras/src/org/oscim/tiling/source/oscimap2/OSciMap2TileSource.java
@@ -143,7 +143,7 @@ public class OSciMap2TileSource extends UrlTileSource {
         private boolean decodeTileTags() throws IOException {
             String tagString = decodeString();
 
-            int curTag = mTileTags.numTags;
+            int curTag = mTileTags.size();
 
             String key = Tags.keys[mSArray[curTag]];
             Tag tag;
@@ -261,7 +261,7 @@ public class OSciMap2TileSource extends UrlTileSource {
             if (fail || indexCnt == 0) {
                 log.debug(mTile + " failed reading way: bytes:" + bytes + " index:"
                         + (Arrays.toString(index)) + " tag:"
-                        + (mElem.tags.numTags > 0 ? Arrays.deepToString(mElem.tags.tags) : "null")
+                        + (mElem.tags.size() > 0 ? Arrays.deepToString(mElem.tags.getTags()) : "null")
                         + " " + indexCnt + " " + coordCnt);
                 return false;
             }
@@ -290,7 +290,7 @@ public class OSciMap2TileSource extends UrlTileSource {
 
             int cnt = 0;
             int end = position() + bytes;
-            int max = mTileTags.numTags - 1;
+            int max = mTileTags.size() - 1;
 
             for (; position() < end; cnt++) {
                 int tagNum = decodeVarint32();
@@ -315,7 +315,7 @@ public class OSciMap2TileSource extends UrlTileSource {
                     return false;
                 }
 
-                mElem.tags.add(mTileTags.tags[tagNum]);
+                mElem.tags.add(mTileTags.get(tagNum));
             }
 
             if (cnt == 0) {

--- a/vtm-json/src/org/oscim/tiling/source/geojson/TileDecoder.java
+++ b/vtm-json/src/org/oscim/tiling/source/geojson/TileDecoder.java
@@ -137,7 +137,7 @@ public class TileDecoder implements ITileDecoder {
 
         //add tag information
         mTileSource.decodeTags(mMapElement, mTagMap);
-        if (mMapElement.tags.numTags == 0)
+        if (mMapElement.tags.size() == 0)
             return;
 
         mTileSource.postGeomHook(mMapElement);

--- a/vtm-web/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
+++ b/vtm-web/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
@@ -67,7 +67,7 @@ public class GeoJsonTileDecoder implements ITileDecoder {
 
             /* add tag information */
             mTileSource.decodeTags(mapElement, f.getProperties(mProperties));
-            if (mapElement.tags.numTags == 0)
+            if (mapElement.tags.size() == 0)
                 continue;
 
             /* add geometry information */

--- a/vtm/src/org/oscim/core/TagSet.java
+++ b/vtm/src/org/oscim/core/TagSet.java
@@ -2,6 +2,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016 Andrey Novikov
  * Copyright 2016 devemux86
+ * Copyright 2017 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *

--- a/vtm/src/org/oscim/core/TagSet.java
+++ b/vtm/src/org/oscim/core/TagSet.java
@@ -30,12 +30,12 @@ public class TagSet {
     /**
      * The Tags.
      */
-    public Tag[] tags;
+    private Tag[] tags;
 
     /**
      * The number of current Tags in set.
      */
-    public int numTags;
+    private int numTags;
 
     /**
      * Instantiates a new TagSet with initial size of 10.
@@ -61,6 +61,13 @@ public class TagSet {
     }
 
     /**
+     * @return Size of TagSet
+     */
+    public int size() {
+        return numTags;
+    }
+
+    /**
      * Clear. Reset the TagSet to contain 0 tags and null out tags.
      */
     public void clearAndNullTags() {
@@ -80,6 +87,19 @@ public class TagSet {
     }
 
     /**
+     * Find Tag by given index.
+     *
+     * @param index the index of tag.
+     * @return the tag if found, null otherwise.
+     */
+    public Tag get(int index) {
+        if (index >= numTags) {
+            return null;
+        }
+        return tags[index];
+    }
+
+    /**
      * Find Tag by given key.
      *
      * @param key the key as intern String.
@@ -94,10 +114,19 @@ public class TagSet {
     }
 
     /**
+     * Return Tags array contained in TagSet.
+     *
+     * @return the tags array.
+     */
+    public Tag[] getTags() {
+        return tags;
+    }
+
+    /**
      * Checks if any tag has the key 'key'.
      *
      * @param key the key as intern String.
-     * @return true, iff any tag has the given key
+     * @return true, if any tag has the given key
      */
     public boolean containsKey(String key) {
         for (int i = 0; i < numTags; i++) {

--- a/vtm/src/org/oscim/layers/tile/vector/OsmTileLayer.java
+++ b/vtm/src/org/oscim/layers/tile/vector/OsmTileLayer.java
@@ -65,12 +65,12 @@ public class OsmTileLayer extends VectorTileLayer {
         };
 
         protected TagSet filterTags(TagSet tagSet) {
-            Tag[] tags = tagSet.tags;
+            Tag[] tags = tagSet.getTags();
 
             mFilteredTags.clear();
 
             O:
-            for (int i = 0, n = tagSet.numTags; i < n; i++) {
+            for (int i = 0, n = tagSet.size(); i < n; i++) {
                 Tag t = tags[i];
 
                 for (TagReplacement replacement : mTagReplacement) {

--- a/vtm/src/org/oscim/theme/MatchingCacheKey.java
+++ b/vtm/src/org/oscim/theme/MatchingCacheKey.java
@@ -37,13 +37,13 @@ class MatchingCacheKey {
      * set temporary values for comparison
      */
     boolean set(TagSet tags, MatchingCacheKey compare) {
-        int numTags = tags.numTags;
+        int numTags = tags.size();
 
         /* Test if tags are equal to previous query */
         if (compare != null && numTags == compare.mTags.length) {
             int i = 0;
             for (; i < numTags; i++) {
-                Tag t1 = tags.tags[i];
+                Tag t1 = tags.get(i);
                 Tag t2 = compare.mTags[i];
 
                 if (!(t1 == t2 || (Utils.equals(t1.key, t2.key) && Utils.equals(t1.value, t2.value))))
@@ -60,7 +60,7 @@ class MatchingCacheKey {
 
         int result = 7;
         for (int i = 0; i < numTags; i++) {
-            Tag t = tags.tags[i];
+            Tag t = tags.get(i);
             result = 31 * result + t.hashCode();
             mTags[i] = t;
         }

--- a/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
+++ b/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
@@ -602,7 +602,8 @@ public class MapDatabase implements ITileDataSource {
         MapElement e = mElem;
 
         for (int elementCounter = numberOfPois; elementCounter != 0; --elementCounter) {
-            int numTags = 0;
+            /* reset to common tag position */
+            e.tags.clear();
 
             if (mDebugFile) {
                 /* get and check the POI signature */
@@ -631,12 +632,7 @@ public class MapDatabase implements ITileDataSource {
             if (numberOfTags != 0) {
                 if (!mReadBuffer.readTags(e.tags, poiTags, numberOfTags))
                     return false;
-
-                numTags = numberOfTags;
             }
-
-            /* reset to common tag position */
-            e.tags.numTags = numTags;
 
             /* get the feature bitmask (1 byte) */
             byte featureByte = mReadBuffer.readByte();
@@ -665,8 +661,8 @@ public class MapDatabase implements ITileDataSource {
 
             if (pois != null) {
                 List<Tag> tags = new ArrayList<>();
-                for (int i = 0; i < e.tags.numTags; i++)
-                    tags.add(e.tags.tags[i]);
+                for (int i = 0; i < e.tags.size(); i++)
+                    tags.add(e.tags.get(i));
                 GeoPoint position = new GeoPoint(latitude, longitude);
                 // depending on the zoom level configuration the poi can lie outside
                 // the tile requested, we filter them out here
@@ -813,7 +809,8 @@ public class MapDatabase implements ITileDataSource {
         //setTileClipping(queryParameters);
 
         for (int elementCounter = numberOfWays; elementCounter != 0; --elementCounter) {
-            int numTags = 0;
+            /* reset to common tag position */
+            e.tags.clear();
 
             if (mDebugFile) {
                 // get and check the way signature
@@ -844,8 +841,6 @@ public class MapDatabase implements ITileDataSource {
                     if (!mReadBuffer.readTags(e.tags, wayTags, numberOfTags))
                         return false;
 
-                    numTags = numberOfTags;
-
                     mReadBuffer.setBufferPosition(pos);
                 }
             } else {
@@ -872,11 +867,8 @@ public class MapDatabase implements ITileDataSource {
             byte numberOfTags = (byte) (specialByte & WAY_NUMBER_OF_TAGS_BITMASK);
 
             if (numberOfTags != 0) {
-
                 if (!mReadBuffer.readTags(e.tags, wayTags, numberOfTags))
                     return false;
-
-                numTags = numberOfTags;
             }
 
             /* get the feature bitmask (1 byte) */
@@ -889,8 +881,6 @@ public class MapDatabase implements ITileDataSource {
             boolean hasName = (featureByte & WAY_FEATURE_NAME) != 0;
             boolean hasHouseNr = (featureByte & WAY_FEATURE_HOUSE_NUMBER) != 0;
             boolean hasRef = (featureByte & WAY_FEATURE_REF) != 0;
-
-            e.tags.numTags = numTags;
 
             if (mTileSource.experimental) {
                 if (hasName) {
@@ -978,8 +968,8 @@ public class MapDatabase implements ITileDataSource {
                     GeoPoint[][] wayNodesArray = wayNodes.toArray(new GeoPoint[wayNodes.size()][]);
                     if (!filterRequired || !wayFilterEnabled || wayFilterBbox.intersectsArea(wayNodesArray)) {
                         List<Tag> tags = new ArrayList<>();
-                        for (int i = 0; i < e.tags.numTags; i++)
-                            tags.add(e.tags.tags[i]);
+                        for (int i = 0; i < e.tags.size(); i++)
+                            tags.add(e.tags.get(i));
                         if (Selector.ALL == selector || hasName || hasHouseNr || hasRef || wayAsLabelTagFilter(tags)) {
                             GeoPoint labelPos = e.labelPosition != null ? new GeoPoint(e.labelPosition.y / 1E6, e.labelPosition.x / 1E6) : null;
                             ways.add(new Way(layer, tags, wayNodesArray, labelPos, e.type));

--- a/vtm/src/org/oscim/tiling/source/mapfile/OSMUtils.java
+++ b/vtm/src/org/oscim/tiling/source/mapfile/OSMUtils.java
@@ -38,8 +38,8 @@ public final class OSMUtils {
      */
     public static boolean isArea(MapElement mapElement) {
         boolean result = true;
-        for (int i = 0; i < mapElement.tags.numTags; i++) {
-            Tag tag = mapElement.tags.tags[i];
+        for (int i = 0; i < mapElement.tags.size(); i++) {
+            Tag tag = mapElement.tags.get(i);
             String key = tag.key.toLowerCase(Locale.ENGLISH);
             String value = tag.value.toLowerCase(Locale.ENGLISH);
             if ("area".equals(key)) {

--- a/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
+++ b/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
@@ -389,7 +389,7 @@ public class TileDecoder extends PbfDecoder {
 
         mElem.tags.clear();
 
-        int max = mTileTags.numTags - 1;
+        int max = mTileTags.size() - 1;
 
         for (int i = 0; i < numTags; i++) {
             int idx = tagIds[i];
@@ -400,7 +400,7 @@ public class TileDecoder extends PbfDecoder {
                         Integer.valueOf(i));
                 return false;
             }
-            mElem.tags.add(mTileTags.tags[idx]);
+            mElem.tags.add(mTileTags.get(idx));
         }
 
         return true;


### PR DESCRIPTION
`TagSet` is sometimes unsafe and not always clear at which position the `numTags` counter is pointing. This should be more convenient.