### PR TITLE
Improve ExtrusionBuckets

### DIFF
--- a/vtm/src/org/oscim/layers/tile/MapTile.java
+++ b/vtm/src/org/oscim/layers/tile/MapTile.java
@@ -17,6 +17,7 @@
  */
 package org.oscim.layers.tile;
 
+import org.oscim.core.MercatorProjection;
 import org.oscim.core.Tile;
 import org.oscim.layers.tile.vector.VectorTileLoader;
 import org.oscim.layers.tile.vector.labeling.LabelTileLoaderHook;
@@ -334,6 +335,15 @@ public class MapTile extends Tile {
             prev = d;
         }
         return null;
+    }
+
+    /**
+     * @return the corresponding ground scale
+     */
+    public float getGroundScale() {
+        double lat = MercatorProjection.toLatitude(this.y);
+        return (float) MercatorProjection
+                .groundResolutionWithScale(lat, 1 << this.zoomLevel);
     }
 
     public static int depthOffset(MapTile t) {

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -20,7 +20,6 @@
 package org.oscim.layers.tile.buildings;
 
 import org.oscim.core.MapElement;
-import org.oscim.core.MercatorProjection;
 import org.oscim.core.Tag;
 import org.oscim.layers.Layer;
 import org.oscim.layers.tile.MapTile;
@@ -29,12 +28,10 @@ import org.oscim.layers.tile.vector.VectorTileLayer.TileLoaderThemeHook;
 import org.oscim.map.Map;
 import org.oscim.renderer.OffscreenRenderer;
 import org.oscim.renderer.OffscreenRenderer.Mode;
-import org.oscim.renderer.bucket.ExtrusionBucket;
 import org.oscim.renderer.bucket.ExtrusionBuckets;
 import org.oscim.renderer.bucket.RenderBuckets;
 import org.oscim.theme.styles.ExtrusionStyle;
 import org.oscim.theme.styles.RenderStyle;
-import org.oscim.utils.pool.Inlist;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -156,24 +153,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
         if (height == 0)
             height = extrusion.defaultHeight * 100;
 
-        ExtrusionBuckets ebs = get(tile);
-
-        for (ExtrusionBucket b = ebs.buckets; b != null; b = b.next()) {
-            if (b.getColors() == extrusion.colors) {
-                b.addPoly(element, height, minHeight);
-                return;
-            }
-        }
-
-        double lat = MercatorProjection.toLatitude(tile.y);
-        float groundScale = (float) MercatorProjection
-                .groundResolutionWithScale(lat, 1 << tile.zoomLevel);
-
-        ebs.buckets = Inlist.push(ebs.buckets,
-                new ExtrusionBucket(0, groundScale,
-                        extrusion.colors));
-
-        ebs.buckets.addPoly(element, height, minHeight);
+        get(tile).addPolyElement(element, tile.getGroundScale(), extrusion.colors, height, minHeight);
     }
 
     /**
@@ -234,7 +214,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
             processElements(tile);
             get(tile).prepare();
         } else
-            get(tile).setBuckets(null);
+            get(tile).resetBuckets(null);
     }
 
     //    private int multi;

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -21,7 +21,6 @@ import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeometryBuffer;
 import org.oscim.core.GeometryBuffer.GeometryType;
 import org.oscim.core.MapElement;
-import org.oscim.core.MercatorProjection;
 import org.oscim.core.Tag;
 import org.oscim.layers.tile.MapTile;
 import org.oscim.layers.tile.TileLoader;
@@ -96,9 +95,7 @@ class S3DBTileLoader extends TileLoader {
     }
 
     private void initTile(MapTile tile) {
-        double lat = MercatorProjection.toLatitude(tile.y);
-        mGroundScale = (float) MercatorProjection
-                .groundResolutionWithScale(lat, 1 << mTile.zoomLevel);
+        mGroundScale = tile.getGroundScale();
 
         mRoofs = new ExtrusionBucket(0, mGroundScale, Color.get(247, 249, 250));
 
@@ -106,7 +103,7 @@ class S3DBTileLoader extends TileLoader {
         //mRoofs = new ExtrusionLayer(0, mGroundScale, Color.get(207, 209, 210));
         mRoofs.next = mParts;
 
-        BuildingLayer.get(tile).setBuckets(mRoofs);
+        BuildingLayer.get(tile).resetBuckets(mRoofs);
 
         process(mTilePlane);
     }
@@ -145,6 +142,7 @@ class S3DBTileLoader extends TileLoader {
             return;
         }
 
+        // May replace with ExtrusionBucket.addMeshElement()
         for (ExtrusionBucket l = mParts; l != null; l = l.next()) {
             if (l.getColor() == c) {
                 l.addMesh(element);

--- a/vtm/src/org/oscim/renderer/bucket/ExtrusionBuckets.java
+++ b/vtm/src/org/oscim/renderer/bucket/ExtrusionBuckets.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2017 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.renderer.bucket;
 
 import org.oscim.backend.GL;


### PR DESCRIPTION
Some methods for clarity:
- Add method `addPolyElement` and `addMeshElement`
- renamed `setBuckets` to `resetBuckets`, cause it removes all dependencies and add `setBuckets`
- Add method `getGroundScale` to MapTile

In `S3DBTileLoader` the attributes `mRoofs` and `mParts` are split; if they're not, we can use `addMeshElement`. Don't know the reason why they are separated in roofs and parts but, I didn't notice any performance reductions, if we change this order of buckets. (Maybe separated, cause the corresponding colour can be found faster, since parts and roofs not always use same colours). But can handle this later...

`setBuckets()` may not necessary.