### PR TITLE
Samples MapsforgeActivity: remember map position

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
@@ -204,11 +204,13 @@ public class MapsforgeActivity extends MapActivity {
                 mMap.layers().add(mapScaleBarLayer);
 
                 MapInfo info = mTileSource.getMapInfo();
-                MapPosition pos = new MapPosition();
-                pos.setByBoundingBox(info.boundingBox, Tile.SIZE * 4, Tile.SIZE * 4);
-                mMap.setMapPosition(pos);
-
-                mPrefs.clear();
+                if (!info.boundingBox.contains(mMap.getMapPosition().getGeoPoint())) {
+                    // Set position to map bounds, if prefs position not located inside it
+                    MapPosition pos = new MapPosition();
+                    pos.setByBoundingBox(info.boundingBox, Tile.SIZE * 4, Tile.SIZE * 4);
+                    mMap.setMapPosition(pos);
+                    mPrefs.clear();
+                }
             }
         } else if (requestCode == SELECT_THEME_FILE) {
             if (resultCode != RESULT_OK || intent == null || intent.getStringExtra(FilePicker.SELECTED_FILE) == null) {

--- a/vtm-playground/build.gradle
+++ b/vtm-playground/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':vtm-jts')
     implementation project(':vtm-mvt')
     implementation "com.badlogicgames.gdx:gdx-platform:$gdxVersion:natives-desktop"
+    implementation 'org.mapsforge:mapsforge-map-awt:master-SNAPSHOT'
     implementation "org.slf4j:slf4j-jdk14:$slf4jVersion"
 }
 

--- a/vtm-playground/src/org/oscim/persistence/PersistenceUtils.java
+++ b/vtm-playground/src/org/oscim/persistence/PersistenceUtils.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.persistence;
+
+import org.mapsforge.map.awt.util.JavaPreferences;
+import org.mapsforge.map.model.common.PreferencesFacade;
+import org.oscim.core.MapPosition;
+
+import java.util.prefs.Preferences;
+
+public class PersistenceUtils {
+    private static final PreferencesFacade preferencesFacade = new JavaPreferences(Preferences.userNodeForPackage(PersistenceUtils.class));
+
+    public static synchronized void loadMapPosPrefs(MapPosition position) {
+        position.setPosition(preferencesFacade.getDouble("LATITUDE", position.getLatitude()),
+                preferencesFacade.getDouble("LONGITUDE", position.getLongitude()));
+        position.setScale(preferencesFacade.getDouble("SCALE", position.getScale()));
+        position.setBearing(preferencesFacade.getFloat("BEARING", position.getBearing()));
+        position.setTilt(preferencesFacade.getFloat("TILT", position.getTilt()));
+    }
+
+    public static synchronized void saveMapPosPrefs(MapPosition position) {
+        System.out.println("MP task: " + position);
+        preferencesFacade.putDouble("LATITUDE", position.getLatitude());
+        preferencesFacade.putDouble("LONGITUDE", position.getLongitude());
+        preferencesFacade.putDouble("SCALE", position.getScale());
+        preferencesFacade.putFloat("BEARING", position.getBearing());
+        preferencesFacade.putFloat("TILT", position.getTilt());
+    }
+
+    public PersistenceUtils() {
+    }
+}

--- a/vtm-playground/src/org/oscim/stuff/MapzenTest.java
+++ b/vtm-playground/src/org/oscim/stuff/MapzenTest.java
@@ -49,6 +49,12 @@ public class MapzenTest extends GdxMapImpl {
         mMap.setMapPosition(position);
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new MapzenTest());

--- a/vtm-playground/src/org/oscim/stuff/MapzenTest.java
+++ b/vtm-playground/src/org/oscim/stuff/MapzenTest.java
@@ -16,11 +16,13 @@
  */
 package org.oscim.stuff;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.gdx.GdxMapImpl;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.source.OkHttpEngine;
 import org.oscim.tiling.source.UrlTileSource;
