### PR TITLE
Moved z-limit settings to LayerRenderer so that z-limit option can be used in OffscreenRenderer too

### DIFF
--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -149,7 +149,7 @@ class GwtMap extends GdxMap {
 
             if (!nobuildings && !s3db) {
                 mBuildingLayer = new BuildingLayer(mMap, l);
-                ((ExtrusionRenderer) mBuildingLayer.getRenderer()).setZLimit((float) 65536 / 10);
+                mBuildingLayer.getRenderer().setZLimit((float) 65536 / 10);
                 mMap.layers().add(mBuildingLayer);
             }
 
@@ -170,7 +170,7 @@ class GwtMap extends GdxMap {
                     return;
                 }
 
-                ((ExtrusionRenderer) mBuildingLayer.getRenderer()).setZLimit((float) val / 10);
+                mBuildingLayer.getRenderer().setZLimit((float) val / 10);
 
                 mMap.updateMap(true);
             }

--- a/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
+++ b/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
@@ -40,8 +40,6 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
     protected int mBucketsCnt;
     protected float mAlpha = 1;
 
-    private float mZLimit = Float.MAX_VALUE;
-
     public ExtrusionRenderer(boolean mesh, boolean alpha) {
         mMode = mesh ? 1 : 0;
         mTranslucent = alpha;
@@ -273,9 +271,5 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
             v.mvp.addDepthOffset(delta);
         }
         v.mvp.setAsUniform(s.uMVP);
-    }
-
-    public void setZLimit(float zLimit) {
-        mZLimit = zLimit;
     }
 }

--- a/vtm/src/org/oscim/renderer/LayerRenderer.java
+++ b/vtm/src/org/oscim/renderer/LayerRenderer.java
@@ -28,6 +28,8 @@ public abstract class LayerRenderer {
      */
     boolean isInitialized;
 
+    protected float mZLimit = Float.MAX_VALUE;
+
     /**
      * Set 'ready for render' state when layer data is ready for rendering.
      *
@@ -69,4 +71,7 @@ public abstract class LayerRenderer {
      */
     public abstract void render(GLViewport viewport);
 
+    public void setZLimit(float zLimit) {
+        mZLimit = zLimit;
+    }
 }

--- a/vtm/src/org/oscim/renderer/OffscreenRenderer.java
+++ b/vtm/src/org/oscim/renderer/OffscreenRenderer.java
@@ -225,4 +225,9 @@ public class OffscreenRenderer extends LayerRenderer {
         gl.drawArrays(GL.TRIANGLE_STRIP, 0, 4);
         GLUtils.checkGlError("....");
     }
+
+    @Override
+    public void setZLimit(float zLimit) {
+        mRenderer.setZLimit(zLimit);
+    }
 }


### PR DESCRIPTION
Fixed bug which crashes when OffscreenRenderer is used to render BuildingLayer.