### PR TITLE
MapEventLayer2: improve double tap issue

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/MarkerOverlayActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/MarkerOverlayActivity.java
@@ -137,6 +137,11 @@ public class MarkerOverlayActivity extends SimpleMapActivity
                 Toast.makeText(MarkerOverlayActivity.this, "Map long press\n" + p, Toast.LENGTH_SHORT).show();
                 return true;
             }
+            if (g instanceof Gesture.TripleTap) {
+                GeoPoint p = mMap.viewport().fromScreenPoint(e.getX(), e.getY());
+                Toast.makeText(MarkerOverlayActivity.this, "Map triple tap\n" + p, Toast.LENGTH_SHORT).show();
+                return true;
+            }
             return false;
         }
     }

--- a/vtm-gdx/src/org/oscim/gdx/GestureHandlerImpl.java
+++ b/vtm-gdx/src/org/oscim/gdx/GestureHandlerImpl.java
@@ -41,6 +41,7 @@ public class GestureHandlerImpl extends GestureDetector.GestureAdapter {
         // Handle double tap zoom
         if (button == Input.Buttons.LEFT) {
             if (count == 2) {
+                //System.out.println("Double tap desktop not necessary with MapEventLayer2");
                 float pivotX = x - map.getWidth() / 2;
                 float pivotY = y - map.getHeight() / 2;
                 map.animator().animateZoom(300, 2, pivotX, pivotY);

--- a/vtm-playground/src/org/oscim/test/MarkerLayerTest.java
+++ b/vtm-playground/src/org/oscim/test/MarkerLayerTest.java
@@ -134,6 +134,11 @@ public class MarkerLayerTest extends GdxMapApp implements ItemizedLayer.OnItemGe
                 System.out.println("Map long press " + p);
                 return true;
             }
+            if (g instanceof Gesture.TripleTap) {
+                GeoPoint p = mMap.viewport().fromScreenPoint(e.getX(), e.getY());
+                System.out.println("Map triple tap " + p);
+                return true;
+            }
             return false;
         }
     }

--- a/vtm/src/org/oscim/layers/MapEventLayer.java
+++ b/vtm/src/org/oscim/layers/MapEventLayer.java
@@ -71,12 +71,17 @@ public class MapEventLayer extends AbstractMapEventLayer implements InputListene
     private long mStartMove;
 
     /**
+     * 1in = 25.4mm
+     */
+    private static final float INCH = 25.4f;
+
+    /**
      * 2mm as minimal distance to start move: dpi / 25.4
      */
-    private static final float MIN_SLOP = 25.4f / 2;
+    private static final float MIN_SLOP = INCH / 2;
 
-    private static final float PINCH_ZOOM_THRESHOLD = MIN_SLOP / 2;
-    private static final float PINCH_TILT_THRESHOLD = MIN_SLOP / 2;
+    private static final float PINCH_ZOOM_THRESHOLD = INCH / 4; // 4mm
+    private static final float PINCH_TILT_THRESHOLD = INCH / 4; // 4mm
     private static final float PINCH_TILT_SLOPE = 0.75f;
     private static final float PINCH_ROTATE_THRESHOLD = 0.2f;
     private static final float PINCH_ROTATE_THRESHOLD2 = 0.5f;


### PR DESCRIPTION
Improves #280.

Don't know what you exactly meant with this @devemux86:
> The consecutive "double tap zoom" doesn't work, the map doesn't zoom for all but only for the last double tap

Maybe you can check that.

The only difference to the `MapEventLayer` , I noticed, is, that `MapEventLayer2` needs marginal more time for double event, to check triple event. If triple would be optional this can be shortened.

Maybe can give a note at [forum topic](https://groups.google.com/forum/#!topic/mapsforge-dev/YHnj6ebQE0A). Don't know if other class could replaced then.