### PR TITLE
Do not read theme twice if format is predefined

### DIFF
--- a/vtm-android/src/org/oscim/android/theme/AssetsRenderTheme.java
+++ b/vtm-android/src/org/oscim/android/theme/AssetsRenderTheme.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2010, 2011, 2012 mapsforge.org
  * Copyright 2016-2017 devemux86
+ * Copyright 2017 Andrey Novikov
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -20,6 +21,7 @@ import android.text.TextUtils;
 
 import org.oscim.theme.IRenderTheme.ThemeException;
 import org.oscim.theme.ThemeFile;
+import org.oscim.theme.ThemeUtils;
 import org.oscim.theme.XmlRenderThemeMenuCallback;
 import org.oscim.utils.Utils;
 
@@ -96,6 +98,11 @@ public class AssetsRenderTheme implements ThemeFile {
         } catch (IOException e) {
             throw new ThemeException(e.getMessage());
         }
+    }
+
+    @Override
+    public boolean isMapsforgeTheme() {
+        return ThemeUtils.isMapsforgeTheme(this);
     }
 
     @Override

--- a/vtm-themes/src/org/oscim/theme/VtmThemes.java
+++ b/vtm-themes/src/org/oscim/theme/VtmThemes.java
@@ -3,6 +3,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
  * Copyright 2017 nebular
+ * Copyright 2017 Andrey Novikov
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -56,6 +57,11 @@ public enum VtmThemes implements ThemeFile {
     @Override
     public InputStream getRenderThemeAsStream() throws ThemeException {
         return AssetAdapter.readFileAsStream(mPath);
+    }
+
+    @Override
+    public boolean isMapsforgeTheme() {
+        return false;
     }
 
     @Override

--- a/vtm/src/org/oscim/theme/ExternalRenderTheme.java
+++ b/vtm/src/org/oscim/theme/ExternalRenderTheme.java
@@ -2,6 +2,7 @@
  * Copyright 2010, 2011, 2012 mapsforge.org
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
+ * Copyright 2017 Andrey Novikov
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -105,6 +106,11 @@ public class ExternalRenderTheme implements ThemeFile {
             throw new ThemeException(e.getMessage());
         }
         return is;
+    }
+
+    @Override
+    public boolean isMapsforgeTheme() {
+        return ThemeUtils.isMapsforgeTheme(this);
     }
 
     @Override

--- a/vtm/src/org/oscim/theme/StreamRenderTheme.java
+++ b/vtm/src/org/oscim/theme/StreamRenderTheme.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016-2017 devemux86
+ * Copyright 2017 Andrey Novikov
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -87,6 +88,11 @@ public class StreamRenderTheme implements ThemeFile {
             throw new ThemeException(e.getMessage());
         }
         return mInputStream;
+    }
+
+    @Override
+    public boolean isMapsforgeTheme() {
+        return ThemeUtils.isMapsforgeTheme(this);
     }
 
     @Override

--- a/vtm/src/org/oscim/theme/ThemeFile.java
+++ b/vtm/src/org/oscim/theme/ThemeFile.java
@@ -2,6 +2,7 @@
  * Copyright 2010, 2011, 2012 mapsforge.org
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
+ * Copyright 2017 Andrey Novikov
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -42,6 +43,13 @@ public interface ThemeFile extends Serializable {
      * @throws ThemeException if an error occurs while reading the render theme XML.
      */
     InputStream getRenderThemeAsStream() throws ThemeException;
+
+    /**
+     * Tells ThemeLoader if theme file is in Mapsforge format
+     *
+     * @return true if theme file is in Mapsforge format
+     */
+    boolean isMapsforgeTheme();
 
     /**
      * @param menuCallback the interface callback to create a settings menu on the fly.

--- a/vtm/src/org/oscim/theme/ThemeLoader.java
+++ b/vtm/src/org/oscim/theme/ThemeLoader.java
@@ -2,6 +2,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
  * Copyright 2017 Longri
+ * Copyright 2017 Andrey Novikov
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -46,7 +47,7 @@ public class ThemeLoader {
 
     public static IRenderTheme load(ThemeFile theme, ThemeCallback themeCallback) throws ThemeException {
         IRenderTheme t;
-        if (ThemeUtils.isMapsforgeTheme(theme))
+        if (theme.isMapsforgeTheme())
             t = Parameters.TEXTURE_ATLAS ? XmlMapsforgeAtlasThemeBuilder.read(theme, themeCallback) : XmlMapsforgeThemeBuilder.read(theme, themeCallback);
         else
             t = Parameters.TEXTURE_ATLAS ? XmlAtlasThemeBuilder.read(theme, themeCallback) : XmlThemeBuilder.read(theme, themeCallback);


### PR DESCRIPTION
This is not a good solution to always read theme twice to check if it is in native or mapsforge format. Despite `ThemeUtils` closes `InputStream` asap it is not always a good solution. In my case I construct theme from many pieces depending on user input and I have to do it twice just to flag that the theme is in native format.

As `ThemeFile` is an interface more clear solution is to let its implementation decide what format it implements. General implementations use `ThemeUtils` as before.