### PR TITLE
Refactor ExtrusionBucket

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -159,8 +159,8 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
         ExtrusionBuckets ebs = get(tile);
 
         for (ExtrusionBucket b = ebs.buckets; b != null; b = b.next()) {
-            if (b.colors == extrusion.colors) {
-                b.add(element, height, minHeight);
+            if (b.getColors() == extrusion.colors) {
+                b.addPoly(element, height, minHeight);
                 return;
             }
         }
@@ -173,7 +173,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
                 new ExtrusionBucket(0, groundScale,
                         extrusion.colors));
 
-        ebs.buckets.add(element, height, minHeight);
+        ebs.buckets.addPoly(element, height, minHeight);
     }
 
     /**

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -139,15 +139,15 @@ class S3DBTileLoader extends TileLoader {
             String roofShape = element.tags.getValue(Tag.KEY_ROOF_SHAPE);
 
             if (isRoof && (roofShape == null || Tag.VALUE_FLAT.equals(roofShape)))
-                mRoofs.add(element);
+                mRoofs.addMesh(element);
             else
-                mParts.add(element);
+                mParts.addMesh(element);
             return;
         }
 
         for (ExtrusionBucket l = mParts; l != null; l = l.next()) {
-            if (l.color == c) {
-                l.add(element);
+            if (l.getColor() == c) {
+                l.addMesh(element);
                 return;
             }
         }
@@ -156,7 +156,7 @@ class S3DBTileLoader extends TileLoader {
         l.next = mParts.next;
         mParts.next = l;
 
-        l.add(element);
+        l.addMesh(element);
     }
 
     @Override

--- a/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
+++ b/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
@@ -95,7 +95,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
     @Override
     public void render(GLViewport v) {
 
-        float[] currentColor = null;
+        float[] currentColors = null;
         float currentAlpha = 0;
 
         gl.depthMask(true);
@@ -171,11 +171,11 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
 
             for (; eb != null; eb = eb.next()) {
 
-                if (eb.colors != currentColor) {
-                    currentColor = eb.colors;
+                if (eb.getColors() != currentColors) {
+                    currentColors = eb.getColors();
                     GLUtils.glUniform4fv(s.uColor,
                             mMode == 0 ? 4 : 1,
-                            eb.colors);
+                            currentColors);
                 }
 
                 gl.vertexAttribPointer(s.aPos, 3, GL.SHORT,


### PR DESCRIPTION
Refactor some attributes in `ExtrusionBucket`
- color and colors as private (add getters)
- renamed `add` (for meshes) to `addMesh`
- renamed `add` (for polygons) to `addPoly`

Notes: `add`(mesh) and `add`(poly) not give the same result with other parameters, so this should be more separated.
