### PR TITLE
LineClipper: name and unify clip states

### DIFF
--- a/vtm/src/org/oscim/layers/PathLayer.java
+++ b/vtm/src/org/oscim/layers/PathLayer.java
@@ -412,7 +412,7 @@ public class PathLayer extends Layer implements GestureListener {
                     }
                     i = 0;
                     // if the end point is inside, add it
-                    if (mClipper.getPrevOutcode() == LineClipper.OUTSIDE) {
+                    if (mClipper.getPrevOutcode() == LineClipper.INSIDE) {
                         projected[i++] = prevX;
                         projected[i++] = prevY;
                     }

--- a/vtm/src/org/oscim/layers/PathLayer.java
+++ b/vtm/src/org/oscim/layers/PathLayer.java
@@ -396,11 +396,11 @@ public class PathLayer extends Layer implements GestureListener {
                 }
 
                 int clip = mClipper.clipNext(x, y);
-                if (clip < 1) {
+                if (clip != LineClipper.INSIDE) {
                     if (i > 2)
                         ll.addLine(projected, i, false);
 
-                    if (clip < 0) {
+                    if (clip == LineClipper.INTERSECTION) {
                         /* add line segment */
                         segment = mClipper.getLine(segment, 0);
                         ll.addLine(segment, 4, false);
@@ -412,7 +412,7 @@ public class PathLayer extends Layer implements GestureListener {
                     }
                     i = 0;
                     // if the end point is inside, add it
-                    if (mClipper.getPrevOutcode() == 0) {
+                    if (mClipper.getPrevOutcode() == LineClipper.OUTSIDE) {
                         projected[i++] = prevX;
                         projected[i++] = prevY;
                     }

--- a/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
@@ -556,7 +556,7 @@ public class ExtrusionBucket extends RenderBucket {
             }
 
             /* check if face is within tile */
-            if (mClipper.clipNext((int) nx, (int) ny) == 0) {
+            if (mClipper.clipNext((int) nx, (int) ny) == LineClipper.OUTSIDE) {
                 even = ++even % 2;
                 continue;
             }

--- a/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
@@ -349,8 +349,8 @@ public final class PolygonBucket extends RenderBucket {
                      * be completly contained within box */
                     if ((out != LineClipper.INSIDE) && (out != LineClipper.OUTSIDE)) {
                         mScreenClip.clipStart(box[6], box[7]);
-                        out = LineClipper.INSIDE;
-                        for (int i = 0; i < 8 && out == LineClipper.INSIDE; i += 2)
+                        out = LineClipper.OUTSIDE;
+                        for (int i = 0; i < 8 && out == LineClipper.OUTSIDE; i += 2)
                             out = mScreenClip.clipNext(box[i], box[i + 1]);
 
                         if (out == LineClipper.OUTSIDE) {

--- a/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
@@ -333,28 +333,27 @@ public final class PolygonBucket extends RenderBucket {
                     /* project bbox of polygon to screen */
                     v.mvp.prj2D(pb.bbox, 0, box, 0, 4);
 
-                    int out = 0;
+                    int out = LineClipper.INSIDE;
                     for (int i = 0; i < 8; i += 2) {
                         int o = mScreenClip.outcode(box[i], box[i + 1]);
 
-                        if (o == 0) {
+                        if (o == LineClipper.INSIDE) {
                             /* at least one corner is inside */
-                            out = 0;
+                            out = LineClipper.INSIDE;
                             break;
                         }
                         out |= o;
                     }
                     /* Check if any polygon-bucket edge intersects the screen.
                      * Also check the very unlikely case where the view might
-                     * be
-                     * completly contained within box */
-                    if ((out != 0) && (out != 0xF)) {
+                     * be completly contained within box */
+                    if ((out != LineClipper.INSIDE) && (out != LineClipper.OUTSIDE)) {
                         mScreenClip.clipStart(box[6], box[7]);
-                        out = 0;
-                        for (int i = 0; i < 8 && out == 0; i += 2)
+                        out = LineClipper.INSIDE;
+                        for (int i = 0; i < 8 && out == LineClipper.INSIDE; i += 2)
                             out = mScreenClip.clipNext(box[i], box[i + 1]);
 
-                        if (out == 0) {
+                        if (out == LineClipper.OUTSIDE) {
                             //log.debug("out {}\n {}\n {}", out, Arrays.toString(pb.bbox), Arrays.toString(box));
 
                             //    log.debug("outside {} {} {}", out,

--- a/vtm/src/org/oscim/utils/geom/LineClipper.java
+++ b/vtm/src/org/oscim/utils/geom/LineClipper.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2012, 2013 Hannes Janetzek
  * Copyright 2016 Bezzu
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -27,10 +28,13 @@ import org.oscim.core.GeometryBuffer;
 public class LineClipper {
 
     public static final int INSIDE = 0; // 0000
+    public static final int OUTSIDE = 0xF; // 1111
     public static final int LEFT = 1; // 0001
     public static final int RIGHT = 2; // 0010
     public static final int BOTTOM = 4; // 0100
     public static final int TOP = 8; // 1000
+
+    public static final int INTERSECTION = -1;
 
     private float xmin, xmax, ymin, ymax;
 
@@ -90,8 +94,8 @@ public class LineClipper {
     }
 
     /**
-     * @return 0 if not intersection, 1 fully within, -1 clipped (and 'out' set
-     * to new points)
+     * @return OUTSIDE (= 1111) if not intersection, INSIDE (= 0) if fully within,
+     * INTERSECTION (= -1) if clipped (and 'out' set to new points)
      */
     public int clipNext(float x1, float y1) {
         int accept;
@@ -109,12 +113,12 @@ public class LineClipper {
 
         if ((mPrevOutcode | outcode) == 0) {
             // Bitwise OR is 0. Trivially accept
-            accept = 1;
+            accept = INSIDE;
         } else if ((mPrevOutcode & outcode) != 0) {
             // Bitwise AND is not 0. Trivially reject
-            accept = 0;
+            accept = OUTSIDE;
         } else {
-            accept = clip(mPrevX, mPrevY, x1, y1, mPrevOutcode, outcode) ? -1 : 0;
+            accept = clip(mPrevX, mPrevY, x1, y1, mPrevOutcode, outcode) ? INTERSECTION : OUTSIDE;
         }
         mPrevOutcode = outcode;
         mPrevX = x1;
@@ -258,10 +262,10 @@ public class LineClipper {
                 y = in.points[inPos++];
 
                 int clip = clipNext(x, y);
-                if (clip == 0) {
+                if (clip == OUTSIDE) {
                     /* current segment is fully outside */
                     inside = false; // needed?
-                } else if (clip == 1) {
+                } else if (clip == INSIDE) {
                     /* current segment is fully within */
                     out.addPoint(x, y);
                 } else { /* clip == -1 */


### PR DESCRIPTION
Methods used different clip states for the same `int` value. This was very confusing as both were used sometimes in the same variable (see [`PolygonBucket`](https://github.com/mapsforge/vtm/blob/master/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java#L355)).