### PR TITLE
International Date Line: draw tiles with proxy immediately (Fix #89)

### DIFF
--- a/vtm/src/org/oscim/layers/tile/TileRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/TileRenderer.java
@@ -158,9 +158,11 @@ public abstract class TileRenderer extends LayerRenderer {
 
             /* load tile that is referenced by this holder */
             MapTile proxy = tile.holder;
-            if (proxy != null && proxy.state(NEW_DATA)) {
-                uploadCnt += uploadTileData(proxy);
-                tile.state = proxy.state;
+            if (proxy != null && (proxy.state(NEW_DATA) || proxy.state(READY))) {
+                if (proxy.state(READY))
+                    tile.state = NEW_DATA; // Changing independently of tile state, as long as it isn't READY
+                //uploadCnt += uploadTileData(proxy); // Should already been done in separate call
+                uploadCnt += uploadTileData(tile); // Actual tile must be loaded immediately
                 continue;
             }
 
@@ -168,7 +170,7 @@ public abstract class TileRenderer extends LayerRenderer {
             proxy = tile.getProxy(PROXY_PARENT, NEW_DATA);
             if (proxy != null) {
                 uploadCnt += uploadTileData(proxy);
-                /* dont load child proxies */
+                /* don't load child proxies */
                 continue;
             }
 

--- a/vtm/src/org/oscim/layers/tile/TileRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/TileRenderer.java
@@ -159,8 +159,7 @@ public abstract class TileRenderer extends LayerRenderer {
             /* load tile that is referenced by this holder */
             MapTile proxy = tile.holder;
             if (proxy != null && (proxy.state(NEW_DATA) || proxy.state(READY))) {
-                if (proxy.state(READY))
-                    tile.state = NEW_DATA; // Changing independently of tile state, as long as it isn't READY
+                tile.state = NEW_DATA; // Changing independently of tile state, as long as it isn't READY
                 //uploadCnt += uploadTileData(proxy); // Should already been done in separate call
                 uploadCnt += uploadTileData(tile); // Actual tile must be loaded immediately
                 continue;


### PR DESCRIPTION
Fix #89
Problem was that a tile that has a proxy was not rendered. Proxies appear at the international date line as they represent the original tile with numeration from zero. Instead the proxy (the original tile) is loaded, which already was rendered. 
Second problem is, that the already rendered proxies have state `READY` as the missing tile is in `LOAD` mode. So the tile normally always has the same state as its proxy. But it wasn't rendered yet, so there is need to set state to `NEW_DATA`. So tile is now rendered immediately. 

I don't quite understand why proxies are rendered at all, as they are processed in separate call or don't appear... 