### PR TITLE
PathLayer: use GL_INT buffer

### DIFF
--- a/vtm-jts/src/org/oscim/layers/vector/PathLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/PathLayer.java
@@ -40,6 +40,8 @@ import java.util.List;
  */
 public class PathLayer extends VectorLayer {
 
+    private static final boolean USE_INT = true;
+
     protected final ArrayList<GeoPoint> mPoints;
 
     protected Style mStyle;
@@ -49,7 +51,7 @@ public class PathLayer extends VectorLayer {
     private final Point mPoint2 = new Point();
 
     public PathLayer(Map map, Style style) {
-        super(map);
+        super(map, USE_INT);
         mStyle = style;
 
         mPoints = new ArrayList<>();

--- a/vtm/src/org/oscim/renderer/BucketRenderer.java
+++ b/vtm/src/org/oscim/renderer/BucketRenderer.java
@@ -70,7 +70,11 @@ public class BucketRenderer extends LayerRenderer {
     public final RenderBuckets buckets;
 
     public BucketRenderer() {
-        buckets = new RenderBuckets();
+        this(false);
+    }
+
+    public BucketRenderer(boolean useInt) {
+        buckets = new RenderBuckets(useInt);
         mMapPosition = new MapPosition();
     }
 

--- a/vtm/src/org/oscim/renderer/MapRenderer.java
+++ b/vtm/src/org/oscim/renderer/MapRenderer.java
@@ -189,7 +189,7 @@ public class MapRenderer {
 
         mNewSurface = false;
 
-        /** initialize quad indices used by Texture- and LineTexRenderer */
+        /* initialize quad indices used by Texture- and LineTexRenderer */
         int[] vboIds = GLUtils.glGenBuffers(2);
 
         mQuadIndicesID = vboIds[0];
@@ -214,7 +214,7 @@ public class MapRenderer {
                 GL.STATIC_DRAW);
         GLState.bindElementBuffer(0);
 
-        /** initialize default quad */
+        /* initialize default quad */
         FloatBuffer floatBuffer = MapRenderer.getFloatBuffer(8);
         float[] quad = new float[]{-1, -1, -1, 1, 1, -1, 1, 1};
         floatBuffer.put(quad);

--- a/vtm/src/org/oscim/renderer/bucket/BitmapBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/BitmapBucket.java
@@ -23,6 +23,7 @@ import org.oscim.renderer.GLState;
 import org.oscim.renderer.GLViewport;
 import org.oscim.renderer.bucket.TextureItem.TexturePool;
 
+import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
 import static org.oscim.backend.GLAdapter.gl;
@@ -122,17 +123,17 @@ public class BitmapBucket extends TextureBucket {
         buf[pos++] = texMax;
         buf[pos++] = texMax;
 
-        this.vertexOffset = vboData.position() * 2;
+        this.vertexOffset = vboData.position() * SHORT_BYTES;
         vboData.put(buf);
     }
 
     @Override
-    protected void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    protected void compile(Buffer vboData, ShortBuffer iboData) {
 
         if (mBitmap == null)
             return;
 
-        setVertices(vboData);
+        setVertices((ShortBuffer) vboData);
 
         textures.upload();
 

--- a/vtm/src/org/oscim/renderer/bucket/CircleBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/CircleBucket.java
@@ -2,6 +2,7 @@
  * Copyright 2016 Andrey Novikov
  * Copyright 2016 devemux86
  * Copyright 2017 schedul-xor
+ * Copyright 2018 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -52,32 +53,32 @@ public class CircleBucket extends RenderBucket {
 
         if (GLAdapter.CIRCLE_QUADS) {
             // Create quad
-            vertexItems.add((short) ((x + circle.radius) * COORD_SCALE), (short) ((y - circle.radius) * COORD_SCALE));
+            vertexItems.add((int) ((x + circle.radius) * COORD_SCALE), (int) ((y - circle.radius) * COORD_SCALE));
             int ne = numVertices++;
-            vertexItems.add((short) ((x - circle.radius) * COORD_SCALE), (short) ((y - circle.radius) * COORD_SCALE));
+            vertexItems.add((int) ((x - circle.radius) * COORD_SCALE), (int) ((y - circle.radius) * COORD_SCALE));
             int nw = numVertices++;
-            vertexItems.add((short) ((x - circle.radius) * COORD_SCALE), (short) ((y + circle.radius) * COORD_SCALE));
+            vertexItems.add((int) ((x - circle.radius) * COORD_SCALE), (int) ((y + circle.radius) * COORD_SCALE));
             int sw = numVertices++;
-            vertexItems.add((short) ((x + circle.radius) * COORD_SCALE), (short) ((y + circle.radius) * COORD_SCALE));
+            vertexItems.add((int) ((x + circle.radius) * COORD_SCALE), (int) ((y + circle.radius) * COORD_SCALE));
             int se = numVertices++;
 
-            indiceItems.add((short) ne);
+            indiceItems.add(ne);
             numIndices++;
-            indiceItems.add((short) nw);
+            indiceItems.add(nw);
             numIndices++;
-            indiceItems.add((short) sw);
+            indiceItems.add(sw);
             numIndices++;
 
-            indiceItems.add((short) sw);
+            indiceItems.add(sw);
             numIndices++;
-            indiceItems.add((short) se);
+            indiceItems.add(se);
             numIndices++;
-            indiceItems.add((short) ne);
+            indiceItems.add(ne);
             numIndices++;
         } else {
             // Use point
-            vertexItems.add((short) (x * COORD_SCALE), (short) (y * COORD_SCALE));
-            indiceItems.add((short) numVertices++);
+            vertexItems.add((int) (x * COORD_SCALE), (int) (y * COORD_SCALE));
+            indiceItems.add(numVertices++);
             numIndices++;
         }
     }

--- a/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2012, 2013 Hannes Janetzek
- * Copyright 2017 Gustl22
+ * Copyright 2017-2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -30,6 +30,7 @@ import org.oscim.utils.pool.Pool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
 import static org.oscim.renderer.MapRenderer.COORD_SCALE;
@@ -283,7 +284,7 @@ public class ExtrusionBucket extends RenderBucket {
         if (addVertex)
             vertexItems.add(v.x, v.y, v.z, v.n);
 
-        mIndices[IND_MESH].add((short) v.id);
+        mIndices[IND_MESH].add(v.id);
         numIndices++;
     }
 
@@ -473,11 +474,11 @@ public class ExtrusionBucket extends RenderBucket {
         float ux, uy;
 
         float a = (float) Math.sqrt(vx * vx + vy * vy);
-        short color1 = (short) ((1 + vx / a) * 127);
+        int color1 = (int) ((1 + vx / a) * 127);
 
-        short fcolor = color1, color2 = 0;
+        int fcolor = color1, color2 = 0;
 
-        short h = (short) height, mh = (short) minHeight;
+        int h = (int) height, mh = (int) minHeight;
 
         int even = 0;
         int changeX = 0, changeY = 0, angleSign = 0;
@@ -502,10 +503,10 @@ public class ExtrusionBucket extends RenderBucket {
                 nx = points[pos + 0];
                 ny = points[pos + 1];
             } else { // if (addFace)
-                short c = (short) (color1 | fcolor << 8);
+                int c = (color1 | fcolor << 8);
                 /* add bottom and top vertex for each point */
-                vertexItems.add((short) (cx * COORD_SCALE), (short) (cy * COORD_SCALE), mh, c);
-                vertexItems.add((short) (cx * COORD_SCALE), (short) (cy * COORD_SCALE), h, c);
+                vertexItems.add((int) (cx * COORD_SCALE), (int) (cy * COORD_SCALE), mh, c);
+                vertexItems.add((int) (cx * COORD_SCALE), (int) (cy * COORD_SCALE), h, c);
 
                 //v += 8;
                 break;
@@ -516,17 +517,17 @@ public class ExtrusionBucket extends RenderBucket {
 
             /* set lighting (by direction) */
             a = (float) Math.sqrt(vx * vx + vy * vy);
-            color2 = (short) ((1 + vx / a) * 127);
+            color2 = (int) ((1 + vx / a) * 127);
 
-            short c;
+            int c;
             if (even == 0)
-                c = (short) (color1 | color2 << 8);
+                c = (color1 | color2 << 8);
             else
-                c = (short) (color2 | color1 << 8);
+                c = (color2 | color1 << 8);
 
             /* add bottom and top vertex for each point */
-            vertexItems.add((short) (cx * COORD_SCALE), (short) (cy * COORD_SCALE), mh, c);
-            vertexItems.add((short) (cx * COORD_SCALE), (short) (cy * COORD_SCALE), h, c);
+            vertexItems.add((int) (cx * COORD_SCALE), (int) (cy * COORD_SCALE), mh, c);
+            vertexItems.add((int) (cx * COORD_SCALE), (int) (cy * COORD_SCALE), h, c);
 
             color1 = color2;
 
@@ -562,11 +563,11 @@ public class ExtrusionBucket extends RenderBucket {
             }
 
             /* add ZigZagQuadIndices(tm) for sides */
-            short vert = (short) (vOffset + (i - 2));
-            short s0 = vert++;
-            short s1 = vert++;
-            short s2 = vert++;
-            short s3 = vert++;
+            int vert = vOffset + (i - 2);
+            int s0 = vert++;
+            int s1 = vert++;
+            int s2 = vert++;
+            int s3 = vert++;
 
             /* connect last to first (when number of faces is even) */
             if (!addFace && i == len) {
@@ -591,7 +592,7 @@ public class ExtrusionBucket extends RenderBucket {
     }
 
     @Override
-    public void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    public void compile(Buffer vboData, ShortBuffer iboData) {
 
         if (numVertices == 0)
             return;
@@ -606,7 +607,7 @@ public class ExtrusionBucket extends RenderBucket {
                 iOffset += idx[i];
             }
         }
-        vertexOffset = vboData.position() * 2;
+        vertexOffset = vboData.position() * SHORT_BYTES;
         vertexItems.compile(vboData);
 
         clear();

--- a/vtm/src/org/oscim/renderer/bucket/HairLineBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/HairLineBucket.java
@@ -41,7 +41,7 @@ public class HairLineBucket extends RenderBucket {
     }
 
     public void addLine(GeometryBuffer geom) {
-        short id = (short) numVertices;
+        int id = numVertices;
 
         float pts[] = geom.points;
 
@@ -60,17 +60,16 @@ public class HairLineBucket extends RenderBucket {
 
             int end = inPos + len;
 
-            vertexItems.add((short) (pts[inPos++] * COORD_SCALE),
-                    (short) (pts[inPos++] * COORD_SCALE));
-            short first = id;
+            vertexItems.add((int) (pts[inPos++] * COORD_SCALE),
+                    (int) (pts[inPos++] * COORD_SCALE));
+            int first = id;
 
             indiceItems.add(id++);
             numIndices++;
 
             while (inPos < end) {
-
-                vertexItems.add((short) (pts[inPos++] * COORD_SCALE),
-                        (short) (pts[inPos++] * COORD_SCALE));
+                vertexItems.add((int) (pts[inPos++] * COORD_SCALE),
+                        (int) (pts[inPos++] * COORD_SCALE));
 
                 indiceItems.add(id);
                 numIndices++;

--- a/vtm/src/org/oscim/renderer/bucket/IVertexData.java
+++ b/vtm/src/org/oscim/renderer/bucket/IVertexData.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2012 Hannes Janetzek
+ * Copyright 2018 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.renderer.bucket;
+
+import java.nio.Buffer;
+
+public interface IVertexData {
+    void add(float a);
+
+    void add(int a);
+
+    void add(float a, float b);
+
+    void add(int a, int b);
+
+    void add(float a, float b, float c);
+
+    void add(int a, int b, int c);
+
+    void add(float a, float b, float c, float d);
+
+    void add(int a, int b, int c, int d);
+
+    void add(float a, float b, float c, float d, float e, float f);
+
+    void add(int a, int b, int c, int d, int e, int f);
+
+    int compile(Buffer buffer);
+
+    int countSize();
+
+    void dispose();
+
+    boolean empty();
+
+    // IChunk obtainChunk(); // TODO interface for Chunk
+
+    void releaseChunk();
+
+    void releaseChunk(int size);
+
+    void seek(int offset);
+}

--- a/vtm/src/org/oscim/renderer/bucket/IntVertexData.java
+++ b/vtm/src/org/oscim/renderer/bucket/IntVertexData.java
@@ -17,23 +17,22 @@
  */
 package org.oscim.renderer.bucket;
 
-import org.oscim.renderer.bucket.VertexData.Chunk;
-import org.oscim.utils.FastMath;
+import org.oscim.renderer.bucket.IntVertexData.Chunk;
 import org.oscim.utils.pool.Inlist;
 import org.oscim.utils.pool.SyncPool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.Buffer;
-import java.nio.ShortBuffer;
+import java.nio.IntBuffer;
 
 /**
  * A linked list of array chunks to hold temporary vertex data.
  * <p/>
  * TODO override append() etc to update internal (cur) state.
  */
-public class VertexData extends Inlist.List<Chunk> implements IVertexData {
-    static final Logger log = LoggerFactory.getLogger(VertexData.class);
+public class IntVertexData extends Inlist.List<Chunk> implements IVertexData {
+    static final Logger log = LoggerFactory.getLogger(IntVertexData.class);
 
     /**
      * Size of array chunks. Must be multiple of:
@@ -49,7 +48,7 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
     private static final int MAX_POOL = 500;
 
     public static class Chunk extends Inlist<Chunk> {
-        public final short[] vertices = new short[SIZE];
+        public final int[] vertices = new int[SIZE];
         public int used;
     }
 
@@ -120,7 +119,7 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
         int size = 0;
         for (Chunk it = head(); it != null; it = it.next) {
             size += it.used;
-            ((ShortBuffer) sbuf).put(it.vertices, 0, it.used);
+            ((IntBuffer) sbuf).put(it.vertices, 0, it.used);
         }
         dispose();
         return size;
@@ -131,7 +130,7 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
     /* set SIZE to get new item on add */
     private int used = SIZE;
 
-    private short[] vertices;
+    private int[] vertices;
 
     private void getNext() {
         if (cur == null) {
@@ -151,15 +150,11 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
 
     @Override
     public void add(float a) {
-        add(toShort(a));
+        add((int) a);
     }
 
     @Override
     public void add(int a) {
-        add((short) a);
-    }
-
-    private void add(short a) {
         if (used == SIZE)
             getNext();
 
@@ -168,15 +163,11 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
 
     @Override
     public void add(float a, float b) {
-        add(toShort(a), toShort(b));
+        add((int) a, (int) b);
     }
 
     @Override
     public void add(int a, int b) {
-        add((short) a, (short) b);
-    }
-
-    private void add(short a, short b) {
         if (used == SIZE)
             getNext();
 
@@ -187,15 +178,11 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
 
     @Override
     public void add(float a, float b, float c) {
-        add(toShort(a), toShort(b), toShort(c));
+        add((int) a, (int) b, (int) c);
     }
 
     @Override
     public void add(int a, int b, int c) {
-        add((short) a, (short) b, (short) c);
-    }
-
-    private void add(short a, short b, short c) {
         if (used == SIZE)
             getNext();
 
@@ -207,15 +194,11 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
 
     @Override
     public void add(float a, float b, float c, float d) {
-        add(toShort(a), toShort(b), toShort(c), toShort(d));
+        add((int) a, (int) b, (int) c, (int) d);
     }
 
     @Override
     public void add(int a, int b, int c, int d) {
-        add((short) a, (short) b, (short) c, (short) d);
-    }
-
-    private void add(short a, short b, short c, short d) {
         if (used == SIZE)
             getNext();
 
@@ -228,15 +211,11 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
 
     @Override
     public void add(float a, float b, float c, float d, float e, float f) {
-        add(toShort(a), toShort(b), toShort(c), toShort(d), toShort(e), toShort(f));
+        add((int) a, (int) b, (int) c, (int) d, (int) e, (int) f);
     }
 
     @Override
     public void add(int a, int b, int c, int d, int e, int f) {
-        add((short) a, (short) b, (short) c, (short) d, (short) e, (short) f);
-    }
-
-    private void add(short a, short b, short c, short d, short e, short f) {
         if (used == SIZE)
             getNext();
 
@@ -247,10 +226,6 @@ public class VertexData extends Inlist.List<Chunk> implements IVertexData {
         vertices[used + 4] = e;
         vertices[used + 5] = f;
         used += 6;
-    }
-
-    private static short toShort(float v) {
-        return (short) FastMath.clamp(v, Short.MIN_VALUE, Short.MAX_VALUE);
     }
 
     /**

--- a/vtm/src/org/oscim/renderer/bucket/LineTexBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/LineTexBucket.java
@@ -2,6 +2,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2018 devemux86
  * Copyright 2017 Longri
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -30,6 +31,7 @@ import org.oscim.utils.FastMath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.ShortBuffer;
@@ -112,7 +114,7 @@ public final class LineTexBucket extends LineBucket {
              * allocated memory */
             numVertices = 1;
         }
-        VertexData vi = vertexItems;
+        IVertexData vi = vertexItems;
 
         /* reset offset to last written position */
         if (!evenSegment)
@@ -163,15 +165,15 @@ public final class LineTexBucket extends LineBucket {
                 //    vy /= a;
                 
                 /* normalized perpendicular to line segment */
-                short dx = (short) ((-vy / a) * DIR_SCALE);
-                short dy = (short) ((vx / a) * DIR_SCALE);
+                int dx = (int) ((-vy / a) * DIR_SCALE);
+                int dy = (int) ((vx / a) * DIR_SCALE);
 
-                vi.add((short) x, (short) y, dx, dy, (short) lineLength, (short) 0);
+                vi.add((int) x, (int) y, dx, dy, (int) lineLength, 0);
 
                 lineLength += a;
 
                 vi.seek(6);
-                vi.add((short) nx, (short) ny, dx, dy, (short) lineLength, (short) 0);
+                vi.add((int) nx, (int) ny, dx, dy, (int) lineLength, 0);
 
                 x = nx;
                 y = ny;
@@ -209,7 +211,7 @@ public final class LineTexBucket extends LineBucket {
     }
 
     @Override
-    protected void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    protected void compile(Buffer vboData, ShortBuffer iboData) {
         compileVertexItems(vboData);
         /* add additional vertex for interleaving, see TexLineLayer. */
         vboData.position(vboData.position() + 6);

--- a/vtm/src/org/oscim/renderer/bucket/MeshBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/MeshBucket.java
@@ -61,7 +61,7 @@ public class MeshBucket extends RenderBucket {
     }
 
     public void addConvexMesh(GeometryBuffer geom) {
-        short start = (short) numVertices;
+        int start = numVertices;
 
         if (numVertices >= (1 << 16)) {
             return;
@@ -72,7 +72,7 @@ public class MeshBucket extends RenderBucket {
 
         vertexItems.add(geom.points[2] * COORD_SCALE,
                 geom.points[3] * COORD_SCALE);
-        short prev = (short) (start + 1);
+        int prev = start + 1;
 
         numVertices += 2;
 
@@ -132,7 +132,7 @@ public class MeshBucket extends RenderBucket {
             if (size > VertexData.SIZE)
                 size = VertexData.SIZE;
 
-            Chunk chunk = vertexItems.obtainChunk();
+            Chunk chunk = ((VertexData) vertexItems).obtainChunk();
 
             tess.getVertices(chunk.vertices, offset, size, COORD_SCALE);
             offset += size;

--- a/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/PolygonBucket.java
@@ -2,6 +2,7 @@
  * Copyright 2012 Hannes Janetzek
  * Copyright 2016 Longri
  * Copyright 2016 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -35,6 +36,7 @@ import org.oscim.utils.math.Interpolation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
 import static org.oscim.backend.GLAdapter.gl;
@@ -73,7 +75,7 @@ public final class PolygonBucket extends RenderBucket {
     final float[] bbox = new float[8];
 
     public void addPolygon(float[] points, int[] index) {
-        short center = (short) ((Tile.SIZE >> 1) * COORD_SCALE);
+        int center = (int) ((Tile.SIZE >> 1) * COORD_SCALE);
 
         boolean outline = area.strokeWidth > 0;
 
@@ -102,21 +104,21 @@ public final class PolygonBucket extends RenderBucket {
                 ymin = Math.min(ymin, y);
 
                 if (outline) {
-                    indiceItems.add((short) numVertices);
+                    indiceItems.add(numVertices);
                     numIndices++;
                 }
 
-                vertexItems.add((short) x, (short) y);
+                vertexItems.add((int) x, (int) y);
                 numVertices++;
 
                 if (outline) {
-                    indiceItems.add((short) numVertices);
+                    indiceItems.add(numVertices);
                     numIndices++;
                 }
             }
 
-            vertexItems.add((short) (points[pos + 0] * COORD_SCALE),
-                    (short) (points[pos + 1] * COORD_SCALE));
+            vertexItems.add((int) (points[pos + 0] * COORD_SCALE),
+                    (int) (points[pos + 1] * COORD_SCALE));
             numVertices++;
 
             pos += length;
@@ -129,7 +131,7 @@ public final class PolygonBucket extends RenderBucket {
     }
 
     @Override
-    protected void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    protected void compile(Buffer vboData, ShortBuffer iboData) {
         if (area.strokeWidth == 0) {
             /* add vertices to shared VBO */
             compileVertexItems(vboData);

--- a/vtm/src/org/oscim/renderer/bucket/SymbolBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/SymbolBucket.java
@@ -26,6 +26,7 @@ import org.oscim.utils.pool.Inlist;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
 import static org.oscim.renderer.MapRenderer.COORD_SCALE;
@@ -72,9 +73,9 @@ public final class SymbolBucket extends TextureBucket {
     }
 
     @Override
-    protected void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    protected void compile(Buffer vboData, ShortBuffer iboData) {
         /* offset of layer data in vbo */
-        this.vertexOffset = vboData.position() * 2; //SHORT_BYTES;
+        this.vertexOffset = vboData.position() * SHORT_BYTES;
 
         int numIndices = 0;
 
@@ -133,13 +134,13 @@ public final class SymbolBucket extends TextureBucket {
                 continue;
             }
 
-            short u1 = (short) (COORD_SCALE * x);
-            short v1 = (short) (COORD_SCALE * y);
-            short u2 = (short) (COORD_SCALE * (x + width));
-            short v2 = (short) (COORD_SCALE * (y + height));
+            int u1 = (int) (COORD_SCALE * x);
+            int v1 = (int) (COORD_SCALE * y);
+            int u2 = (int) (COORD_SCALE * (x + width));
+            int v2 = (int) (COORD_SCALE * (y + height));
 
             PointF prevOffset = null;
-            short x1 = 0, y1 = 0, x2 = 0, y2 = 0;
+            int x1 = 0, y1 = 0, x2 = 0, y2 = 0;
             float minX, minY, maxX, maxY;
 
             /* add symbol items referencing the same bitmap */
@@ -157,25 +158,25 @@ public final class SymbolBucket extends TextureBucket {
                             float hw = width / 2f;
                             float hh = height / 2f;
 
-                            x1 = (short) (COORD_SCALE * (-hw));
-                            x2 = (short) (COORD_SCALE * (hw));
-                            y1 = (short) (COORD_SCALE * (hh));
-                            y2 = (short) (COORD_SCALE * (-hh));
+                            x1 = (int) (COORD_SCALE * (-hw));
+                            x2 = (int) (COORD_SCALE * (hw));
+                            y1 = (int) (COORD_SCALE * (hh));
+                            y2 = (int) (COORD_SCALE * (-hh));
                         } else {
-                            float hw = (float) (it.offset.x * width);
-                            float hh = (float) (it.offset.y * height);
-                            x1 = (short) (COORD_SCALE * (-hw));
-                            x2 = (short) (COORD_SCALE * (width - hw));
-                            y1 = (short) (COORD_SCALE * (height - hh));
-                            y2 = (short) (COORD_SCALE * (-hh));
+                            float hw = it.offset.x * width;
+                            float hh = it.offset.y * height;
+                            x1 = (int) (COORD_SCALE * (-hw));
+                            x2 = (int) (COORD_SCALE * (width - hw));
+                            y1 = (int) (COORD_SCALE * (height - hh));
+                            y2 = (int) (COORD_SCALE * (-hh));
                         }
                     }
 
                     /* add vertices */
-                    short tx = (short) ((int) (COORD_SCALE * it.x) & LBIT_MASK
+                    int tx = ((int) (COORD_SCALE * it.x) & LBIT_MASK
                             | (it.billboard ? 1 : 0));
 
-                    short ty = (short) (COORD_SCALE * it.y);
+                    int ty = (int) (COORD_SCALE * it.y);
 
                     vertexItems.add(tx, ty, x1, y1, u1, v2);
                     vertexItems.add(tx, ty, x1, y2, u1, v1);
@@ -188,13 +189,13 @@ public final class SymbolBucket extends TextureBucket {
                     if (prev.texRegion != null && prev.texRegion != it.texRegion && prev.rotation != it.rotation)
                         break;
 
-                    short offsetX, offsetY;
+                    int offsetX, offsetY;
                     if (it.offset == null) {
                         offsetX = 0;
                         offsetY = 0;
                     } else {
-                        offsetX = (short) (((width / 2f) - (it.offset.x * width)) * COORD_SCALE);
-                        offsetY = (short) (((height / 2f) - (it.offset.y * height)) * COORD_SCALE);
+                        offsetX = (int) (((width / 2f) - (it.offset.x * width)) * COORD_SCALE);
+                        offsetY = (int) (((height / 2f) - (it.offset.y * height)) * COORD_SCALE);
                     }
 
                     float hw = width / 2f;
@@ -232,9 +233,9 @@ public final class SymbolBucket extends TextureBucket {
                     }
 
                     /* add vertices */
-                    short tx = (short) (((int) (COORD_SCALE * it.x) & LBIT_MASK
+                    int tx = (((int) (COORD_SCALE * it.x) & LBIT_MASK
                             | (it.billboard ? 1 : 0)) + offsetX);
-                    short ty = (short) ((COORD_SCALE * it.y) + offsetY);
+                    int ty = (int) ((COORD_SCALE * it.y) + offsetY);
 
                     vertexItems.add(tx, ty, points[0], points[1], u1, v2); // lower-left
                     vertexItems.add(tx, ty, points[2], points[3], u1, v1); // upper-left

--- a/vtm/src/org/oscim/renderer/bucket/TextBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/TextBucket.java
@@ -161,19 +161,19 @@ public class TextBucket extends TextureBucket {
     protected void addItem(TextItem it,
                            float width, float height, float x, float y) {
         /* texture coordinates */
-        short u1 = (short) (COORD_SCALE * x);
-        short v1 = (short) (COORD_SCALE * y);
-        short u2 = (short) (COORD_SCALE * (x + width));
-        short v2 = (short) (COORD_SCALE * (y + height));
+        int u1 = (int) (COORD_SCALE * x);
+        int v1 = (int) (COORD_SCALE * y);
+        int u2 = (int) (COORD_SCALE * (x + width));
+        int v2 = (int) (COORD_SCALE * (y + height));
 
-        short x1, x2, x3, x4, y1, y3, y2, y4;
+        int x1, x2, x3, x4, y1, y3, y2, y4;
         float hw = width / 2.0f;
         float hh = height / 2.0f;
         if (it.text.caption) {
-            x1 = x3 = (short) (COORD_SCALE * -hw);
-            x2 = x4 = (short) (COORD_SCALE * hw);
-            y1 = y2 = (short) (COORD_SCALE * (it.text.dy + hh));
-            y3 = y4 = (short) (COORD_SCALE * (it.text.dy - hh));
+            x1 = x3 = (int) (COORD_SCALE * -hw);
+            x2 = x4 = (int) (COORD_SCALE * hw);
+            y1 = y2 = (int) (COORD_SCALE * (it.text.dy + hh));
+            y3 = y4 = (int) (COORD_SCALE * (it.text.dy - hh));
         } else {
             float vx = it.x1 - it.x2;
             float vy = it.y1 - it.y2;
@@ -191,23 +191,23 @@ public class TextBucket extends TextureBucket {
             vy *= hw;
 
             /* top-left */
-            x1 = (short) (COORD_SCALE * (vx - ux));
-            y1 = (short) (COORD_SCALE * (vy - uy));
+            x1 = (int) (COORD_SCALE * (vx - ux));
+            y1 = (int) (COORD_SCALE * (vy - uy));
             /* top-right */
-            x2 = (short) (COORD_SCALE * (-vx - ux));
-            y2 = (short) (COORD_SCALE * (-vy - uy));
+            x2 = (int) (COORD_SCALE * (-vx - ux));
+            y2 = (int) (COORD_SCALE * (-vy - uy));
             /* bot-right */
-            x4 = (short) (COORD_SCALE * (-vx + ux2));
-            y4 = (short) (COORD_SCALE * (-vy + uy2));
+            x4 = (int) (COORD_SCALE * (-vx + ux2));
+            y4 = (int) (COORD_SCALE * (-vy + uy2));
             /* bot-left */
-            x3 = (short) (COORD_SCALE * (vx + ux2));
-            y3 = (short) (COORD_SCALE * (vy + uy2));
+            x3 = (int) (COORD_SCALE * (vx + ux2));
+            y3 = (int) (COORD_SCALE * (vy + uy2));
         }
 
         /* add vertices */
         int tmp = (int) (COORD_SCALE * it.x) & LBIT_MASK;
-        short tx = (short) (tmp | (it.text.caption ? 1 : 0));
-        short ty = (short) (COORD_SCALE * it.y);
+        int tx = (tmp | (it.text.caption ? 1 : 0));
+        int ty = (int) (COORD_SCALE * it.y);
 
         vertexItems.add(tx, ty, x1, y1, u1, v2);
         vertexItems.add(tx, ty, x3, y3, u1, v1);

--- a/vtm/src/org/oscim/renderer/bucket/TextureBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/TextureBucket.java
@@ -26,6 +26,7 @@ import org.oscim.renderer.bucket.TextureItem.TexturePool;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.Buffer;
 import java.nio.ShortBuffer;
 
 import static org.oscim.backend.GLAdapter.gl;
@@ -67,7 +68,7 @@ public class TextureBucket extends RenderBucket {
     public boolean fixed;
 
     @Override
-    protected void compile(ShortBuffer vboData, ShortBuffer iboData) {
+    protected void compile(Buffer vboData, ShortBuffer iboData) {
 
         for (TextureItem t = textures; t != null; t = t.next)
             t.upload();


### PR DESCRIPTION
To achieve #472, we need to consider all layers. But layers, which aren't rendered based on tiles, only have a limited [visible range](https://github.com/mapsforge/vtm/blob/master/vtm/src/org/oscim/renderer/bucket/LineBucket.java#L38) (`TileGridLayer`, `LabelLayer`, etc.). Especially the `PathLayer` needs to be extended to guarantee that paths (e.g. of Graphhopper routing) are displayed.

Example GL_SHORT:
![short_bucket](https://user-images.githubusercontent.com/18537755/38777883-f4efcbac-40af-11e8-8f29-af0aac26846b.png)

Example GL_INT:
![int_bucket](https://user-images.githubusercontent.com/18537755/38777882-f154837a-40af-11e8-8e23-a1300d12ab08.png)

I know this is a heavy intervention in core code, but it has its benefits :)
If there're any questions on code, can ask of course.