### PR TITLE
Improve fling animation

### DIFF
--- a/vtm/src/org/oscim/layers/MapEventLayer.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer.java
@@ -342,7 +342,7 @@ public class MapEventLayer extends AbstractMapEventLayer implements InputListene
                     mCanTilt = false;
                     mTwoFingersDone = true;
 
-                    mAngle = rad;
+                    mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 } else if (!mDoScale) {
                     /* reduce pinch trigger by the amount of rotation */
                     deltaPinch *= 1 - (r / PINCH_ROTATE_THRESHOLD);
@@ -359,7 +359,7 @@ public class MapEventLayer extends AbstractMapEventLayer implements InputListene
                 /* start rotate again */
                 mDoRotate = true;
                 mCanRotate = true;
-                mAngle = rad;
+                mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 mTwoFingersDone = true;
             }
         }

--- a/vtm/src/org/oscim/layers/MapEventLayer.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer.java
@@ -342,7 +342,8 @@ public class MapEventLayer extends AbstractMapEventLayer implements InputListene
                     mCanTilt = false;
                     mTwoFingersDone = true;
 
-                    mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
+                    /*start from recognized position (smoother rotation)*/
+                    mAngle = rad;
                 } else if (!mDoScale) {
                     /* reduce pinch trigger by the amount of rotation */
                     deltaPinch *= 1 - (r / PINCH_ROTATE_THRESHOLD);
@@ -359,8 +360,10 @@ public class MapEventLayer extends AbstractMapEventLayer implements InputListene
                 /* start rotate again */
                 mDoRotate = true;
                 mCanRotate = true;
-                mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 mTwoFingersDone = true;
+
+                /*start from recognized position (smoother rotation)*/
+                mAngle = rad;
             }
         }
 

--- a/vtm/src/org/oscim/layers/MapEventLayer2.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer2.java
@@ -426,7 +426,7 @@ public class MapEventLayer2 extends AbstractMapEventLayer implements InputListen
                     mCanTilt = false;
                     mTwoFingersDone = true;
 
-                    mAngle = rad;
+                    mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 } else if (!mDoScale) {
                     /* reduce pinch trigger by the amount of rotation */
                     deltaPinch *= 1 - (r / PINCH_ROTATE_THRESHOLD);
@@ -443,7 +443,7 @@ public class MapEventLayer2 extends AbstractMapEventLayer implements InputListen
                 /* start rotate again */
                 mDoRotate = true;
                 mCanRotate = true;
-                mAngle = rad;
+                mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 mTwoFingersDone = true;
             }
         }

--- a/vtm/src/org/oscim/layers/MapEventLayer2.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer2.java
@@ -426,7 +426,8 @@ public class MapEventLayer2 extends AbstractMapEventLayer implements InputListen
                     mCanTilt = false;
                     mTwoFingersDone = true;
 
-                    mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
+                    /*start from recognized position (smoother rotation)*/
+                    mAngle = rad;
                 } else if (!mDoScale) {
                     /* reduce pinch trigger by the amount of rotation */
                     deltaPinch *= 1 - (r / PINCH_ROTATE_THRESHOLD);
@@ -443,8 +444,10 @@ public class MapEventLayer2 extends AbstractMapEventLayer implements InputListen
                 /* start rotate again */
                 mDoRotate = true;
                 mCanRotate = true;
-                mAngle = rad; /* remove to rotate from motion beginning position, not from recognition position */
                 mTwoFingersDone = true;
+
+                /*start from recognized position (smoother rotation)*/
+                mAngle = rad;
             }
         }
 

