### PR TITLE
OpenMapTiles: support building heights

### DIFF
--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -60,14 +60,40 @@ public class MapElement extends GeometryBuffer {
         this.setLayer(element.layer);
     }
 
+    /**
+     * @return height in meters, if present
+     */
+    public Float height() {
+        String v = tags.getValue(Tag.KEY_HEIGHT); // Mapsforge & OSciMap & Mapzen
+        if (v == null)
+            v = tags.getValue("render_height"); // OpenMapTiles
+        if (v != null)
+            return Float.parseFloat(v);
+        return null;
+    }
+
     public boolean isBuilding() {
         return tags.containsKey(Tag.KEY_BUILDING)
+                || "building".equals(tags.getValue("layer")) // OpenMapTiles
                 || "building".equals(tags.getValue("kind")); // Mapzen
     }
 
     public boolean isBuildingPart() {
         return tags.containsKey(Tag.KEY_BUILDING_PART)
+                || "building:part".equals(tags.getValue("layer")) // OpenMapTiles
                 || "building_part".equals(tags.getValue("kind")); // Mapzen
+    }
+
+    /**
+     * @return minimum height in meters, if present
+     */
+    public Float minHeight() {
+        String v = tags.getValue(Tag.KEY_MIN_HEIGHT); // Mapsforge & OSciMap & Mapzen
+        if (v == null)
+            v = tags.getValue("render_min_height"); // OpenMapTiles
+        if (v != null)
+            return Float.parseFloat(v);
+        return null;
     }
 
     public void setLabelPosition(float x, float y) {

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -129,18 +129,19 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook {
         int height = 0; // cm
         int minHeight = 0; // cm
 
-        String v = element.tags.getValue(Tag.KEY_HEIGHT);
-        if (v != null)
-            height = (int) (Float.parseFloat(v) * 100);
+        String v;
+        Float f = element.height();
+        if (f != null)
+            height = (int) (f * 100);
         else {
             // #TagFromTheme: generalize level/height tags
             if ((v = element.tags.getValue(Tag.KEY_BUILDING_LEVELS)) != null)
                 height = (int) (Float.parseFloat(v) * BUILDING_LEVEL_HEIGHT);
         }
 
-        v = element.tags.getValue(Tag.KEY_MIN_HEIGHT);
-        if (v != null)
-            minHeight = (int) (Float.parseFloat(v) * 100);
+        f = element.minHeight();
+        if (f != null)
+            minHeight = (int) (f * 100);
         else {
             // #TagFromTheme: level/height tags
             if ((v = element.tags.getValue(Tag.KEY_BUILDING_MIN_LEVEL)) != null)


### PR DESCRIPTION
Alternatively can put methods `height` and `minHeight` inside `BuildingLayer` with extra Parameter, if it is not that relevant in `MapElement`.