### PR TITLE
New MvtTileDecoder to allow parsing mvt pbf tiles

### DIFF
--- a/vtm-playground/src/org/oscim/test/OpenMapTilesMvtTest.java
+++ b/vtm-playground/src/org/oscim/test/OpenMapTilesMvtTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 devemux86
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.test;
+
+import org.oscim.gdx.GdxMapApp;
+import org.oscim.layers.tile.buildings.BuildingLayer;
+import org.oscim.layers.tile.vector.VectorTileLayer;
+import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.theme.VtmThemes;
+import org.oscim.tiling.source.OkHttpEngine;
+import org.oscim.tiling.source.UrlTileSource;
+import org.oscim.tiling.source.geojson.OpenMapTilesGeojsonTileSource;
+import org.oscim.tiling.source.mvt.OpenMapTilesMvtTileSource;
+
+import java.io.File;
+import java.util.UUID;
+
+import okhttp3.Cache;
+import okhttp3.OkHttpClient;
+
+public class OpenMapTilesMvtTest extends GdxMapApp {
+
+    private static final boolean USE_CACHE = false;
+
+    @Override
+    public void createLayers() {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+        if (USE_CACHE) {
+            // Cache the tiles into file system
+            File cacheDirectory = new File(System.getProperty("java.io.tmpdir"), UUID.randomUUID().toString());
+            int cacheSize = 10 * 1024 * 1024; // 10 MB
+            Cache cache = new Cache(cacheDirectory, cacheSize);
+            builder.cache(cache);
+        }
+        OkHttpEngine.OkHttpFactory factory = new OkHttpEngine.OkHttpFactory(builder);
+
+        UrlTileSource tileSource = OpenMapTilesMvtTileSource.builder()
+                .apiKey("xxxxxx") // Put a proper API key
+                .httpFactory(factory)
+                .locale("en")
+                .build();
+
+        VectorTileLayer l = mMap.setBaseMap(tileSource);
+        mMap.setTheme(VtmThemes.OPENMAPTILES);
+
+        mMap.layers().add(new BuildingLayer(mMap, l));
+        mMap.layers().add(new LabelLayer(mMap, l));
+    }
+
+    public static void main(String[] args) {
+        GdxMapApp.init();
+        GdxMapApp.run(new OpenMapTilesMvtTest());
+    }
+}

