### PR TITLE
Improve theme styles

### DIFF
--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -49,6 +49,11 @@
             <xs:enumeration value="monospace" />
             <xs:enumeration value="sans_serif" />
             <xs:enumeration value="serif" />
+            <xs:enumeration value="thin" />
+            <xs:enumeration value="light" />
+            <xs:enumeration value="medium" />
+            <xs:enumeration value="black" />
+            <xs:enumeration value="condensed" />
         </xs:restriction>
     </xs:simpleType>
 

--- a/vtm-android/src/org/oscim/android/canvas/AndroidPaint.java
+++ b/vtm-android/src/org/oscim/android/canvas/AndroidPaint.java
@@ -26,33 +26,46 @@ import org.oscim.backend.canvas.Paint;
 
 class AndroidPaint implements Paint {
 
-    private static int getStyle(org.oscim.backend.canvas.Paint.FontStyle fontStyle) {
+    private static Typeface getTypeface(org.oscim.backend.canvas.Paint.FontFamily fontFamily,
+                                        org.oscim.backend.canvas.Paint.FontStyle fontStyle) {
+        int style;
+
         switch (fontStyle) {
             case BOLD:
-                return Typeface.BOLD;
+                style = Typeface.BOLD;
+                break;
             case BOLD_ITALIC:
-                return Typeface.BOLD_ITALIC;
+                style = Typeface.BOLD_ITALIC;
+                break;
             case ITALIC:
-                return Typeface.ITALIC;
+                style = Typeface.ITALIC;
+                break;
             case NORMAL:
-                return Typeface.NORMAL;
+            default:
+                style = Typeface.NORMAL;
         }
 
-        throw new IllegalArgumentException("unknown font style: " + fontStyle);
-    }
-
-    private static Typeface getTypeface(org.oscim.backend.canvas.Paint.FontFamily fontFamily) {
         switch (fontFamily) {
             case DEFAULT:
-                return Typeface.DEFAULT;
+                return Typeface.create(Typeface.DEFAULT, style);
             case DEFAULT_BOLD:
-                return Typeface.DEFAULT_BOLD;
+                return Typeface.create(Typeface.DEFAULT_BOLD, style);
             case MONOSPACE:
-                return Typeface.MONOSPACE;
+                return Typeface.create(Typeface.MONOSPACE, style);
             case SANS_SERIF:
-                return Typeface.SANS_SERIF;
+                return Typeface.create(Typeface.SANS_SERIF, style);
             case SERIF:
-                return Typeface.SERIF;
+                return Typeface.create(Typeface.SERIF, style);
+            case MEDIUM:
+                return Typeface.create("sans-serif-medium", style);
+            case LIGHT:
+                return Typeface.create("sans-serif-light", style);
+            case THIN:
+                return Typeface.create("sans-serif-thin", style);
+            case BLACK:
+                return Typeface.create("sans-serif-black", style);
+            case CONDENSED:
+                return Typeface.create("sans-serif-condensed", style);
         }
 
         throw new IllegalArgumentException("unknown font family: " + fontFamily);
@@ -111,8 +124,7 @@ class AndroidPaint implements Paint {
 
     @Override
     public void setTypeface(FontFamily fontFamily, FontStyle fontStyle) {
-        Typeface typeface = Typeface.create(getTypeface(fontFamily),
-                getStyle(fontStyle));
+        Typeface typeface = getTypeface(fontFamily, fontStyle);
         mPaint.setTypeface(typeface);
     }
 

--- a/vtm-desktop/src/org/oscim/awt/AwtPaint.java
+++ b/vtm-desktop/src/org/oscim/awt/AwtPaint.java
@@ -50,7 +50,7 @@ public class AwtPaint implements Paint {
     }
 
     private static Font getFont(FontFamily fontFamily, FontStyle fontStyle, int textSize) {
-        Map<Attribute, Object> attributes = null;
+        Map<Attribute, Object> attributes;
         String name = null;
 
         switch (fontFamily) {
@@ -66,26 +66,18 @@ public class AwtPaint implements Paint {
                 attributes = TEXT_ATTRIBUTES;
                 name = Font.SERIF;
                 break;
-            case THIN:
-                attributes = new HashMap<>(TEXT_ATTRIBUTES);
-                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_EXTRA_LIGHT);
-                break;
-            case LIGHT:
-                attributes = new HashMap<>(TEXT_ATTRIBUTES);
-                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_LIGHT);
-                break;
-            case MEDIUM:
-                attributes = new HashMap<>(TEXT_ATTRIBUTES);
-                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_MEDIUM);
-                break;
+            case MEDIUM: // Java deriveFont does not differ this weight
             case BLACK:
                 attributes = new HashMap<>(TEXT_ATTRIBUTES);
-                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_HEAVY);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD);
                 break;
             case CONDENSED:
                 attributes = new HashMap<>(TEXT_ATTRIBUTES);
-                attributes.put(TextAttribute.WEIGHT, TextAttribute.WIDTH_CONDENSED);
+                attributes.put(TextAttribute.WIDTH, TextAttribute.WIDTH_CONDENSED);
                 break;
+            default:
+                // THIN and LIGHT aren't differed from DEFAULT in Java deriveFont
+                attributes = TEXT_ATTRIBUTES;
         }
 
         return new Font(name, getFontStyle(fontStyle), textSize).deriveFont(attributes);

--- a/vtm-desktop/src/org/oscim/awt/AwtPaint.java
+++ b/vtm-desktop/src/org/oscim/awt/AwtPaint.java
@@ -30,6 +30,7 @@ import java.awt.Stroke;
 import java.awt.font.TextAttribute;
 import java.awt.image.BufferedImage;
 import java.text.AttributedCharacterIterator.Attribute;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,7 +49,7 @@ public class AwtPaint implements Paint {
         throw new IllegalArgumentException("unknown cap: " + cap);
     }
 
-    private static String getFontName(FontFamily fontFamily) {
+    private static String getFontFamily(FontFamily fontFamily, Map<Attribute, Object> optTextAttr) {
         switch (fontFamily) {
             case MONOSPACE:
                 return Font.MONOSPACED;
@@ -59,6 +60,21 @@ public class AwtPaint implements Paint {
                 return Font.SANS_SERIF;
             case SERIF:
                 return Font.SERIF;
+            case THIN:
+                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_EXTRA_LIGHT);
+                return null;
+            case LIGHT:
+                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_LIGHT);
+                return null;
+            case MEDIUM:
+                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_MEDIUM);
+                return null;
+            case BLACK:
+                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_HEAVY);
+                return null;
+            case CONDENSED:
+                optTextAttr.put(TextAttribute.WIDTH, TextAttribute.WIDTH_CONDENSED);
+                return null;
         }
 
         throw new IllegalArgumentException("unknown fontFamily: " + fontFamily);