@@ -42,7 +44,9 @@ public class MapzenTest extends GdxMapImpl {
         mMap.layers().add(new BuildingLayer(mMap, l));
         mMap.layers().add(new LabelLayer(mMap, l));
 
-        mMap.setMapPosition(53.08, 8.82, 1 << 17);
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
     }
 
     public static void main(String[] args) {

--- a/vtm-playground/src/org/oscim/test/ClusterMarkerLayerTest.java
+++ b/vtm-playground/src/org/oscim/test/ClusterMarkerLayerTest.java
@@ -19,6 +19,7 @@ import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.canvas.Bitmap;
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeoPoint;
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.layers.marker.ClusterMarkerRenderer;
 import org.oscim.layers.marker.ItemizedLayer;
@@ -28,6 +29,7 @@ import org.oscim.layers.marker.MarkerRenderer;
 import org.oscim.layers.marker.MarkerRendererFactory;
 import org.oscim.layers.marker.MarkerSymbol;
 import org.oscim.layers.tile.bitmap.BitmapTileLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.OkHttpEngine;
 import org.oscim.tiling.source.bitmap.DefaultSources;
@@ -52,7 +54,9 @@ public class ClusterMarkerLayerTest extends MarkerLayerTest {
                     .build();
             mMap.layers().add(new BitmapTileLayer(mMap, tileSource));
 
-            mMap.setMapPosition(53.08, 8.83, 1 << 15);
+            MapPosition position = mMap.getMapPosition();
+            PersistenceUtils.loadMapPosPrefs(position);
+            mMap.setMapPosition(position);
 
             Bitmap bitmapPoi = CanvasAdapter.decodeBitmap(getClass().getResourceAsStream("/res/marker_poi.png"));
             final MarkerSymbol symbol;

--- a/vtm-playground/src/org/oscim/test/ClusterMarkerLayerTest.java
+++ b/vtm-playground/src/org/oscim/test/ClusterMarkerLayerTest.java
@@ -102,6 +102,12 @@ public class ClusterMarkerLayerTest extends MarkerLayerTest {
         }
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new ClusterMarkerLayerTest());

--- a/vtm-playground/src/org/oscim/test/ExternalRenderThemeTest.java
+++ b/vtm-playground/src/org/oscim/test/ExternalRenderThemeTest.java
@@ -96,6 +96,12 @@ public class ExternalRenderThemeTest extends GdxMapImpl {
         // mMap.getLayers().add(new GenericLayer(mMap, new GridRenderer()));
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new ExternalRenderThemeTest(), null, 256);

--- a/vtm-playground/src/org/oscim/test/ExternalRenderThemeTest.java
+++ b/vtm-playground/src/org/oscim/test/ExternalRenderThemeTest.java
@@ -18,10 +18,12 @@ package org.oscim.test;
 
 import com.badlogic.gdx.Input;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.gdx.GdxMapImpl;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.renderer.MapRenderer;
 import org.oscim.theme.IRenderTheme;
 import org.oscim.theme.IRenderTheme.ThemeException;
@@ -60,7 +62,9 @@ public class ExternalRenderThemeTest extends GdxMapImpl {
 
     @Override
     public void createLayers() {
-        mMap.setMapPosition(53.08, 8.83, 1 << 14);
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
 
         /*TileSource tileSource = OSciMap4TileSource.builder()
                 .httpFactory(new OkHttpEngine.OkHttpFactory())

--- a/vtm-playground/src/org/oscim/test/MapsforgeTest.java
+++ b/vtm-playground/src/org/oscim/test/MapsforgeTest.java
@@ -24,6 +24,7 @@ import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.buildings.S3DBLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.renderer.BitmapRenderer;
 import org.oscim.renderer.GLViewport;
 import org.oscim.scalebar.DefaultMapScaleBar;
@@ -80,8 +81,18 @@ public class MapsforgeTest extends GdxMapImpl {
 
         MapInfo info = tileSource.getMapInfo();
         MapPosition pos = new MapPosition();
-        pos.setByBoundingBox(info.boundingBox, Tile.SIZE * 4, Tile.SIZE * 4);
+        PersistenceUtils.loadMapPosPrefs(pos);
+        if (!info.boundingBox.contains(pos.getGeoPoint())) {
+            // Set position to map bounds, if prefs position not located inside it
+            pos.setByBoundingBox(info.boundingBox, Tile.SIZE * 4, Tile.SIZE * 4);
+        }
         mMap.setMapPosition(pos);
+    }
+
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
     }
 
     static File getMapFile(String[] args) {

--- a/vtm-playground/src/org/oscim/test/OSciMapS3DBTest.java
+++ b/vtm-playground/src/org/oscim/test/OSciMapS3DBTest.java
@@ -16,10 +16,12 @@
  */
 package org.oscim.test;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.layers.tile.buildings.S3DBTileLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.OkHttpEngine;
@@ -46,8 +48,9 @@ public class OSciMapS3DBTest extends GdxMapApp {
         mMap.layers().add(tl);
         mMap.layers().add(new LabelLayer(mMap, l));
 
-        mMap.setMapPosition(53.08, 8.82, 1 << 17);
-
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
     }
 
     public static void main(String[] args) {

--- a/vtm-playground/src/org/oscim/test/OSciMapS3DBTest.java
+++ b/vtm-playground/src/org/oscim/test/OSciMapS3DBTest.java
@@ -53,6 +53,12 @@ public class OSciMapS3DBTest extends GdxMapApp {
         mMap.setMapPosition(position);
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         init();
         run(new OSciMapS3DBTest());

--- a/vtm-playground/src/org/oscim/test/RuleVisitorTest.java
+++ b/vtm-playground/src/org/oscim/test/RuleVisitorTest.java
@@ -94,6 +94,12 @@ public class RuleVisitorTest extends GdxMapImpl {
         mMap.setMapPosition(position);
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new RuleVisitorTest());

--- a/vtm-playground/src/org/oscim/test/RuleVisitorTest.java
+++ b/vtm-playground/src/org/oscim/test/RuleVisitorTest.java
@@ -18,9 +18,11 @@ package org.oscim.test;
 
 import com.badlogic.gdx.Input;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.gdx.GdxMapImpl;
 import org.oscim.layers.tile.vector.VectorTileLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.renderer.MapRenderer;
 import org.oscim.theme.RenderTheme;
 import org.oscim.theme.VtmThemes;
@@ -87,7 +89,9 @@ public class RuleVisitorTest extends GdxMapImpl {
 
         //mMap.setMapPosition(7.707, 81.689, 1 << 16);
 
-        mMap.setMapPosition(53.08, 8.82, 1 << 16);
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
     }
 
     public static void main(String[] args) {

--- a/vtm-playground/src/org/oscim/test/SimpleMapTest.java
+++ b/vtm-playground/src/org/oscim/test/SimpleMapTest.java
@@ -16,12 +16,14 @@
  */
 package org.oscim.test;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.layers.GroupLayer;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.map.Map;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.renderer.BitmapRenderer;
 import org.oscim.renderer.GLViewport;
 import org.oscim.scalebar.DefaultMapScaleBar;
@@ -63,7 +65,10 @@ public class SimpleMapTest extends GdxMapApp {
         map.layers().add(mapScaleBarLayer);
 
         map.setTheme(VtmThemes.DEFAULT);
-        map.setMapPosition(53.075, 8.808, 1 << 17);
+
+        MapPosition position = map.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        map.setMapPosition(position);
     }
 
     public static void main(String[] args) {

--- a/vtm-playground/src/org/oscim/test/SimpleMapTest.java
+++ b/vtm-playground/src/org/oscim/test/SimpleMapTest.java
@@ -71,6 +71,12 @@ public class SimpleMapTest extends GdxMapApp {
         map.setMapPosition(position);
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(getMap().getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new SimpleMapTest());

--- a/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
+++ b/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
@@ -72,7 +72,12 @@ public class ThemeBuilderTest extends GdxMapImpl {
         MapPosition position = mMap.getMapPosition();
         PersistenceUtils.loadMapPosPrefs(position);
         mMap.setMapPosition(position);
+    }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
     }
 
     public static void main(String[] args) {

--- a/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
+++ b/vtm-playground/src/org/oscim/test/ThemeBuilderTest.java
@@ -18,10 +18,12 @@ package org.oscim.test;
 
 import org.oscim.backend.canvas.Color;
 import org.oscim.backend.canvas.Paint.Cap;
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.gdx.GdxMapImpl;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.theme.RenderTheme;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.OkHttpEngine;
@@ -67,7 +69,9 @@ public class ThemeBuilderTest extends GdxMapImpl {
 
         mMap.layers().add(new LabelLayer(mMap, l));
 
-        mMap.setMapPosition(53.08, 8.82, 1 << 17);
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
 
     }
 

--- a/vtm-playground/src/org/oscim/test/gdx/poi3d/Gdx3DTest.java
+++ b/vtm-playground/src/org/oscim/test/gdx/poi3d/Gdx3DTest.java
@@ -16,11 +16,13 @@
  */
 package org.oscim.test.gdx.poi3d;
 
+import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
 import org.oscim.gdx.GdxMapImpl;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
+import org.oscim.persistence.PersistenceUtils;
 import org.oscim.renderer.MapRenderer;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
@@ -33,7 +35,9 @@ public class Gdx3DTest extends GdxMapImpl {
     public void createLayers() {
         MapRenderer.setBackgroundColor(0xff888888);
 
-        mMap.setMapPosition(53.1, 8.8, 1 << 15);
+        MapPosition position = mMap.getMapPosition();
+        PersistenceUtils.loadMapPosPrefs(position);
+        mMap.setMapPosition(position);
 
         TileSource ts = OSciMap4TileSource.builder()
                 .httpFactory(new OkHttpEngine.OkHttpFactory())

--- a/vtm-playground/src/org/oscim/test/gdx/poi3d/Gdx3DTest.java
+++ b/vtm-playground/src/org/oscim/test/gdx/poi3d/Gdx3DTest.java
@@ -64,6 +64,12 @@ public class Gdx3DTest extends GdxMapImpl {
         mMap.layers().add(new LabelLayer(mMap, mMapLayer));
     }
 
+    @Override
+    public void dispose() {
+        PersistenceUtils.saveMapPosPrefs(mMap.getMapPosition());
+        super.dispose();
+    }
+
     public static void main(String[] args) {
         GdxMapApp.init();
         GdxMapApp.run(new Gdx3DTest());


### PR DESCRIPTION
It's uncomfortable to always zoom back to position where you leaved the application. So position is only set if pref position is out of map bounds.
Unfortunately desktop app does not have preferences (or did I miss something), so maybe this could be added as `enhancement`.