### PR TITLE
BuildingLayer: introduce ZoomLimiter (#503)

### DIFF
--- a/vtm/src/org/oscim/layers/tile/ZoomLimiter.java
+++ b/vtm/src/org/oscim/layers/tile/ZoomLimiter.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2018 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.layers.tile;
+
+public class ZoomLimiter {
+
+    private int mMaxZoom;
+    private int mMinZoom;
+
+    /**
+     * Indicates that layer isn't processed again over zoom limit
+     */
+    private int mZoomLimit;
+
+    private TileManager mTileManager;
+
+    /**
+     * A layer which avoid rendering tiles over a specific zoom limit
+     */
+    public ZoomLimiter(TileManager tileManager, int minZoom, int maxZoom, int zoomLimit) {
+        if (zoomLimit < minZoom || zoomLimit > maxZoom) {
+            throw new IllegalArgumentException("Zoom limit is out of range");
+        }
+        mTileManager = tileManager;
+        mZoomLimit = zoomLimit;
+        mMinZoom = minZoom;
+        mMaxZoom = maxZoom;
+    }
+
+    public void addZoomLimit() {
+        if (mZoomLimit < mMaxZoom && mZoomLimit >= mMinZoom) {
+            // Request tiles of mZoomLimit.
+            mTileManager.addZoomLimit(mZoomLimit);
+        }
+    }
+
+    public void removeZoomLimit() {
+        if (mZoomLimit < mMaxZoom && mZoomLimit >= mMinZoom) {
+            mTileManager.removeZoomLimit(mZoomLimit);
+        }
+    }
+
+    /**
+     * Get tile of zoom limit if zoomLevel is larger than limit
+     */
+    public MapTile getTile(MapTile t) {
+        if (t.zoomLevel > mZoomLimit && t.zoomLevel <= mMaxZoom) {
+            int diff = t.zoomLevel - mZoomLimit;
+            return mTileManager.getTile(t.tileX >> diff, t.tileY >> diff, mZoomLimit);
+        }
+        return t;
+    }
+
+    public int getMaxZoom() {
+        return mMaxZoom;
+    }
+
+    public int getMinZoom() {
+        return mMinZoom;
+    }
+
+    /*public TileManager getTileManager() {
+        return mTileManager;
+    }*/
+
+    public int getZoomLimit() {
+        return mZoomLimit;
+    }
+
+    public interface IZoomLimiter {
+        /**
+         * Sets the ZoomLimiter
+         */
+        void setZoomLimiter(ZoomLimiter zoomLimiter);
+
+        /**
+         * Add zoom limit to tile manager to load these tiles
+         */
+        void addZoomLimit();
+
+        /**
+         * Remove zoom limit
+         */
+        void removeZoomLimit();
+
+    }
+}

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2018 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -21,6 +22,7 @@ import org.oscim.layers.tile.MapTile;
 import org.oscim.layers.tile.TileDistanceSort;
 import org.oscim.layers.tile.TileRenderer;
 import org.oscim.layers.tile.TileSet;
+import org.oscim.layers.tile.ZoomLimiter;
 import org.oscim.renderer.ExtrusionRenderer;
 import org.oscim.renderer.GLViewport;
 import org.oscim.renderer.MapRenderer;
@@ -28,6 +30,9 @@ import org.oscim.renderer.bucket.ExtrusionBuckets;
 import org.oscim.renderer.bucket.RenderBuckets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static java.lang.System.currentTimeMillis;
 import static org.oscim.layers.tile.MapTile.State.NEW_DATA;
@@ -40,8 +45,7 @@ public class BuildingRenderer extends ExtrusionRenderer {
     private final TileRenderer mTileRenderer;
     private final TileSet mTileSet;
 
-    private final int mZoomMin;
-    private final int mZoomMax;
+    private final ZoomLimiter mZoomLimiter;
 
     private final float mFadeInTime = 250;
     private final float mFadeOutTime = 400;
@@ -49,12 +53,11 @@ public class BuildingRenderer extends ExtrusionRenderer {
     private long mAnimTime;
     private boolean mShow;
 
-    public BuildingRenderer(TileRenderer tileRenderer, int zoomMin, int zoomMax,
+    public BuildingRenderer(TileRenderer tileRenderer, ZoomLimiter zoomLimiter,
                             boolean mesh, boolean alpha) {
         super(mesh, alpha);
 
-        mZoomMax = zoomMax;
-        mZoomMin = zoomMin;
+        mZoomLimiter = zoomLimiter;
         mTileRenderer = tileRenderer;
         mTileSet = new TileSet();
     }
@@ -69,7 +72,7 @@ public class BuildingRenderer extends ExtrusionRenderer {
     @Override
     public void update(GLViewport v) {
 
-        int diff = (v.pos.zoomLevel - mZoomMin);
+        int diff = (v.pos.zoomLevel - mZoomLimiter.getMinZoom());
 
         /* if below min zoom or already faded out */
         if (diff < -1) {
@@ -106,9 +109,9 @@ public class BuildingRenderer extends ExtrusionRenderer {
             return;
         }
 
-        mTileRenderer.getVisibleTiles(mTileSet);
+        Integer zoom = mTileRenderer.getVisibleTiles(mTileSet, true);
 
-        if (mTileSet.cnt == 0) {
+        if (mTileSet.cnt == 0 || zoom == null) {
             mTileRenderer.releaseTiles(mTileSet);
             setReady(false);
             return;
@@ -126,9 +129,8 @@ public class BuildingRenderer extends ExtrusionRenderer {
         boolean compiled = false;
 
         int activeTiles = 0;
-        int zoom = tiles[0].zoomLevel;
 
-        if (zoom >= mZoomMin && zoom <= mZoomMax) {
+        if (zoom <= mZoomLimiter.getZoomLimit() && zoom >= mZoomLimiter.getMinZoom()) {
             /* TODO - if tile is not available try parent or children */
 
             for (int i = 0; i < mTileSet.cnt; i++) {
@@ -143,15 +145,16 @@ public class BuildingRenderer extends ExtrusionRenderer {
                     compiled = true;
                 }
             }
-        }
-        /*else if (zoom == mZoomMax + 1) {
-            // special case for s3db: render from parent tiles
+        } else if (zoom > mZoomLimiter.getZoomLimit() && zoom <= mZoomLimiter.getMaxZoom()) {
+            // render from zoom limit tile, and avoid doubles
+            Set<MapTile> hashTiles = new HashSet<>();
             for (int i = 0; i < mTileSet.cnt; i++) {
-                MapTile t = tiles[i].node.parent();
+                hashTiles.add(mZoomLimiter.getTile(tiles[i]));
+            }
 
-                if (t == null)
-                    continue;
+            hashTiles.remove(null); // Remove possible null value
 
+            for (MapTile t : hashTiles) {
                 ExtrusionBuckets ebs = getBuckets(t);
                 if (ebs == null)
                     continue;
@@ -164,8 +167,7 @@ public class BuildingRenderer extends ExtrusionRenderer {
                     compiled = true;
                 }
             }
-        }*/
-        else if (zoom == mZoomMin - 1) {
+        } else if (zoom == mZoomLimiter.getMinZoom() - 1) {
             /* check if proxy children are ready */
             for (int i = 0; i < mTileSet.cnt; i++) {
                 MapTile t = tiles[i];

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
@@ -19,6 +19,7 @@ package org.oscim.layers.tile.buildings;
 import org.oscim.layers.tile.TileLayer;
 import org.oscim.layers.tile.TileManager;
 import org.oscim.layers.tile.TileRenderer;
+import org.oscim.layers.tile.ZoomLimiter;
 import org.oscim.map.Map;
 import org.oscim.renderer.GLViewport;
 import org.oscim.renderer.LayerRenderer;
@@ -49,7 +50,7 @@ public class S3DBTileLayer extends TileLayer {
      */
     public S3DBTileLayer(Map map, TileSource tileSource, boolean fxaa, boolean ssao) {
         super(map, new TileManager(map, MAX_CACHE));
-        setRenderer(new S3DBTileRenderer(fxaa, ssao));
+        setRenderer(new S3DBTileRenderer(getManager(), fxaa, ssao));
 
         mTileManager.setZoomLevel(MIN_ZOOM, MAX_ZOOM);
         mTileSource = tileSource;
@@ -64,8 +65,8 @@ public class S3DBTileLayer extends TileLayer {
     public static class S3DBTileRenderer extends TileRenderer {
         LayerRenderer mRenderer;
 
-        public S3DBTileRenderer(boolean fxaa, boolean ssao) {
-            mRenderer = new BuildingRenderer(this, MIN_ZOOM, MAX_ZOOM, true, false);
+        public S3DBTileRenderer(TileManager manager, boolean fxaa, boolean ssao) {
+            mRenderer = new BuildingRenderer(this, new ZoomLimiter(manager, MIN_ZOOM, MAX_ZOOM, MIN_ZOOM), true, false);
 
             if (fxaa || ssao) {
                 Mode mode = Mode.FXAA;

--- a/vtm/src/org/oscim/map/Layers.java
+++ b/vtm/src/org/oscim/map/Layers.java
@@ -3,6 +3,7 @@
  * Copyright 2016-2017 devemux86
  * Copyright 2016 Andrey Novikov
  * Copyright 2017 Longri
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -24,6 +25,7 @@ import org.oscim.event.GestureListener;
 import org.oscim.event.MotionEvent;
 import org.oscim.layers.GroupLayer;
 import org.oscim.layers.Layer;
+import org.oscim.layers.tile.ZoomLimiter;
 import org.oscim.map.Map.InputListener;
 import org.oscim.map.Map.UpdateListener;
 import org.oscim.renderer.LayerRenderer;
@@ -78,6 +80,10 @@ public final class Layers extends AbstractList<Layer> {
             mMap.events.bind((UpdateListener) layer);
         if (layer instanceof InputListener)
             mMap.input.bind((InputListener) layer);
+        // add zoom limit to tile manager
+        if (layer instanceof ZoomLimiter.IZoomLimiter) {
+            ((ZoomLimiter.IZoomLimiter) layer).addZoomLimit();
+        }
 
         // bind added group layer
         if (layer instanceof GroupLayer) {
@@ -87,6 +93,9 @@ public final class Layers extends AbstractList<Layer> {
                     mMap.events.bind((UpdateListener) gl);
                 if (gl instanceof InputListener)
                     mMap.input.bind((InputListener) gl);
+                if (gl instanceof ZoomLimiter.IZoomLimiter) {
+                    ((ZoomLimiter.IZoomLimiter) gl).addZoomLimit();
+                }
             }
         }
 
@@ -128,6 +137,10 @@ public final class Layers extends AbstractList<Layer> {
             mMap.events.unbind((UpdateListener) remove);
         if (remove instanceof InputListener)
             mMap.input.unbind((InputListener) remove);
+        // remove zoom limit from tile manager
+        if (remove instanceof ZoomLimiter.IZoomLimiter) {
+            ((ZoomLimiter.IZoomLimiter) remove).removeZoomLimit();
+        }
 
         // unbind removed group layer
         if (remove instanceof GroupLayer) {
@@ -137,6 +150,9 @@ public final class Layers extends AbstractList<Layer> {
                     mMap.events.unbind((UpdateListener) gl);
                 if (gl instanceof InputListener)
                     mMap.input.unbind((InputListener) gl);
+                if (gl instanceof ZoomLimiter.IZoomLimiter) {
+                    ((ZoomLimiter.IZoomLimiter) gl).removeZoomLimit();
+                }
             }
         }
 


### PR DESCRIPTION
See #503 
There're some core changes, but I think it's too circuitous to add extra classes. Maybe can add extra branch to test.
I'm very much in favor to leave name `zoomLimit` so there's no confusion with `overzoom` as they haven't the same value. As I said, this also can be attached to non-overzoomed layers/sources.