@@ -169,9 +185,10 @@ public class AwtPaint implements Paint {
 
     @Override
     public void setTypeface(FontFamily fontFamily, FontStyle fontStyle) {
-        this.fontName = getFontName(fontFamily);
+        Map<Attribute, Object> tmpAttributes = new HashMap<>(this.TEXT_ATTRIBUTES);
+        this.fontName = getFontFamily(fontFamily, tmpAttributes);
         this.fontStyle = getFontStyle(fontStyle);
-        this.font = new Font(this.fontName, this.fontStyle, (int) this.textSize).deriveFont(this.TEXT_ATTRIBUTES);
+        this.font = new Font(this.fontName, this.fontStyle, (int) this.textSize).deriveFont(tmpAttributes);
     }
 
     @Override

--- a/vtm-desktop/src/org/oscim/awt/AwtPaint.java
+++ b/vtm-desktop/src/org/oscim/awt/AwtPaint.java
@@ -49,35 +49,46 @@ public class AwtPaint implements Paint {
         throw new IllegalArgumentException("unknown cap: " + cap);
     }
 
-    private static String getFontFamily(FontFamily fontFamily, Map<Attribute, Object> optTextAttr) {
+    private static Font getFont(FontFamily fontFamily, FontStyle fontStyle, int textSize) {
+        Map<Attribute, Object> attributes = null;
+        String name = null;
+
         switch (fontFamily) {
             case MONOSPACE:
-                return Font.MONOSPACED;
-            case DEFAULT:
-            case DEFAULT_BOLD:
-                return null;
+                attributes = TEXT_ATTRIBUTES;
+                name = Font.MONOSPACED;
+                break;
             case SANS_SERIF:
-                return Font.SANS_SERIF;
+                attributes = TEXT_ATTRIBUTES;
+                name = Font.SANS_SERIF;
+                break;
             case SERIF:
-                return Font.SERIF;
+                attributes = TEXT_ATTRIBUTES;
+                name = Font.SERIF;
+                break;
             case THIN:
-                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_EXTRA_LIGHT);
-                return null;
+                attributes = new HashMap<>(TEXT_ATTRIBUTES);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_EXTRA_LIGHT);
+                break;
             case LIGHT:
-                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_LIGHT);
-                return null;
+                attributes = new HashMap<>(TEXT_ATTRIBUTES);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_LIGHT);
+                break;
             case MEDIUM:
-                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_MEDIUM);
-                return null;
+                attributes = new HashMap<>(TEXT_ATTRIBUTES);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_MEDIUM);
+                break;
             case BLACK:
-                optTextAttr.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_HEAVY);
-                return null;
+                attributes = new HashMap<>(TEXT_ATTRIBUTES);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WEIGHT_HEAVY);
+                break;
             case CONDENSED:
-                optTextAttr.put(TextAttribute.WIDTH, TextAttribute.WIDTH_CONDENSED);
-                return null;
+                attributes = new HashMap<>(TEXT_ATTRIBUTES);
+                attributes.put(TextAttribute.WEIGHT, TextAttribute.WIDTH_CONDENSED);
+                break;
         }
 
