### PR TITLE
Enhance copying MapElement and GeometryBuffer

### DIFF
--- a/vtm/src/org/oscim/core/GeometryBuffer.java
+++ b/vtm/src/org/oscim/core/GeometryBuffer.java
@@ -22,6 +22,8 @@ package org.oscim.core;
  * - should make internals private, maybe
  */
 
+import java.util.Arrays;
+
 /**
  * The GeometryBuffer class holds temporary geometry data for processing.
  * Only One geometry type can be set at a time. Use 'clear()' to reset the
@@ -126,6 +128,22 @@ public class GeometryBuffer {
         this.indexCurrentPos = 0;
         this.pointNextPos = 0;
         this.pointLimit = points.length - 2;
+    }
+
+    /**
+     * @param buffer the buffer to copy
+     */
+    public GeometryBuffer(GeometryBuffer buffer) {
+        int indexSize = 0;
+        while (indexSize < buffer.index.length && buffer.index[indexSize] != -1) {
+            indexSize++;
+        }
+        this.points = Arrays.copyOf(buffer.points, buffer.pointNextPos);
+        this.index = Arrays.copyOf(buffer.index, indexSize);
+
+        this.pointNextPos = buffer.pointNextPos;
+        this.indexCurrentPos = buffer.indexCurrentPos;
+        this.type = buffer.type;
     }
 
     /**

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -18,8 +18,6 @@
  */
 package org.oscim.core;
 
-import java.util.Arrays;
-
 /**
  * The MapElement class is a reusable containter for a geometry
  * with tags.
@@ -51,6 +49,16 @@ public class MapElement extends GeometryBuffer {
         super(points, index);
     }
 
+    /**
+     * @param element the map element to copy
+     */
+    public MapElement(MapElement element) {
+        super(element);
+        this.tags.set(element.tags.asArray());
+        this.labelPosition = element.labelPosition;
+        this.setLayer(element.layer);
+    }
+
     public void setLabelPosition(float x, float y) {
         labelPosition = new PointF(x, y);
     }
@@ -74,26 +82,9 @@ public class MapElement extends GeometryBuffer {
     }
 
     /**
-     * @return a deep copy of this MapElement
+     * @return a duplicate of the element's geometries
      */
-    public MapElement clone() {
-        int indexSize = this.indexCurrentPos + 1;
-        for (int i = 0; i < this.index.length; i++) {
-            if (this.index[i] == -1) {
-                indexSize = i;
-                break;
-            }
-        }
-        float[] copyPoints = Arrays.copyOf(this.points, this.pointNextPos);
-        int[] copyIndex = Arrays.copyOf(this.index, indexSize);
-
-        MapElement copy = new MapElement(copyPoints, copyIndex);
-        copy.tags.set(this.tags.asArray());
-        copy.pointNextPos = this.pointNextPos;
-        copy.labelPosition = this.labelPosition;
-        copy.setLayer(this.layer);
-        copy.indexCurrentPos = this.indexCurrentPos;
-        copy.type = this.type;
-        return copy;
+    public GeometryBuffer getGeometryBuffer() {
+        return new GeometryBuffer(this);
     }
 }

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -19,12 +19,12 @@
 package org.oscim.core;
 
 /**
- * The MapElement class is a reusable containter for a geometry
+ * The MapElement class is a reusable container for a geometry
  * with tags.
  * MapElement is created by TileDataSource(s) and passed to
  * MapTileLoader via ITileDataSink.process().
  * This is just a buffer that belongs to TileDataSource,
- * so dont keep a reference to it when passed as parameter.
+ * so don't keep a reference to it when passed as parameter.
  */
 public class MapElement extends GeometryBuffer {
 
@@ -76,15 +76,6 @@ public class MapElement extends GeometryBuffer {
 
     @Override
     public String toString() {
-
         return tags.toString() + '\n' + super.toString() + '\n';
-
-    }
-
-    /**
-     * @return a duplicate of the element's geometries
-     */
-    public GeometryBuffer getGeometryBuffer() {
-        return new GeometryBuffer(this);
     }
 }

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -109,7 +109,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
                 buildingElements = new ArrayList<>();
                 mBuildings.put(tile.hashCode(), buildingElements);
             }
-            element = element.clone(); // Deep copy, because element will be cleared
+            element = new MapElement(element); // Deep copy, because element will be cleared
             buildingElements.add(new BuildingElement(element, extrusion, isBuildingPart));
             return true;
         }


### PR DESCRIPTION
Sorry that I rewrite the clone method of MapElement again, but there was a bug:
If you clone the same element twice, the second element only had the size of `indexCurrentPos` (which is often 0). This had no effect on the latest release. But now it copies all values until there is a `-1`.
I exploit the opportunity to introduce a copy-constructor instead of a clone-method, because it allows using the parent constructor (here a new `GeometryBuffer`).
~Furthermore I added a method `getGeometryBuffer` in MapElement, which I will reduce copying tags in later steps.~