### PR TITLE
VectorLayer / PathLayer: clip to max GL.Short resolution

### DIFF
--- a/vtm/src/org/oscim/layers/PathLayer.java
+++ b/vtm/src/org/oscim/layers/PathLayer.java
@@ -5,6 +5,7 @@
  * Copyright 2016 Bezzu
  * Copyright 2016 Pedinel
  * Copyright 2017 Andrey Novikov
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -35,6 +36,7 @@ import org.oscim.event.MotionEvent;
 import org.oscim.map.Map;
 import org.oscim.renderer.BucketRenderer;
 import org.oscim.renderer.GLViewport;
+import org.oscim.renderer.MapRenderer;
 import org.oscim.renderer.bucket.LineBucket;
 import org.oscim.renderer.bucket.RenderBuckets;
 import org.oscim.theme.styles.LineStyle;
@@ -244,27 +246,27 @@ public class PathLayer extends Layer implements GestureListener {
                 return;
 
             /* keep position to render relative to current state */
-            mMapPosition.copy(t.pos);
+            mMapPosition.copy(t.position);
 
             /* compile new layers */
-            buckets.set(t.bucket.get());
+            buckets.set(t.buckets.get());
             compile();
         }
     }
 
     final static class Task {
-        RenderBuckets bucket = new RenderBuckets();
-        MapPosition pos = new MapPosition();
+        final RenderBuckets buckets = new RenderBuckets();
+        final MapPosition position = new MapPosition();
     }
 
     final class Worker extends SimpleWorker<Task> {
 
-        // limit coords
-        private final int max = 2048;
+        // limit coords to maximum resolution of GL.Short
+        private final int MAX_CLIP = (int) ((Tile.SIZE * Tile.TILE_SIZE_MULTIPLE) / MapRenderer.COORD_SCALE) - 1;
 
         public Worker(Map map) {
             super(map, 0, new Task(), new Task());
-            mClipper = new LineClipper(-max, -max, max, max);
+            mClipper = new LineClipper(-MAX_CLIP, -MAX_CLIP, MAX_CLIP, MAX_CLIP);
             mPPoints = new float[0];
         }
 
@@ -320,8 +322,8 @@ public class PathLayer extends Layer implements GestureListener {
 
             }
             if (size == 0) {
-                if (task.bucket.get() != null) {
-                    task.bucket.clear();
+                if (task.buckets.get() != null) {
+                    task.buckets.clear();
                     mMap.render();
                 }
                 return true;
@@ -330,22 +332,22 @@ public class PathLayer extends Layer implements GestureListener {
             LineBucket ll;
 
             if (mLineStyle.stipple == 0 && mLineStyle.texture == null)
-                ll = task.bucket.getLineBucket(0);
+                ll = task.buckets.getLineBucket(0);
             else
-                ll = task.bucket.getLineTexBucket(0);
+                ll = task.buckets.getLineTexBucket(0);
 
             ll.line = mLineStyle;
 
             //ll.scale = ll.line.width;
 
-            mMap.getMapPosition(task.pos);
+            mMap.getMapPosition(task.position);
 
-            int zoomlevel = task.pos.zoomLevel;
-            task.pos.scale = 1 << zoomlevel;
+            int zoomlevel = task.position.zoomLevel;
+            task.position.scale = 1 << zoomlevel;
 
-            double mx = task.pos.x;
-            double my = task.pos.y;
-            double scale = Tile.SIZE * task.pos.scale;
+            double mx = task.position.x;
+            double my = task.position.y;
+            double scale = Tile.SIZE * task.position.scale;
 
             // flip around dateline
             int flip = 0;
@@ -437,7 +439,7 @@ public class PathLayer extends Layer implements GestureListener {
 
         @Override
         public void cleanup(Task task) {
-            task.bucket.clear();
+            task.buckets.clear();
         }
 
         private int addPoint(float[] points, int i, int x, int y) {

--- a/vtm/src/org/oscim/layers/vector/AbstractVectorLayer.java
+++ b/vtm/src/org/oscim/layers/vector/AbstractVectorLayer.java
@@ -1,8 +1,26 @@
+/*
+ * Copyright 2014-2015 Hannes Janetzek
+ * Copyright 2018 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.layers.vector;
 
 import org.oscim.core.Box;
 import org.oscim.core.GeometryBuffer;
 import org.oscim.core.MapPosition;
+import org.oscim.core.Tile;
 import org.oscim.event.Event;
 import org.oscim.layers.Layer;
 import org.oscim.map.Map;
@@ -10,6 +28,7 @@ import org.oscim.map.Map.UpdateListener;
 import org.oscim.map.Viewport;
 import org.oscim.renderer.BucketRenderer;
 import org.oscim.renderer.GLViewport;
+import org.oscim.renderer.MapRenderer;
 import org.oscim.renderer.bucket.RenderBuckets;
 import org.oscim.utils.async.SimpleWorker;
 import org.oscim.utils.geom.TileClipper;
@@ -21,8 +40,11 @@ public abstract class AbstractVectorLayer<T> extends Layer implements UpdateList
 
     protected final static double UNSCALE_COORD = 4;
 
+    // limit coords to maximum resolution of GL.Short
+    private final int MAX_CLIP = (int) ((Tile.SIZE * Tile.TILE_SIZE_MULTIPLE) / MapRenderer.COORD_SCALE) - 1;
+
     protected final GeometryBuffer mGeom = new GeometryBuffer(128, 4);
-    protected final TileClipper mClipper = new TileClipper(-1024, -1024, 1024, 1024);
+    protected final TileClipper mClipper = new TileClipper(-MAX_CLIP, -MAX_CLIP, MAX_CLIP, MAX_CLIP);
 
     protected final Worker mWorker;
     protected long mUpdateDelay = 50;

--- a/vtm/src/org/oscim/renderer/bucket/LineBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/LineBucket.java
@@ -35,7 +35,7 @@ import static org.oscim.renderer.MapRenderer.COORD_SCALE;
 
 /**
  * Note:
- * Coordinates must be in range [-4096..4096] and the maximum
+ * Coordinates must be in range [-4096..4095] and the maximum
  * resolution for coordinates is 0.25 as points will be converted
  * to fixed point values.
  */


### PR DESCRIPTION
In JTS `PathLayer` now isn't cropped any more. Seems like another internal scale is used there.

Basic `PathLayer` unfortunately still crops the paths, but does better than before. Setting `MapRenderer.COORD_SCALE =  4f`, would solve this.
Minor refactors in basic `PathLayer` are done to match better the scheme of `AbstractVectorLayer`
See #343, #527 