### PR TITLE
ColorUtil: semi-relative modHSV

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -123,7 +123,7 @@ public class S3DBLayer extends BuildingLayer {
         Integer bColor = null;
         if (mColored) {
             if (element.tags.containsKey(Tag.KEY_BUILDING_COLOR)) {
-                bColor = S3DBUtils.getColor(element.tags.getValue(Tag.KEY_BUILDING_COLOR), false);
+                bColor = S3DBUtils.getColor(element.tags.getValue(Tag.KEY_BUILDING_COLOR), false, false);
             } else if (element.tags.containsKey(Tag.KEY_BUILDING_MATERIAL)) {
                 bColor = S3DBUtils.getMaterialColor(element.tags.getValue(Tag.KEY_BUILDING_MATERIAL), false);
             }
@@ -210,7 +210,7 @@ public class S3DBLayer extends BuildingLayer {
         if (mColored) {
             v = element.tags.getValue(Tag.KEY_ROOF_COLOR);
             if (v != null)
-                roofColor = S3DBUtils.getColor(v, true);
+                roofColor = S3DBUtils.getColor(v, true, false);
             else if ((v = element.tags.getValue(Tag.KEY_ROOF_MATERIAL)) != null)
                 roofColor = S3DBUtils.getMaterialColor(v, true);
         }

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -125,7 +125,7 @@ class S3DBTileLoader extends TileLoader {
 
         int c = 0;
         if (element.tags.containsKey(OSCIM4_KEY_COLOR)) {
-            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), isRoof);
+            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), isRoof, true);
         }
 
         if (c == 0 && element.tags.containsKey(OSCIM4_KEY_MATERIAL)) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -1054,16 +1054,17 @@ public final class S3DBUtils {
     }
 
     /**
-     * @param color the color as string (see http://wiki.openstreetmap.org/wiki/Key:colour)
-     * @param roof  declare if color is used for roofs
+     * @param color     the color as string (see http://wiki.openstreetmap.org/wiki/Key:colour)
+     * @param roof      declare if color is used for roofs
+     * @param relative  declare if colors are modified relative to their values
      * @return the color as integer (8 bit each a, r, g, b)
      */
-    public static int getColor(String color, boolean roof) {
+    public static int getColor(String color, boolean roof, boolean relative) {
 
         if (color.charAt(0) == '#') {
             int c = Color.parseColor(color, Color.CYAN);
             /* hardcoded colors are way too saturated for my taste */
-            return ColorUtil.modHsv(c, 1.0, 0.4, HSV_V, true);
+            return ColorUtil.modHsv(c, 1.0, 0.4, HSV_V, relative);
         }
 
         if (roof) {
@@ -1101,7 +1102,7 @@ public final class S3DBUtils {
         Integer css = ColorsCSS.get(color);
 
         if (css != null)
-            return ColorUtil.modHsv(css, 1.0, HSV_S, HSV_V, true);
+            return ColorUtil.modHsv(css, 1.0, HSV_S, HSV_V, relative);
 
         log.debug("unknown color:{}", color);
         return 0;

--- a/vtm/src/org/oscim/utils/ColorUtil.java
+++ b/vtm/src/org/oscim/utils/ColorUtil.java
@@ -45,13 +45,21 @@ public class ColorUtil {
         return hsvToRgb(hsl.x, clamp(saturation * hsl.y, 0, 1), hsl.z);
     }
 
+    /**
+     * @param hue        the hue
+     * @param saturation the saturation
+     * @param value      the lightness (usual a range from 0 to 2)
+     * @param relative   indicate if colors are modified relative to their values
+     *                   (e.g black not changes if relative)
+     */
     public static synchronized int modHsv(int color, double hue, double saturation, double value,
                                           boolean relative) {
         Vec3 hsl = TMP_VEC;
         rgbToHsv(r(color), g(color), b(color), hsl);
         return hsvToRgb(clamp(hue * hsl.x, 0, 1),
                 clamp(saturation * hsl.y, 0, 1),
-                clamp(value * hsl.z, 0, 1));
+                clamp(relative || (value - 1) < 0 ? value * hsl.z :
+                        hsl.z + (value - 1) * (1 - hsl.z), 0, 1));
     }
 
     // functions ported from http://axonflux.com/handy-rgb-to-hsl-and-rgb-to-hsv-color-model-c


### PR DESCRIPTION
Added implementation of semi-relative color modification.
Example relative: 
```
float value = 1.2
limit(0.0 * value, 1) = 0.0 // black keeps black
limit(1.0 * value, 1) = 1.0 // white keeps white
```
Simplified example semi-relative: 
```
float value = 1.2
if(value > 1){
    limit(0.0 + (value - 1) * (1 - 0.0), 1) = 0.2 // black is increased
    limit(1.0 + (value - 1) * (1 - 1.0), 1) = 1.0 // white keeps white
}
```

Modified S3DBUtils to support this. Now the black parts don't appear like a hole.
  