### PR TITLE
Export jts classes as API during build

### DIFF
--- a/vtm-jts/build.gradle
+++ b/vtm-jts/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'maven'
 
 dependencies {
     api project(':vtm')
-    implementation 'com.vividsolutions:jts:1.13'
+    api 'com.vividsolutions:jts:1.13'
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 }
 


### PR DESCRIPTION
Not exporting them will cause compile error when using some of the vtm classes