--- a/vtm/src/org/oscim/map/Animator.java
+++ b/vtm/src/org/oscim/map/Animator.java
@@ -47,7 +47,6 @@ public class Animator {
     public final static int ANIM_ROTATE = 1 << 2;
     public final static int ANIM_TILT = 1 << 3;
     public final static int ANIM_FLING = 1 << 4;
-    public final static float ANIM_DEFAULT_DURATION = 500;
 
     private final Map mMap;
 
@@ -59,7 +58,7 @@ public class Animator {
     private final Point mPivot = new Point();
     private final Point mVelocity = new Point();
 
-    private float mDuration = ANIM_DEFAULT_DURATION;
+    private float mDuration = 500;
     private long mAnimEnd = -1;
     private Easing.Type mEasingType = Easing.Type.LINEAR;
 
@@ -168,7 +167,7 @@ public class Animator {
     }
 
     public void animateTo(GeoPoint p) {
-        animateTo((long) ANIM_DEFAULT_DURATION, p, 1, true, Easing.Type.LINEAR);
+        animateTo(500, p, 1, true, Easing.Type.LINEAR);
     }
 
     public void animateTo(long duration, MapPosition pos) {
@@ -226,15 +225,6 @@ public class Animator {
 
     public void animateFling(float velocityX, float velocityY,
                              int xmin, int xmax, int ymin, int ymax) {
-        // Smooth fling: Uses velocity to calculate duration.
-        // Increase velocity with 500 as reference, cause duration decelerates animation.
-        float duration = (Math.abs(velocityX) + Math.abs(velocityY)) / 2;
-        animateFling(velocityX * (duration / ANIM_DEFAULT_DURATION),
-                velocityY * (duration / ANIM_DEFAULT_DURATION), xmin, xmax, ymin, ymax, duration);
-    }
-
-    public void animateFling(float velocityX, float velocityY,
-        int xmin, int xmax, int ymin, int ymax, float duration) {
 
         ThreadUtils.assertMainThread();
 
@@ -245,6 +235,8 @@ public class Animator {
 
         mScroll.x = 0;
         mScroll.y = 0;
+
+        float duration = 500;
 
         float flingFactor = CanvasAdapter.DEFAULT_DPI / CanvasAdapter.dpi;
         mVelocity.x = velocityX * flingFactor;

--- a/vtm/src/org/oscim/map/Animator.java
+++ b/vtm/src/org/oscim/map/Animator.java
@@ -4,6 +4,7 @@
  * Copyright 2016 devemux86
  * Copyright 2016 Izumi Kawashima
  * Copyright 2017 Wolfgang Schramm
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -46,6 +47,7 @@ public class Animator {
     public final static int ANIM_ROTATE = 1 << 2;
     public final static int ANIM_TILT = 1 << 3;
     public final static int ANIM_FLING = 1 << 4;
+    public final static float ANIM_DEFAULT_DURATION = 500;
 
     private final Map mMap;
 
@@ -57,7 +59,7 @@ public class Animator {
     private final Point mPivot = new Point();
     private final Point mVelocity = new Point();
 
-    private float mDuration = 500;
+    private float mDuration = ANIM_DEFAULT_DURATION;
     private long mAnimEnd = -1;
     private Easing.Type mEasingType = Easing.Type.LINEAR;
 
@@ -166,7 +168,7 @@ public class Animator {
     }
 
     public void animateTo(GeoPoint p) {
-        animateTo(500, p, 1, true, Easing.Type.LINEAR);
+        animateTo((long) ANIM_DEFAULT_DURATION, p, 1, true, Easing.Type.LINEAR);
     }
 
     public void animateTo(long duration, MapPosition pos) {
@@ -224,6 +226,15 @@ public class Animator {
 
     public void animateFling(float velocityX, float velocityY,
                              int xmin, int xmax, int ymin, int ymax) {
+        // Smooth fling: Uses velocity to calculate duration.
+        // Increase velocity with 500 as reference, cause duration decelerates animation.
+        float duration = (Math.abs(velocityX) + Math.abs(velocityY)) / 2;
+        animateFling(velocityX * (duration / ANIM_DEFAULT_DURATION),
+                velocityY * (duration / ANIM_DEFAULT_DURATION), xmin, xmax, ymin, ymax, duration);
+    }
+
+    public void animateFling(float velocityX, float velocityY,
+        int xmin, int xmax, int ymin, int ymax, float duration) {
 
         ThreadUtils.assertMainThread();
 
@@ -235,8 +246,6 @@ public class Animator {
         mScroll.x = 0;
         mScroll.y = 0;
 
-        float duration = 500;
-
         float flingFactor = CanvasAdapter.DEFAULT_DPI / CanvasAdapter.dpi;
         mVelocity.x = velocityX * flingFactor;
         mVelocity.y = velocityY * flingFactor;
@@ -247,7 +256,7 @@ public class Animator {
             return;
         }
 
-        animStart(duration, ANIM_FLING, Easing.Type.LINEAR);
+        animStart(duration, ANIM_FLING, Easing.Type.SINE_OUT);
     }
 
     private void animStart(float duration, int state, Easing.Type easingType) {

--- a/vtm/src/org/oscim/utils/Easing.java
+++ b/vtm/src/org/oscim/utils/Easing.java
@@ -88,12 +88,10 @@ public class Easing {
 
     static private float sineIn(float x, float t, float b, float c, float d) {
         return -c * (float) Math.cos(t/d * (Math.PI/2)) + c + b;
-
     }
 
     static private float sineOut(float x, float t, float b, float c, float d) {
         return c * (float) Math.sin(t / d * (Math.PI / 2)) + b;
-
     }
 
     static private float expoOut(float x, float t, float b, float c, float d) {

--- a/vtm/src/org/oscim/utils/Easing.java
+++ b/vtm/src/org/oscim/utils/Easing.java
@@ -22,6 +22,8 @@ public class Easing {
     public enum Type {
         LINEAR,
         SINE_INOUT,
+        SINE_IN,
+        SINE_OUT,
         EXPO_OUT,
         QUAD_INOUT,
         CUBIC_INOUT,
@@ -47,6 +49,12 @@ public class Easing {
                 break;
             case SINE_INOUT:
                 adv = sineInout(x, t, b, c, d);
+                break;
+            case SINE_IN:
+                adv = sineIn(x, t, b, c, d);
+                break;
+            case SINE_OUT:
+                adv = sineOut(x, t, b, c, d);
                 break;
             case EXPO_OUT:
                 adv = expoOut(x, t, b, c, d);
@@ -76,6 +84,16 @@ public class Easing {
 
     static private float sineInout(float x, float t, float b, float c, float d) {
         return -c / 2 * (float) (Math.cos(Math.PI * t / d) - 1) + b;
+    }
+
+    static private float sineIn(float x, float t, float b, float c, float d) {
+        return -c * (float) Math.cos(t/d * (Math.PI/2)) + c + b;
+
+    }
+
+    static private float sineOut(float x, float t, float b, float c, float d) {
+        return c * (float) Math.sin(t / d * (Math.PI / 2)) + b;
+
     }
 
     static private float expoOut(float x, float t, float b, float c, float d) {


### PR DESCRIPTION
- Easing: add Sin in and out
- Animator: Smooth fling animation. ~So the animation duration is not always 500ms, but adapts on the gesture speed.~ And uses smoother sin_out as ease type.
- MapEventLayer: note for changing initial rotation position. If removing marked lines, it does a real rotation of where you tabbed your fingers first (cf. Google Maps). But this needs an animation to get not distressed by display jumps.

BTW: You better notice the difference on touch devices.