### PR TITLE
OpenMapTiles Max-Zoom Fix

### DIFF
--- a/vtm-json/src/org/oscim/tiling/source/geojson/OpenMapTilesGeojsonTileSource.java
+++ b/vtm-json/src/org/oscim/tiling/source/geojson/OpenMapTilesGeojsonTileSource.java
@@ -33,7 +33,7 @@ public class OpenMapTilesGeojsonTileSource extends GeojsonTileSource {
         private String locale = "";
 
         public Builder() {
-            super(DEFAULT_URL, DEFAULT_PATH, 1, 16);
+            super(DEFAULT_URL, DEFAULT_PATH, 1, 14);
         }
 
         public T locale(String locale) {


### PR DESCRIPTION
Fixed Maxzoom for OpenMapTiles.

See: https://free.tilehosting.com/data/v3.json?key=[YOUR_KEY]

Prints: `maxzoom: 14`