### PR TITLE
Fix text drawing with stroke on iOS

### DIFF
--- a/vtm-ios/src/org/oscim/ios/backend/IosCanvas.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosCanvas.java
@@ -76,8 +76,6 @@ public class IosCanvas implements Canvas {
         IosPaint iosFill = (IosPaint) fill;
         if (stroke != null) {
             IosPaint iosStroke = (IosPaint) stroke;
-            iosFill.setStrokeWidth(iosStroke.strokeWidth);
-            iosFill.setStrokeColor(iosStroke.getColor());
             iosStroke.drawLine(this.cgBitmapContext, string, x, y);
         }
         iosFill.drawLine(this.cgBitmapContext, string, x, y);

--- a/vtm-ios/src/org/oscim/ios/backend/IosPaint.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosPaint.java
@@ -194,7 +194,7 @@ public class IosPaint implements Paint {
                 !!!!!
                 NOTE: The value of NSStrokeWidthAttributeName is interpreted as a percentage of the font point size.
                 */
-                float strokeWidthPercent = -(this.strokeWidth / this.textSize * 50);
+                float strokeWidthPercent = (this.strokeWidth / this.textSize * 150);
                 attribs.setStrokeWidth(strokeWidthPercent);
 
                 NSAttributedString attributedString = new NSAttributedString(text, attribs);


### PR DESCRIPTION

After the changes from #236 to the scaling, I didn't really like the text drawing under iOS anymore, so I reworked it again!

Especially the handling of the text stroke was not correct!

before PR:
![bildschirmfoto 2017-11-09 um 15 13 07](https://user-images.githubusercontent.com/2542295/32649241-9a776f76-c5f9-11e7-8a04-49b905db9ac3.png)

after change with PR:
![bildschirmfoto 2017-11-10 um 09 22 34](https://user-images.githubusercontent.com/2542295/32649257-af2c8082-c5f9-11e7-9722-8ddb6eccf393.png)