-        throw new IllegalArgumentException("unknown fontFamily: " + fontFamily);
+        return new Font(name, getFontStyle(fontStyle), textSize).deriveFont(attributes);
     }
 
     private static int getFontStyle(FontStyle fontStyle) {
@@ -124,8 +135,6 @@ public class AwtPaint implements Paint {
     Stroke stroke;
     Style style = Style.FILL;
     private int cap = getCap(Cap.BUTT);
-    private String fontName = DEFAULT_FONT.getFontName();
-    private int fontStyle = DEFAULT_FONT.getStyle();
     private int join = getJoin(Join.MITER);
     private float strokeWidth;
     private float textSize = DEFAULT_FONT.getSize();
@@ -185,10 +194,7 @@ public class AwtPaint implements Paint {
 
     @Override
     public void setTypeface(FontFamily fontFamily, FontStyle fontStyle) {
-        Map<Attribute, Object> tmpAttributes = new HashMap<>(this.TEXT_ATTRIBUTES);
-        this.fontName = getFontFamily(fontFamily, tmpAttributes);
-        this.fontStyle = getFontStyle(fontStyle);
-        this.font = new Font(this.fontName, this.fontStyle, (int) this.textSize).deriveFont(tmpAttributes);
+        this.font = getFont(fontFamily, fontStyle, (int) this.textSize);
     }
 
     @Override

--- a/vtm-extras/src/org/oscim/tiling/source/mapnik/carto.xml
+++ b/vtm-extras/src/org/oscim/tiling/source/mapnik/carto.xml
@@ -296,7 +296,7 @@
                 -->
             </m>
             <m zoom-min="17">
-                <caption fill="#4040ff" font-size="10" font-style="bold" k="name" stroke="#ffffff"
+                <caption fill="#2d51bc" font-size="10" font-style="bold" k="name" stroke="#ffffff"
                     stroke-width="2.0" />
                 <caption fill="#606060" font-size="10" font-style="bold" k="addr:housenumber"
                     stroke="#ffffff" stroke-width="2.0" />
@@ -629,9 +629,9 @@
         -->
         <!-- historic -->
         <!--
-          <m k="historic"> <circle r="3" fill="#4040ff" stroke="#606060"
+          <m k="historic"> <circle r="3" fill="#2d51bc" stroke="#606060"
           width="1.5" /> <m zoom-min="17"> <caption
-          k="name" dy="10" font-style="bold" font-size="10" fill="#4040ff" stroke="#ffffff"
+          k="name" dy="10" font-style="bold" font-size="10" fill="#2d51bc" stroke="#ffffff"
           width="2.0" /> </m> </m>
         -->
         <!-- house numbers -->
@@ -672,16 +672,16 @@
         <!-- railway -->
         <m k="railway">
             <m v="station" zoom-min="14">
-                <circle fill="#ec2d2d" r="6" stroke="#606060" stroke-width="1.5" />
+                <circle fill="#af3a3a" r="6" stroke="#606060" stroke-width="1.5" />
                 <!--
-                  <caption k="name" dy="15" font-style="bold" font-size="13" fill="#ec2d2d"
+                  <caption k="name" dy="15" font-style="bold" font-size="13" fill="#af3a3a"
                   stroke="#ffffff" stroke-width="2.0" />
                 -->
             </m>
             <m v="halt|tram_stop" zoom-min="17">
-                <circle fill="#ec2d2d" r="4" stroke="#606060" stroke-width="1.5" />
+                <circle fill="#af3a3a" r="4" stroke="#606060" stroke-width="1.5" />
                 <!--
-                  <caption k="name" dy="10" font-style="bold" font-size="11" fill="#ec2d2d"
+                  <caption k="name" dy="10" font-style="bold" font-size="11" fill="#af3a3a"
                   stroke="#ffffff" stroke-width="2.0" />
                 -->
             </m>

--- a/vtm-ios/src/org/oscim/ios/backend/IosPaint.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosPaint.java
@@ -28,6 +28,7 @@ import org.robovm.apple.foundation.NSAttributedString;
 import org.robovm.apple.uikit.NSAttributedStringAttributes;
 import org.robovm.apple.uikit.UIColor;
 import org.robovm.apple.uikit.UIFont;
+import org.robovm.apple.uikit.UIFontDescriptor;
 import org.robovm.apple.uikit.UIFontWeight;
 
 import java.util.HashMap;
@@ -60,10 +61,6 @@ public class IosPaint implements Paint {
         }
         return CGLineJoin.Miter;
     }
-
-    private static final String DEFAULT_FONT_NAME = UIFont.getSystemFont(1, UIFontWeight.Semibold).getFontDescriptor().getPostscriptName();
-    private static final String DEFAULT_FONT_NAME_BOLD = UIFont.getSystemFont(1, UIFontWeight.Bold).getFontDescriptor().getPostscriptName();
-    private static final String DEFAULT_FONT_NAME_ITALIC = UIFont.getItalicSystemFont(1).getFontDescriptor().getPostscriptName();
 
     private Align align;
     private final NSAttributedStringAttributes attribs = new NSAttributedStringAttributes();
@@ -210,100 +207,126 @@ public class IosPaint implements Paint {
         /*
           DEVICE_DEFAULT = [iOS == getDeviceDefault()], [Android == 'Roboto']
           MONOSPACE      = [iOS == 'Courier'], [Android == 'Droid Sans Mono']
-          SANS_SERIF     = [iOS == 'Verdena'], [Android == 'Droid Sans']
+          SANS_SERIF     = [iOS == 'HelveticaNeue'], [Android == 'Droid Sans']
           SERIF          = [iOS == 'Georgia'], [Android == 'Droid Serif']
          */
 
-        String fontname = DEFAULT_FONT_NAME;
+        // Better approach: use font descriptor
+        // UIFontDescriptor fontD = font.getFontDescriptor();
+
+        UIFontWeight weight = UIFontWeight.Regular;
         switch (this.fontFamily) {
-            case DEFAULT:
-                // set Style
-                switch (this.fontStyle) {
-                    case NORMAL:
-                        fontname = DEFAULT_FONT_NAME;
-                        break;
-                    case BOLD:
-                        fontname = DEFAULT_FONT_NAME_BOLD;
-                        break;
-                    case BOLD_ITALIC:
-                        fontname = DEFAULT_FONT_NAME_BOLD;
-                        break;
-                    case ITALIC:
-                        fontname = DEFAULT_FONT_NAME_ITALIC;
-                        break;
-                }
-                break;
             case DEFAULT_BOLD:
-                // ignore style
-                fontname = DEFAULT_FONT_NAME_BOLD;
+                weight = UIFontWeight.Bold;
                 break;
-            case MONOSPACE:
-                // set Style
-                switch (this.fontStyle) {
-                    case NORMAL:
-                        fontname = "CourierNewPS-BoldMT";
-                        break;
-                    case BOLD:
-                        fontname = "CourierNewPS-BoldMT";
-                        break;
-                    case BOLD_ITALIC:
-                        fontname = "CourierNewPS-BoldMT";
-                        break;
-                    case ITALIC:
-                        fontname = "CourierNewPS-BoldMT";
-                        break;
-                }
+            case MEDIUM:
+                weight = UIFontWeight.Medium;
                 break;
-            case SANS_SERIF:
-                // set Style
-                switch (this.fontStyle) {
-                    case NORMAL:
-                        fontname = "Verdana";
-                        break;
-                    case BOLD:
-                        fontname = "Verdana-Bold";
-                        break;
-                    case BOLD_ITALIC:
-                        fontname = "Verdana-BoldItalic";
-                        break;
-                    case ITALIC:
-                        fontname = "Verdana-Italic";
-                        break;
-                }
+            case THIN:
+                weight = UIFontWeight.Thin;
                 break;
-            case SERIF:
-                // set Style
-                switch (this.fontStyle) {
-                    case NORMAL:
-                        fontname = "Georgia";
-                        break;
-                    case BOLD:
-                        fontname = "Georgia-Bold";
-                        break;
-                    case BOLD_ITALIC:
-                        fontname = "Georgia-BoldItalic";
-                        break;
-                    case ITALIC:
-                        fontname = "Georgia-Italic";
-                        break;
-                }
+            case LIGHT:
+                weight = UIFontWeight.Light;
                 break;
+            case BLACK:
+                weight = UIFontWeight.Black;
+                break;
+//            case SANS_SERIF:
+//                break;
+//            case CONDENSED:
+//                break;
+//            case SERIF:
+//                break;
+//            case MONOSPACE:
+//                break;
         }
 
         synchronized (attribs) {
-            String key = fontname + this.textSize;
+            UIFont font = null;
+            String fontname = null;
 
-            //try to get buffered font
-            UIFont font = fontHashMap.get(key);
+            switch (this.fontStyle) {
+                case BOLD:
+                    switch (this.fontFamily) {
+                        case CONDENSED:
+                            fontname = "HelveticaNeue-CondensedBold";
+                            break;
+                        case SERIF:
+                            fontname = "Georgia-Bold";
+                            break;
+                        case MONOSPACE:
+                            fontname = "CourierNewPS-BoldMT";
+                            break;
+                        default:
+                            // Always bold
+                            font = UIFont.getSystemFont(textSize, UIFontWeight.Bold);
+                    }
+                    break;
+                case ITALIC:
+                    switch (this.fontFamily) {
+                        case CONDENSED:
+                            fontname = "HelveticaNeue-Italic";
+                            break;
+                        case SERIF:
+                            fontname = "Georgia-Italic";
+                            break;
+                        case MONOSPACE:
+                            fontname = "CourierNewPS-ItalicMT";
+                            break;
+                        default:
+                            // Add differences in italic weight
+                            font = UIFont.getItalicSystemFont(textSize);
+                    }
+                    break;
+                case BOLD_ITALIC:
+                    switch (this.fontFamily) {
+                        case CONDENSED:
+                            fontname = "HelveticaNeue-BoldItalic";
+                            break;
+                        case SERIF:
+                            fontname = "Georgia-BoldItalic";
+                            break;
+                        case MONOSPACE:
+                            fontname = "CourierNewPS-BoldItalicMT";
+                            break;
+                        default:
+                            // Always bold and italic
+                            fontname = "HelveticaNeue-BoldItalic";
+                    }
+                    break;
+                default:
+                    switch (this.fontFamily) {
+                        case CONDENSED:
+                            fontname = "HelveticaNeue";
+                            // or if better "HelveticaNeue-CondensedBold", cond. regular not available
+                            break;
+                        case SERIF:
+                            fontname = "Georgia";
+                            break;
+                        case MONOSPACE:
+                            fontname = "CourierNewPSMT";
+                            break;
+                        default:
+                            font = UIFont.getSystemFont(textSize, weight);
+                    }
+                    break;
+            }
 
             if (font == null) {
-                CTFont ctFont = CTFont.create(fontname, this.textSize, CGAffineTransform.Identity());
+                String key = fontname + this.textSize;
 
-                descent = (float) ctFont.getDescent();
-                fontHeight = (float) ctFont.getBoundingBox().getHeight();
+                //try to get buffered font
+                font = fontHashMap.get(key);
 
-                font = ctFont.as(UIFont.class);
-                fontHashMap.put(key, font);
+                if (font == null) {
+                    CTFont ctFont = CTFont.create(fontname, this.textSize, CGAffineTransform.Identity());
+
+                    descent = (float) ctFont.getDescent();
+                    fontHeight = (float) ctFont.getBoundingBox().getHeight();
+
+                    font = ctFont.as(UIFont.class);
+                    fontHashMap.put(key, font);
+                }
             }
 
             CTFont ctFont = font.as(CTFont.class);

--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -12,6 +12,9 @@
     <style-text style="bold" fill="#101010" id="major-road" k="name" priority="1" size="16"
         stroke="#eeeeee" stroke-width="2.0" />
 
+    <style-text font-family="medium" caption="true" dy="20" fill="#2d51bc" id="caption-small-blue"
+        k="name" size="14" stroke="#ffffff" stroke-width="2.0" />
+
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
     <style-text caption="true" id="ref-caption" use="ref" />
@@ -605,9 +608,9 @@
                 <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#4040ff" k="name" priority="9" size="14"
-                    stroke="#ffffff" stroke-width="2.0" />
-                <caption style="bold" fill="#606060" k="addr:housenumber" priority="10" size="12"
+                <text priority="9" use="caption-small-blue" />
+                <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                    priority="10" size="12"
                     stroke="#ffffff" stroke-width="2.0" />
             </m>
         </m>
@@ -1007,7 +1010,7 @@
 
         <!-- historic -->
         <!-- <m k="historic" v="ruins" zoom-min="17">
-          <caption k="name" style="bold" size="10" fill="#4040ff" stroke="#ffffff" stroke-width="2.0"
+          <caption k="name" style="bold" size="10" fill="#2d51bc" stroke="#ffffff" stroke-width="2.0"
           />
           </m> -->
 
@@ -1126,13 +1129,13 @@
         <m k="railway">
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
 
             <m v="halt|tram_stop">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">
@@ -1283,10 +1286,14 @@
                     <symbol src="assets:symbols/amenity/toilets.svg" />
                 </m>
             </m>
+
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
+            </m>
         </m>
 
         <m k="shop">
-            <m select="first" zoom-min="15">
+            <m select="first" zoom-min="16">
                 <m v="bakery">
                     <symbol src="assets:symbols/shopping/bakery.svg" />
                 </m>
@@ -1307,6 +1314,10 @@
                 <m select="when-matched" zoom-min="17">
                     <text use="poi" />
                 </m>
+            </m>
+
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
             </m>
         </m>
 
@@ -1349,6 +1360,9 @@
                 <symbol src="assets:symbols/tourist/museum.svg" />
             </m>
 
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
+            </m>
         </m>
 
         <m k="natural" v="peak" zoom-min="12">
@@ -1361,7 +1375,8 @@
 
         <!-- house numbers -->
         <m k="addr:housenumber" zoom-min="17">
-            <caption style="bold" fill="#606060" k="addr:housenumber" size="12" stroke="#ffffff"
+            <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                size="12" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -1135,7 +1135,7 @@
 
             <m v="halt|tram_stop">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -1155,7 +1155,7 @@
 
             <m v="halt|tram_stop">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -602,9 +602,10 @@
                 <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#4040ff" k="name" priority="9" size="14"
+                <caption style="bold" fill="#2d51bc" k="name" priority="9" size="14"
                     stroke="#ffffff" stroke-width="2.0" />
-                <caption style="bold" fill="#606060" k="addr_housenumber" priority="10" size="12"
+                <caption font-family="condensed" style="bold" fill="#606060" k="addr_housenumber"
+                    priority="10" size="12"
                     stroke="#ffffff" stroke-width="2.0" />
             </m>
         </m>
@@ -1004,7 +1005,7 @@
 
         <!-- historic -->
         <!-- <m k="historic" v="ruins" zoom-min="17">
-          <caption k="name" style="bold" size="10" fill="#4040ff" stroke="#ffffff" stroke-width="2.0"
+          <caption k="name" style="bold" size="10" fill="#2d51bc" stroke="#ffffff" stroke-width="2.0"
           />
           </m> -->
 
@@ -1148,13 +1149,13 @@
         <m k="kind">
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
 
             <m v="halt|tram_stop">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">
@@ -1384,7 +1385,8 @@
 
         <!-- house numbers -->
         <m k="addr_housenumber" zoom-min="17">
-            <caption style="bold" fill="#606060" k="addr:housenumber" size="12" stroke="#ffffff"
+            <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                size="12" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/newtron.xml
+++ b/vtm-themes/resources/assets/vtm/newtron.xml
@@ -1288,7 +1288,7 @@
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>

--- a/vtm-themes/resources/assets/vtm/newtron.xml
+++ b/vtm-themes/resources/assets/vtm/newtron.xml
@@ -540,9 +540,11 @@
                 <extrusion line-color="#10ffffff" side-color="#cc202020" top-color="#cc404040" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#4040ff" k="name" priority="9" size="14"
-                    stroke="#ffffff" stroke-width="2.0" />
-                <caption style="bold" fill="#ffffff" k="addr:housenumber" priority="10" size="12"
+                <m zoom-min="17">
+                    <text use="caption-small-blue" />
+                </m>
+                <caption font-family="condensed" style="bold" fill="#ffffff" k="addr:housenumber"
+                    priority="10" size="12"
                     stroke="#606060" stroke-width="2.0" />
             </m>
         </m>
@@ -1016,7 +1018,7 @@
 
         <!-- historic -->
         <!-- <m k="historic" v="ruins" zoom-min="17">
-          <caption k="name" style="bold" size="10" fill="#4040ff" stroke="#ffffff" stroke-width="2.0"
+          <caption k="name" style="bold" size="10" fill="#2d51bc" stroke="#ffffff" stroke-width="2.0"
           />
           </m> -->
 
@@ -1281,12 +1283,12 @@
             </m>
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>
@@ -1339,7 +1341,8 @@
 
         <!-- house numbers -->
         <m k="addr:housenumber" zoom-min="17">
-            <caption style="bold" fill="#ffffff" k="addr:housenumber" size="12" stroke="#606060"
+            <caption font-family="condensed" style="bold" fill="#ffffff" k="addr:housenumber"
+                size="12" stroke="#606060"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/openmaptiles.xml
+++ b/vtm-themes/resources/assets/vtm/openmaptiles.xml
@@ -12,6 +12,9 @@
     <style-text style="bold" fill="#101010" id="major-road" k="name" priority="1" size="16"
         stroke="#eeeeee" stroke-width="2.0" />
 
+    <style-text font-family="medium" caption="true" dy="20" fill="#2d51bc" id="caption-small-blue"
+        k="name" size="14" stroke="#ffffff" stroke-width="2.0" />
+
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
     <style-text caption="true" id="ref-caption" use="ref" />
@@ -403,6 +406,9 @@
                 <symbol src="assets:symbols/tourist/museum.svg" />
             </m>
 
+            <m zoom-min="14">
+                <text use="caption-small-blue" />
+            </m>
         </m>
     </m>
 </rendertheme>

--- a/vtm-themes/resources/assets/vtm/osmagray.xml
+++ b/vtm-themes/resources/assets/vtm/osmagray.xml
@@ -9,7 +9,8 @@
     <style-line id="secondary" stroke="#c6c6c6" width="1.4" />
     <style-line id="tertiary" stroke="#f7f7f7" width="1.15" />
 
-    <style-text style="bold" caption="true" dy="20" fill="#4d4d4d" id="caption-small-blue" k="name"
+    <style-text font-family="medium" caption="true" dy="20" fill="#4d4d4d" id="caption-small-blue"
+        k="name"
         size="14" stroke="#ffffff" stroke-width="2.0" />
 
     <style-text style="bold" id="highway-road" k="name" size="16" stroke="#d0d0d0"
@@ -559,7 +560,8 @@
 
             <m zoom-min="17">
                 <text priority="9" use="caption-small-blue" />
-                <caption style="bold" fill="#606060" k="addr:housenumber" priority="10" size="12"
+                <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                    priority="10" size="12"
                     stroke="#ffffff" stroke-width="2.0" />
             </m>
         </m>
@@ -1095,7 +1097,7 @@
         </m>
 
         <!--<m k="historic" v="ruins" zoom-min="17">
-            <caption style="bold" fill="#4040ff" k="name" size="16" stroke="#ffffff"
+            <caption style="bold" fill="#2d51bc" k="name" size="16" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>-->
 
@@ -1336,12 +1338,12 @@
             </m>
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>
@@ -1392,7 +1394,8 @@
 
         <!-- house numbers -->
         <m k="addr:housenumber" zoom-min="17">
-            <caption style="bold" fill="#606060" k="addr:housenumber" size="12" stroke="#ffffff"
+            <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                size="12" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/osmagray.xml
+++ b/vtm-themes/resources/assets/vtm/osmagray.xml
@@ -1343,7 +1343,7 @@
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>

--- a/vtm-themes/resources/assets/vtm/osmarender.xml
+++ b/vtm-themes/resources/assets/vtm/osmarender.xml
@@ -9,7 +9,8 @@
     <style-line id="secondary" stroke="#fdbf6f" width="1.4" />
     <style-line id="tertiary" stroke="#ffff90" width="1.15" />
 
-    <style-text style="bold" caption="true" dy="20" fill="#4040ff" id="caption-small-blue" k="name"
+    <style-text font-family="medium" caption="true" dy="20" fill="#2d51bc" id="caption-small-blue"
+        k="name"
         size="14" stroke="#ffffff" stroke-width="2.0" />
 
     <style-text style="bold" id="highway-road" k="name" size="16" stroke="#d0d0d0"
@@ -559,7 +560,8 @@
 
             <m zoom-min="17">
                 <text priority="9" use="caption-small-blue" />
-                <caption style="bold" fill="#606060" k="addr:housenumber" priority="10" size="12"
+                <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                    priority="10" size="12"
                     stroke="#ffffff" stroke-width="2.0" />
             </m>
         </m>
@@ -1095,7 +1097,7 @@
         </m>
 
         <!--<m k="historic" v="ruins" zoom-min="17">
-            <caption style="bold" fill="#4040ff" k="name" size="16" stroke="#ffffff"
+            <caption style="bold" fill="#2d51bc" k="name" size="16" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>-->
 
@@ -1336,12 +1338,12 @@
             </m>
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>
@@ -1392,7 +1394,8 @@
 
         <!-- house numbers -->
         <m k="addr:housenumber" zoom-min="17">
-            <caption style="bold" fill="#606060" k="addr:housenumber" size="12" stroke="#ffffff"
+            <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                size="12" stroke="#ffffff"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/osmarender.xml
+++ b/vtm-themes/resources/assets/vtm/osmarender.xml
@@ -1343,7 +1343,7 @@
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>

--- a/vtm-themes/resources/assets/vtm/tronrender.xml
+++ b/vtm-themes/resources/assets/vtm/tronrender.xml
@@ -3,7 +3,8 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <style-text style="bold" caption="true" dy="20" fill="#4040ff" id="caption-small-blue" k="name"
+    <style-text font-family="medium" caption="true" dy="20" fill="#2d51bc" id="caption-small-blue"
+        k="name"
         size="16" stroke="#ffffff" stroke-width="2.0" />
 
     <style-text style="bold" fill="#eeffee" id="road" k="name" priority="2" size="18"
@@ -540,9 +541,10 @@
                 <extrusion line-color="#50ff00ff" side-color="#cc707070" top-color="#cc707070" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#4040ff" k="name" priority="9" size="14"
+                <caption style="bold" fill="#2d51bc" k="name" priority="9" size="14"
                     stroke="#ffffff" stroke-width="2.0" />
-                <caption style="bold" fill="#ffffff" k="addr:housenumber" priority="10" size="12"
+                <caption font-family="condensed" style="bold" fill="#ffffff" k="addr:housenumber"
+                    priority="10" size="12"
                     stroke="#606060" stroke-width="2.0" />
             </m>
         </m>
@@ -1009,7 +1011,7 @@
 
         <!-- historic -->
         <!-- <m k="historic" v="ruins" zoom-min="17">
-          <caption k="name" style="bold" size="10" fill="#4040ff" stroke="#ffffff" stroke-width="2.0"
+          <caption k="name" style="bold" size="10" fill="#2d51bc" stroke="#ffffff" stroke-width="2.0"
           />
           </m> -->
 
@@ -1274,12 +1276,12 @@
             </m>
             <m v="station" zoom-min="14">
                 <symbol src="assets:symbols/transport/train_station2.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#ec2d2d" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>
@@ -1330,7 +1332,8 @@
 
         <!-- house numbers -->
         <m k="addr:housenumber" zoom-min="17">
-            <caption style="bold" fill="#ffffff" k="addr:housenumber" size="12" stroke="#606060"
+            <caption font-family="condensed" style="bold" fill="#ffffff" k="addr:housenumber"
+                size="12" stroke="#606060"
                 stroke-width="2.0" />
         </m>
     </m>

--- a/vtm-themes/resources/assets/vtm/tronrender.xml
+++ b/vtm-themes/resources/assets/vtm/tronrender.xml
@@ -1281,7 +1281,7 @@
             </m>
             <m v="halt|tram_stop" zoom-min="15">
                 <symbol src="assets:symbols/transport/tram_stop.svg" />
-                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
+                <caption style="bold" dy="20" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>

--- a/vtm-web-app/resources/assets/vtm/default_atlas.xml
+++ b/vtm-web-app/resources/assets/vtm/default_atlas.xml
@@ -12,6 +12,9 @@
     <style-text style="bold" fill="#101010" id="major-road" k="name" priority="1" size="16"
         stroke="#eeeeee" stroke-width="2.0" />
 
+    <style-text font-family="medium" caption="true" dy="20" fill="#2d51bc" id="caption-small-blue"
+        k="name" size="14" stroke="#ffffff" stroke-width="2.0" />
+
     <style-text caption="true" dy="16" fill="#777744" id="poi" k="name" size="16" stroke="#aaffffff"
         stroke-width="2.0" />
 
@@ -590,8 +593,7 @@
                 <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#2d51bc" k="name" size="10" stroke="#ffffff"
-                    stroke-width="2.0" />
+                <text priority="9" use="caption-small-blue" />
                 <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
                     size="10" stroke="#ffffff"
                     stroke-width="2.0" />
@@ -1055,13 +1057,13 @@
         <m k="railway">
             <m v="station" zoom-min="14">
                 <circle fill="#af3a3a" radius="6" stroke="#606060" stroke-width="1.5" />
-                <caption style="bold" dy="15" fill="#af3a3a" k="name" size="13" stroke="#ffffff"
+                <caption style="bold" dy="15" fill="#af3a3a" k="name" size="14" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
 
             <m v="halt|tram_stop">
                 <circle fill="#af3a3a" radius="4" stroke="#606060" stroke-width="1.5" />
-                <caption style="bold" dy="10" fill="#af3a3a" k="name" size="11" stroke="#ffffff"
+                <caption style="bold" dy="10" fill="#af3a3a" k="name" size="12" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">
@@ -1200,6 +1202,10 @@
                     <symbol src="toilets" />
                 </m>
             </m>
+
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
+            </m>
         </m>
 
         <m k="shop">
@@ -1224,6 +1230,9 @@
                 <m select="when-matched" zoom-min="17">
                     <text use="poi" />
                 </m>
+            </m>
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
             </m>
         </m>
 
@@ -1266,6 +1275,9 @@
                 <symbol src="museum" />
             </m>
 
+            <m zoom-min="15">
+                <text use="caption-small-blue" />
+            </m>
         </m>
 
         <m k="natural" v="tree" zoom-min="15">

--- a/vtm-web-app/resources/assets/vtm/default_atlas.xml
+++ b/vtm-web-app/resources/assets/vtm/default_atlas.xml
@@ -590,9 +590,10 @@
                 <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6" />
             </m>
             <m zoom-min="17">
-                <caption style="bold" fill="#4040ff" k="name" size="10" stroke="#ffffff"
+                <caption style="bold" fill="#2d51bc" k="name" size="10" stroke="#ffffff"
                     stroke-width="2.0" />
-                <caption style="bold" fill="#606060" k="addr:housenumber" size="10" stroke="#ffffff"
+                <caption font-family="condensed" style="bold" fill="#606060" k="addr:housenumber"
+                    size="10" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
         </m>
@@ -956,7 +957,7 @@
 
         <!-- historic -->
         <!-- <m k="historic" v="ruins" zoom-min="17">
-          <caption k="name" style="bold" size="10" fill="#4040ff" stroke="#ffffff" stroke-width="2.0"
+          <caption k="name" style="bold" size="10" fill="#2d51bc" stroke="#ffffff" stroke-width="2.0"
           />
           </m> -->
 
@@ -1006,14 +1007,14 @@
         </m>
 
         <!-- historic -->
-        <!-- <m k="historic"> <circle r="3" fill="#4040ff" stroke="#606060"
+        <!-- <m k="historic"> <circle r="3" fill="#2d51bc" stroke="#606060"
           width="1.5" /> <m zoom-min="17"> <caption
-          k="name" dy="10" style="bold" size="10" fill="#4040ff" stroke="#ffffff"
+          k="name" dy="10" style="bold" size="10" fill="#2d51bc" stroke="#ffffff"
           width="2.0" /> </m> </m> -->
 
         <!-- house numbers -->
         <!-- <m k="addr:housenumber" zoom-min="18"> <caption
-          k="addr:housenumber" style="bold" size="10" fill="#606060" stroke="#ffffff"
+          k="addr:housenumber" font-family="condensed" style="bold" size="10" fill="#606060" stroke="#ffffff"
           width="2.0" /> </m> -->
 
         <!-- place -->
@@ -1053,14 +1054,14 @@
         <!-- railway -->
         <m k="railway">
             <m v="station" zoom-min="14">
-                <circle fill="#ec2d2d" radius="6" stroke="#606060" stroke-width="1.5" />
-                <caption style="bold" dy="15" fill="#ec2d2d" k="name" size="13" stroke="#ffffff"
+                <circle fill="#af3a3a" radius="6" stroke="#606060" stroke-width="1.5" />
+                <caption style="bold" dy="15" fill="#af3a3a" k="name" size="13" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
 
             <m v="halt|tram_stop">
-                <circle fill="#ec2d2d" radius="4" stroke="#606060" stroke-width="1.5" />
-                <caption style="bold" dy="10" fill="#ec2d2d" k="name" size="11" stroke="#ffffff"
+                <circle fill="#af3a3a" radius="4" stroke="#606060" stroke-width="1.5" />
+                <caption style="bold" dy="10" fill="#af3a3a" k="name" size="11" stroke="#ffffff"
                     stroke-width="2.0" />
             </m>
             <m v="level_crossing">

--- a/vtm-web/src/org/oscim/gdx/client/GwtPaint.java
+++ b/vtm-web/src/org/oscim/gdx/client/GwtPaint.java
@@ -33,7 +33,7 @@ public class GwtPaint implements Paint {
     float fontSize = 12;
 
     private FontStyle fontStyle = FontStyle.NORMAL;
-    //private FontFamily fontFamily = FontFamily.DEFAULT;
+    private FontFamily fontFamily = FontFamily.DEFAULT;
 
     //String font = "12px sans-serif";
     String font = "13px Helvetica";
@@ -91,7 +91,7 @@ public class GwtPaint implements Paint {
     @Override
     public void setTypeface(FontFamily fontFamily, FontStyle fontStyle) {
         this.fontStyle = fontStyle;
-        //this.fontFamily = fontFamily;
+        this.fontFamily = fontFamily;
         buildFont();
     }
 
@@ -111,21 +111,53 @@ public class GwtPaint implements Paint {
         return 4 + strokeWidth;
     }
 
-    void buildFont() {
+    private void buildFont() {
         StringBuilder sb = new StringBuilder();
+        String weight = null; // Default 400 -> normal
+        String name = "Helvetica";
 
-        if (this.fontStyle == FontStyle.BOLD)
-            sb.append("bold ");
-        else if (this.fontStyle == FontStyle.ITALIC)
-            sb.append("italic ");
+        switch (this.fontFamily) {
+            case MEDIUM:
+                weight = "500";
+                break;
+            case BLACK:
+                weight = "900";
+                break;
+            case DEFAULT_BOLD:
+                weight = "bold"; // 700
+                break;
+            case LIGHT:
+                weight = "300";
+                break;
+            case THIN:
+                weight = "200"; //lighter
+                break;
+            case SERIF:
+                name = "Georgia";
+                break;
+            case MONOSPACE:
+                name = "'Courier New'";
+            case CONDENSED:
+                sb.append("condensed ");
+        }
 
+        switch (this.fontStyle) {
+            case BOLD:
+                weight = "bold";
+                break;
+            case ITALIC:
+                sb.append("italic");
+                break;
+            case BOLD_ITALIC:
+                weight = "bold";
+                sb.append("italic");
+        }
+        if (weight != null)
+            sb.append(weight).append(" ");
         sb.append(Math.round(this.fontSize));
-        sb.append("px ");
-
-        sb.append("Helvetica");
+        sb.append("px ").append(name);
 
         this.font = sb.toString();
-
     }
 
     @Override

--- a/vtm-web/src/org/oscim/gdx/client/GwtPaint.java
+++ b/vtm-web/src/org/oscim/gdx/client/GwtPaint.java
@@ -137,6 +137,7 @@ public class GwtPaint implements Paint {
                 break;
             case MONOSPACE:
                 name = "'Courier New'";
+                break;
             case CONDENSED:
                 sb.append("condensed ");
         }
@@ -146,11 +147,11 @@ public class GwtPaint implements Paint {
                 weight = "bold";
                 break;
             case ITALIC:
-                sb.append("italic");
+                sb.append("italic ");
                 break;
             case BOLD_ITALIC:
                 weight = "bold";
-                sb.append("italic");
+                sb.append("italic ");
         }
         if (weight != null)
             sb.append(weight).append(" ");

--- a/vtm/src/org/oscim/backend/canvas/Paint.java
+++ b/vtm/src/org/oscim/backend/canvas/Paint.java
@@ -41,7 +41,7 @@ public interface Paint {
     }
 
     enum FontFamily {
-        DEFAULT, DEFAULT_BOLD, MONOSPACE, SANS_SERIF, SERIF
+        DEFAULT, DEFAULT_BOLD, MONOSPACE, SANS_SERIF, SERIF, THIN, LIGHT, MEDIUM, BLACK, CONDENSED
     }
 
     enum FontStyle {


### PR DESCRIPTION
Font-families added: `thin`, `light`, `medium`, `black`, `condensed`
If lower API do not support these fonts, they're automatically replaced.
Themes:
- use same font for building names and amenities, shops etc. cause building names describe amenities (changed in default and newtron, other were already right); was kind of peculiar that the same name was written in two fonts...font is called `caption-small-blue` in most cases.
- changed railway color to a more unobtrusive color (so it's no more kind of a warning)
- changed amenity color (`caption-small-blue`) to a more unobtrusive color and use `medium` family/style, cause in big cities too much and big labels are displayed, in my opinion.
- changed house-number style/family to `condensed`, so more space is available
  
BTW a short question: Is there zoom-level 18 available for themes?