### PR TITLE
MapDatabase: improve buildings processing

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -32,6 +32,7 @@ import org.oscim.renderer.bucket.ExtrusionBuckets;
 import org.oscim.renderer.bucket.RenderBuckets;
 import org.oscim.theme.styles.ExtrusionStyle;
 import org.oscim.theme.styles.RenderStyle;
+import org.oscim.tiling.TileSource;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,8 +44,8 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
 
     protected final static int BUILDING_LEVEL_HEIGHT = 280; // cm
 
-    protected final static int MIN_ZOOM = 17;
-    protected final static int MAX_ZOOM = 17;
+    public final static int MIN_ZOOM = 17;
+    public final static int MAX_ZOOM = TileSource.MAX_ZOOM;
 
     public static boolean POST_AA = false;
     public static boolean TRANSLUCENT = true;

--- a/vtm/src/org/oscim/tiling/TileSource.java
+++ b/vtm/src/org/oscim/tiling/TileSource.java
@@ -81,7 +81,6 @@ public abstract class TileSource {
         }
     }
 
-    // FIXME Same as BuildingLayer.MAX_ZOOM
     public static final int MAX_ZOOM = 17;
 
     protected float mAlpha = 1;

--- a/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
+++ b/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
@@ -30,6 +30,7 @@ import org.oscim.core.MercatorProjection;
 import org.oscim.core.Tag;
 import org.oscim.core.Tile;
 import org.oscim.layers.tile.MapTile;
+import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.tiling.ITileDataSink;
 import org.oscim.tiling.ITileDataSource;
 import org.oscim.tiling.TileSource;
@@ -954,10 +955,11 @@ public class MapDatabase implements ITileDataSource {
                     e.setLabelPosition(e.points[0] + labelPosition[0], e.points[1] + labelPosition[1]);
                 mTileProjection.project(e);
 
-                // At large query zoom levels clip everything
+                // Avoid clipping for mass of buildings, which slows rendering.
+                // But clip everything if BuildingLayer is displayed.
                 if ((!e.tags.containsKey(Tag.KEY_BUILDING)
                         && !e.tags.containsKey(Tag.KEY_BUILDING_PART))
-                        || queryParameters.queryZoomLevel > TileSource.MAX_ZOOM) {
+                        || queryParameters.queryZoomLevel >= BuildingLayer.MIN_ZOOM) {
                     if (!mTileClipper.clip(e)) {
                         continue;
                     }


### PR DESCRIPTION
Buildings aren't clipped in map file database, cause clipping every element does take much resources.
But if 3D buildings are rendered, they will be processed multiple times, if not clipped. So I set `BuildingLayer.ZOOM_MIN` as limit of clipping.
This patch also fixes ugly double animation in most cases (tile borders excluded).

Idea for some day: could integrate `Overzoom` inside MapDatabase to avoid double code.