--- a/vtm/build.gradle
+++ b/vtm/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'maven'
 dependencies {
     api "org.slf4j:slf4j-api:$slf4jVersion"
     compileOnly 'com.google.code.findbugs:jsr305:3.0.1'
+    compile 'uk.os.vt:vt-legacy-parser:2.0.7'
 }
 
 sourceSets {

--- a/vtm/src/org/oscim/tiling/source/mvt/MapzenMvtTileSource.java
+++ b/vtm/src/org/oscim/tiling/source/mvt/MapzenMvtTileSource.java
@@ -66,6 +66,6 @@ public class MapzenMvtTileSource extends UrlTileSource {
 
     @Override
     public ITileDataSource getDataSource() {
-        return new UrlTileDataSource(this, new TileDecoder(locale), getHttpEngine());
+        return new UrlTileDataSource(this, new MvtTileDecoder(locale), getHttpEngine());
     }
 }

--- a/vtm/src/org/oscim/tiling/source/mvt/MvtTileDecoder.java
+++ b/vtm/src/org/oscim/tiling/source/mvt/MvtTileDecoder.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2017 devemux86
+ * Copyright 2018 boldtrn
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.tiling.source.mvt;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.LineString;
+import com.vividsolutions.jts.geom.MultiLineString;
+import com.vividsolutions.jts.geom.MultiPoint;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Point;
+import com.vividsolutions.jts.geom.Polygon;
+
+import org.oscim.core.MapElement;
+import org.oscim.core.Tag;
+import org.oscim.core.Tile;
+import org.oscim.tiling.ITileDataSink;
+import org.oscim.tiling.source.ITileDecoder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import uk.os.vt.mvt.adapt.jts.MvtReader;
+import uk.os.vt.mvt.adapt.jts.TagKeyValueMapConverter;
+import uk.os.vt.mvt.adapt.jts.model.JtsLayer;
+import uk.os.vt.mvt.adapt.jts.model.JtsMvt;
+
+public class MvtTileDecoder implements ITileDecoder {
+    private final String mLocale;
+
+    private final static float REF_TILE_SIZE = 4096.0f;
+    private float mScale;
+
+    private final GeometryFactory geomFactory;
+    private ITileDataSink mTileDataSink;
+    private final MapElement mMapElement;
+
+    public MvtTileDecoder() {
+        this("");
+    }
+
+    public MvtTileDecoder(String locale) {
+        mLocale = locale;
+        geomFactory = new GeometryFactory();
+        mMapElement = new MapElement();
+        mMapElement.layer = 5;
+    }
+
+    @Override
+    public boolean decode(Tile tile, ITileDataSink sink, InputStream is)
+            throws IOException {
+
+        mTileDataSink = sink;
+        mScale = REF_TILE_SIZE / Tile.SIZE;
+
+        JtsMvt jtsMvt = MvtReader.loadMvt(
+                is,
+                geomFactory,
+                new TagKeyValueMapConverter());
+
+
+        for (JtsLayer layer : jtsMvt.getLayers()) {
+            for (Geometry geometry : layer.getGeometries()) {
+                try {
+                    parseGeometry(layer, geometry);
+                } catch (Exception e) {
+                    System.out.println("Error Occured");
+                    System.err.println(e.getMessage());
+                    e.printStackTrace();
+                }
+
+            }
+        }
+
+        return true;
+    }
+
+    private void parseGeometry(JtsLayer layer, Geometry geometry) {
+        mMapElement.clear();
+        mMapElement.tags.clear();
+
+        parseTags(layer, geometry);
+        if (mMapElement.tags.size() == 0) {
+            System.out.println("Cannot find anything for geometry " + geometry + " " + geometry.getUserData());
+            return;
+        }
+
+        boolean err = false;
+        if (geometry instanceof Point) {
+            mMapElement.startPoints();
+            processCoordinateArray(geometry.getCoordinates(), false);
+        } else if (geometry instanceof MultiPoint) {
+            MultiPoint multiPoint = (MultiPoint) geometry;
+            for (int i = 0; i < multiPoint.getNumGeometries(); i++) {
+                mMapElement.startPoints();
+                processCoordinateArray(multiPoint.getGeometryN(i).getCoordinates(), false);
+            }
+        } else if (geometry instanceof LineString) {
+            processLineString((LineString) geometry);
+        } else if (geometry instanceof MultiLineString) {
+            MultiLineString multiLineString = (MultiLineString) geometry;
+            for (int i = 0; i < multiLineString.getNumGeometries(); i++) {
+                processLineString((LineString) multiLineString.getGeometryN(i));
+            }
+        } else if (geometry instanceof Polygon) {
+            Polygon polygon = (Polygon) geometry;
+            processPolygon(polygon);
+        } else if (geometry instanceof MultiPolygon) {
+            MultiPolygon multiPolygon = (MultiPolygon) geometry;
+            for (int i = 0; i < multiPolygon.getNumGeometries(); i++) {
+                processPolygon((Polygon) multiPolygon.getGeometryN(i));
+            }
+        }else{
+            err = true;
+        }
+
+        if(!err){
+            mTileDataSink.process(mMapElement);
+        }
+    }
+
+    private void processLineString(LineString lineString) {
+        mMapElement.startLine();
+        processCoordinateArray(lineString.getCoordinates(), false);
+    }
+
+    private void processPolygon(Polygon polygon) {
+        mMapElement.startPolygon();
+        processCoordinateArray(polygon.getExteriorRing().getCoordinates(), true);
+        for (int i = 0; i < polygon.getNumInteriorRing(); i++) {
+            mMapElement.startHole();
+            processCoordinateArray(polygon.getInteriorRingN(i).getCoordinates(), true);
+        }
+    }
+
+    private void processCoordinateArray(Coordinate[] coordinates, boolean removeLast) {
+        int length = removeLast ? coordinates.length - 1 : coordinates.length;
+        for (int i = 0; i < length; i++) {
+            mMapElement.addPoint((float) coordinates[i].x / mScale, (float) coordinates[i].y / mScale);
+        }
+    }
+
+    private void parseTags(JtsLayer layer, Geometry geometry) {
+        mMapElement.tags.add(new Tag("layer", layer.getName()));
+        boolean hasName = false;
+        String fallbackName = null;
+        Map<String, Object> map = (Map<String, Object>) geometry.getUserData();
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            String val = (value instanceof String) ? (String) value : String.valueOf(value);
+
+            if (key.startsWith(Tag.KEY_NAME)) {
+                int len = key.length();
+                if (len == 4) {
+                    fallbackName = val;
+                    continue;
+                }
+                if (len < 7)
+                    continue;
+                if (mLocale.equals(key.substring(5))) {
+                    hasName = true;
+                    mMapElement.tags.add(new Tag(Tag.KEY_NAME, val, false));
+                }
+            } else {
+                mMapElement.tags.add(new Tag(key, val));
+            }
+        }
+        if (!hasName && fallbackName != null)
+            mMapElement.tags.add(new Tag(Tag.KEY_NAME, fallbackName, false));
+    }
+}
+

