### PR TITLE
Refactor S3DB layer

### DIFF
--- a/vtm-android-example/AndroidManifest.xml
+++ b/vtm-android-example/AndroidManifest.xml
@@ -104,7 +104,7 @@
             android:name=".RotateMarkerOverlayActivity"
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity
-            android:name=".S3DBMapActivity"
+            android:name=".OpenScienceMapS3DBMapActivity"
             android:configChanges="keyboardHidden|orientation|screenSize" />
         <activity
             android:name=".SimpleMapActivity"

--- a/vtm-android-example/src/org/oscim/android/test/OpenScienceMapS3DBMapActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/OpenScienceMapS3DBMapActivity.java
@@ -20,13 +20,13 @@ import android.os.Bundle;
 
 import org.oscim.android.cache.TileCache;
 import org.oscim.layers.tile.TileLayer;
-import org.oscim.layers.tile.buildings.S3DBLayer;
+import org.oscim.layers.tile.buildings.S3DBTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.oscimap4.OSciMap4TileSource;
 
-public class S3DBMapActivity extends BaseMapActivity {
+public class OpenScienceMapS3DBMapActivity extends BaseMapActivity {
 
     TileCache mS3dbCache;
 
@@ -47,7 +47,7 @@ public class S3DBMapActivity extends BaseMapActivity {
             mS3dbCache.setCacheSize(512 * (1 << 10));
             ts.setCache(mS3dbCache);
         }
-        TileLayer tl = new S3DBLayer(mMap, ts, true, false);
+        TileLayer tl = new S3DBTileLayer(mMap, ts, true, false);
         mMap.layers().add(tl);
         mMap.layers().add(new LabelLayer(mMap, mBaseLayer));
     }

--- a/vtm-android-example/src/org/oscim/android/test/Samples.java
+++ b/vtm-android-example/src/org/oscim/android/test/Samples.java
@@ -124,7 +124,7 @@ public class Samples extends Activity {
 
         linearLayout.addView(createLabel("Experiments"));
         linearLayout.addView(createButton(ReverseGeocodeActivity.class));
-        linearLayout.addView(createButton(S3DBMapActivity.class));
+        linearLayout.addView(createButton(OpenScienceMapS3DBMapActivity.class));
         linearLayout.addView(createButton(ThemeStylerActivity.class));
         linearLayout.addView(createButton(JeoIndoorMapActivity.class));
     }

--- a/vtm-playground/src/org/oscim/test/S3DBTileLayerTest.java
+++ b/vtm-playground/src/org/oscim/test/S3DBTileLayerTest.java
@@ -17,12 +17,12 @@
 package org.oscim.test;
 
 import org.oscim.gdx.GdxMapApp;
-import org.oscim.layers.tile.buildings.S3DBLayer;
+import org.oscim.layers.tile.buildings.S3DBTileLayer;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.oscimap4.OSciMap4TileSource;
 
-public class S3DBLayerTest extends GdxMapApp {
+public class S3DBTileLayerTest extends GdxMapApp {
 
     @Override
     public void createLayers() {
@@ -34,7 +34,7 @@ public class S3DBLayerTest extends GdxMapApp {
                 .url("http://opensciencemap.org/tiles/s3db")
                 .build();
 
-        S3DBLayer tl = new S3DBLayer(mMap, ts);
+        S3DBTileLayer tl = new S3DBTileLayer(mMap, ts);
         mMap.layers().add(tl);
 
         mMap.setMapPosition(53.08, 8.82, 1 << 17);
@@ -43,6 +43,6 @@ public class S3DBLayerTest extends GdxMapApp {
 
     public static void main(String[] args) {
         init();
-        run(new S3DBLayerTest());
+        run(new S3DBTileLayerTest());
     }
 }

--- a/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
+++ b/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 
 public class ThemeBuilderTest extends GdxMapImpl {
 
-    final Logger log = LoggerFactory.getLogger(S3DBLayerTest.class);
+    final Logger log = LoggerFactory.getLogger(S3DBTileLayerTest.class);
 
     static class MyTheme extends ThemeBuilder {
         public MyTheme() {

--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -33,7 +33,7 @@ import org.oscim.gdx.client.MapConfig;
 import org.oscim.gdx.client.MapUrl;
 import org.oscim.layers.tile.bitmap.BitmapTileLayer;
 import org.oscim.layers.tile.buildings.BuildingLayer;
-import org.oscim.layers.tile.buildings.S3DBLayer;
+import org.oscim.layers.tile.buildings.S3DBTileLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.renderer.MapRenderer;
@@ -138,7 +138,7 @@ class GwtMap extends GdxMap {
                     .zoomMin(16)
                     .zoomMax(16)
                     .build();
-            mMap.layers().add(new S3DBLayer(mMap, ts));
+            mMap.layers().add(new S3DBTileLayer(mMap, ts));
         }
         if (l != null) {
             boolean nolabels = mapUrl.params.containsKey("nolabels");

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2013 Hannes Janetzek
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.layers.tile.buildings;
+
+import org.oscim.layers.tile.TileLayer;
+import org.oscim.layers.tile.TileManager;
+import org.oscim.layers.tile.TileRenderer;
+import org.oscim.map.Map;
+import org.oscim.renderer.GLViewport;
+import org.oscim.renderer.LayerRenderer;
+import org.oscim.renderer.OffscreenRenderer;
+import org.oscim.renderer.OffscreenRenderer.Mode;
+import org.oscim.tiling.TileSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class S3DBTileLayer extends TileLayer {
+    static final Logger log = LoggerFactory.getLogger(S3DBTileLayer.class);
+
+    private final static int MAX_CACHE = 32;
+
+    private final static int MIN_ZOOM = 16;
+    private final static int MAX_ZOOM = 16;
+
+    private final TileSource mTileSource;
+
+    public S3DBTileLayer(Map map, TileSource tileSource) {
+        this(map, tileSource, true, false);
+    }
+
+    /**
+     * Simple-3D-Buildings OSCIM4 Tile Layer
+     *
+     * @param map        Stored map workaround
+     * @param tileSource Source of loaded tiles in {@link org.oscim.layers.tile.vector.VectorTileLayer}
+     * @param fxaa       Switch on Fast Approximate Anti-Aliasing
+     * @param ssao       Switch on Screen Space Ambient Occlusion
+     */
+    public S3DBTileLayer(Map map, TileSource tileSource, boolean fxaa, boolean ssao) {
+        super(map, new TileManager(map, MAX_CACHE));
+        setRenderer(new S3DBTileRenderer(fxaa, ssao));
+
+        mTileManager.setZoomLevel(MIN_ZOOM, MAX_ZOOM);
+        mTileSource = tileSource;
+        initLoader(2);
+    }
+
+    @Override
+    protected S3DBTileLoader createLoader() {
+        return new S3DBTileLoader(getManager(), mTileSource);
+    }
+
+    public static class S3DBTileRenderer extends TileRenderer {
+        LayerRenderer mRenderer;
+
+        public S3DBTileRenderer(boolean fxaa, boolean ssao) {
+            mRenderer = new BuildingRenderer(this, MIN_ZOOM, MAX_ZOOM, true, false);
+
+            if (fxaa || ssao) {
+                Mode mode = Mode.FXAA;
+                if (fxaa && ssao)
+                    mode = Mode.SSAO_FXAA;
+                else if (ssao)
+                    mode = Mode.SSAO;
+                mRenderer = new OffscreenRenderer(mode, mRenderer);
+            }
+        }
+
+        @Override
+        public synchronized void update(GLViewport v) {
+            super.update(v);
+            mRenderer.update(v);
+            setReady(mRenderer.isReady());
+        }
+
+        @Override
+        public synchronized void render(GLViewport v) {
+            mRenderer.render(v);
+        }
+
+        @Override
+        public boolean setup() {
+            mRenderer.setup();
+            return super.setup();
+        }
+    }
+}

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -128,11 +128,11 @@ class S3DBTileLoader extends TileLoader {
 
         int c = 0;
         if (element.tags.containsKey(OSCIM4_KEY_COLOR)) {
-            c = S3DBLayer.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), isRoof);
+            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), isRoof);
         }
 
         if (c == 0 && element.tags.containsKey(OSCIM4_KEY_MATERIAL)) {
-            c = S3DBLayer.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL), isRoof);
+            c = S3DBUtils.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL), isRoof);
         }
 
         if (c == 0) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2017 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -17,95 +18,26 @@
 package org.oscim.layers.tile.buildings;
 
 import org.oscim.backend.canvas.Color;
-import org.oscim.layers.tile.TileLayer;
-import org.oscim.layers.tile.TileManager;
-import org.oscim.layers.tile.TileRenderer;
-import org.oscim.map.Map;
-import org.oscim.renderer.GLViewport;
-import org.oscim.renderer.LayerRenderer;
-import org.oscim.renderer.OffscreenRenderer;
-import org.oscim.renderer.OffscreenRenderer.Mode;
-import org.oscim.tiling.TileSource;
 import org.oscim.utils.ColorUtil;
 import org.oscim.utils.ColorsCSS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class S3DBLayer extends TileLayer {
-    static final Logger log = LoggerFactory.getLogger(S3DBLayer.class);
-
-    private final static int MAX_CACHE = 32;
-
-    private final static int MIN_ZOOM = 16;
-    private final static int MAX_ZOOM = 16;
+/**
+ * Provides utils for S3DB layers
+ */
+public class S3DBUtils {
+    static final Logger log = LoggerFactory.getLogger(S3DBUtils.class);
 
     /* TODO get from theme */
     private final static double HSV_S = 0.7;
     private final static double HSV_V = 1.2;
 
-    private final TileSource mTileSource;
-
-    public S3DBLayer(Map map, TileSource tileSource) {
-        this(map, tileSource, true, false);
-    }
-
     /**
-     * Simple-3D-Buildings OSCIM4 Tile Layer
-     *
-     * @param map        Stored map workaround
-     * @param tileSource Source of loaded tiles in {@link org.oscim.layers.tile.vector.VectorTileLayer}
-     * @param fxaa       Switch on Fast Approximate Anti-Aliasing
-     * @param ssao       Switch on Screen Space Ambient Occlusion
+     * @param color the color as string (see http://wiki.openstreetmap.org/wiki/Key:colour)
+     * @param roof  declare if color is used for roofs
+     * @return the color as integer (8 bit each a, r, g, b)
      */
-    public S3DBLayer(Map map, TileSource tileSource, boolean fxaa, boolean ssao) {
-        super(map, new TileManager(map, MAX_CACHE));
-        setRenderer(new S3DBRenderer(fxaa, ssao));
-
-        mTileManager.setZoomLevel(MIN_ZOOM, MAX_ZOOM);
-        mTileSource = tileSource;
-        initLoader(2);
-    }
-
-    @Override
-    protected S3DBTileLoader createLoader() {
-        return new S3DBTileLoader(getManager(), mTileSource);
-    }
-
-    public static class S3DBRenderer extends TileRenderer {
-        LayerRenderer mRenderer;
-
-        public S3DBRenderer(boolean fxaa, boolean ssao) {
-            mRenderer = new BuildingRenderer(this, MIN_ZOOM, MAX_ZOOM, true, false);
-
-            if (fxaa || ssao) {
-                Mode mode = Mode.FXAA;
-                if (fxaa && ssao)
-                    mode = Mode.SSAO_FXAA;
-                else if (ssao)
-                    mode = Mode.SSAO;
-                mRenderer = new OffscreenRenderer(mode, mRenderer);
-            }
-        }
-
-        @Override
-        public synchronized void update(GLViewport v) {
-            super.update(v);
-            mRenderer.update(v);
-            setReady(mRenderer.isReady());
-        }
-
-        @Override
-        public synchronized void render(GLViewport v) {
-            mRenderer.render(v);
-        }
-
-        @Override
-        public boolean setup() {
-            mRenderer.setup();
-            return super.setup();
-        }
-    }
-
     static int getColor(String color, boolean roof) {
 
         if (color.charAt(0) == '#') {
@@ -155,6 +87,11 @@ public class S3DBLayer extends TileLayer {
         return 0;
     }
 
+    /**
+     * @param material the material as string (see http://wiki.openstreetmap.org/wiki/Key:material and following pages)
+     * @param roof     declare if material is used for roofs
+     * @return the color as integer (8 bit each a, r, g, b)
+     */
     static int getMaterialColor(String material, boolean roof) {
 
         if (roof) {


### PR DESCRIPTION
- Renamed `S3DBLayer` to `S3DBTileLayer`, cause it extends TileLayer
- Renamed `S3DBRenderer` to `S3DBTileRenderer`, cause it extends TileRenderer
- Moved `getColor` and `getMaterialColor` from `S3DBLayer` to `S3DBUtils` and add doc comments; utils will grow from time to time
- Renamed `S3DBMapActivity` to `OpenScienceMapS3DBMapActivity`, cause it provides exclusively OScim4 tile maps

Note: no changes in implementations were made
Renaming is necessary to not confuse tile layers with _"real"_ layers