--- a/vtm/src/org/oscim/tiling/source/mvt/OpenMapTilesMvtTileSource.java
+++ b/vtm/src/org/oscim/tiling/source/mvt/OpenMapTilesMvtTileSource.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2013 Hannes Janetzek
+ * Copyright 2016-2017 devemux86
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.tiling.source.mvt;
+
+import org.oscim.tiling.ITileDataSource;
+import org.oscim.tiling.source.UrlTileDataSource;
+import org.oscim.tiling.source.UrlTileSource;
+
+public class OpenMapTilesMvtTileSource extends UrlTileSource {
+
+    private final static String DEFAULT_URL = "https://free.tilehosting.com/data/v3";
+    private final static String DEFAULT_PATH = "/{Z}/{X}/{Y}.pbf.pict";
+
+    public static class Builder<T extends Builder<T>> extends UrlTileSource.Builder<T> {
+        private String locale = "";
+
+        public Builder() {
+            super(DEFAULT_URL, DEFAULT_PATH, 1, 17);
+            keyName("key");
+        }
+
+        public T locale(String locale) {
+            this.locale = locale;
+            return self();
+        }
+
+        public OpenMapTilesMvtTileSource build() {
+            return new OpenMapTilesMvtTileSource(this);
+        }
+    }
+
+    @SuppressWarnings("rawtypes")
+    public static Builder<?> builder() {
+        return new Builder();
+    }
+
+    private final String locale;
+
+    public OpenMapTilesMvtTileSource(Builder<?> builder) {
+        super(builder);
+        this.locale = builder.locale;
+    }
+
+    public OpenMapTilesMvtTileSource() {
+        this(builder());
+    }
+
+    public OpenMapTilesMvtTileSource(String urlString) {
+        this(builder().url(urlString));
+    }
+
+    @Override
+    public ITileDataSource getDataSource() {
+        return new UrlTileDataSource(this, new MvtTileDecoder(locale), getHttpEngine());
+    }
+}


### PR DESCRIPTION
This PR adds a new MvtTileDecoder, using [this](https://github.com/wdtinc/mapbox-vector-tile-java) nice project. The above mentioned project apparantly does not work with older Android version, that's why I used a fork (which will be hopefully merged soon) that supports older Android versions as well. I tried the new decoder with Mapzen and OMT, both basically work.

There is an issue with decoding Polygons. Probably I made a mistake when creating the new decoder? Maybe someone can have a look? I think there might be something messed up with holes and the outer shell, but I don't know what. 

Screenshots from OMT:
![omt-pbf-munich](https://user-images.githubusercontent.com/1553525/34852023-c7aedcbe-f780-11e7-8ba5-4d5fb4f19361.png)
![omt-pbf-central-europe](https://user-images.githubusercontent.com/1553525/34852024-c7eb0a7c-f780-11e7-87ba-3172e318653c.png)
![omt-pbf-world](https://user-images.githubusercontent.com/1553525/34852025-c827019e-f780-11e7-807d-7b066d44fd30.png)

Screenshots from Mapzen:
![mapzen-pbf-munich](https://user-images.githubusercontent.com/1553525/34852030-cebc2dd6-f780-11e7-952d-7dc85f27e73e.png)
![mapzen-pbf-central-europe](https://user-images.githubusercontent.com/1553525/34852032-d029b846-f780-11e7-8479-ee7f4fd57561.png)
![mapzen-pbf-world](https://user-images.githubusercontent.com/1553525/34852033-d0d3bc74-f780-11e7-8400-4db65b002f6d.png)
