### PR TITLE
LineTexBucket: fix out of short range (#220, #529)

### DIFF
--- a/vtm/resources/assets/shaders/linetex_layer_tex.glsl
+++ b/vtm/resources/assets/shaders/linetex_layer_tex.glsl
@@ -5,12 +5,13 @@ uniform mat4 u_mvp;
 uniform vec4 u_color;
 uniform float u_pscale;
 uniform float u_width;
-attribute vec4 a_pos0;
+attribute vec4 a_pos0; // posX, posY, extrusX, extrusY
 attribute vec4 a_pos1;
-attribute vec2 a_len0;
+attribute vec2 a_len0; // lineLength, distance
 attribute vec2 a_len1;
-attribute float a_flip;
+attribute float a_flip; // flip state
 varying vec2 v_st;
+varying float dist;
 void
 main(){
   vec4 pos;
@@ -18,11 +19,13 @@ main(){
     //    vec2 dir = u_width * a_pos0.zw;
     pos = vec4(a_pos0.xy + (u_width * a_pos0.zw), 0.0, 1.0);
     v_st = vec2(a_len0.x / u_pscale, 1.0);
+    dist = (a_len0.y + 32768) / u_pscale; // 32768 == -Short.MIN_VALUE
   }
   else {
     //    vec2 dir = u_width * a_pos1.zw;
     pos = vec4(a_pos1.xy - (u_width * a_pos1.zw), 0.0, 1.0);
     v_st = vec2(a_len1.x / u_pscale, -1.0);
+    dist = (a_len1.y + 32768) / u_pscale; // 32768 == -Short.MIN_VALUE
   }
   gl_Position = u_mvp * pos;
 }
@@ -39,20 +42,26 @@ uniform vec4 u_color;
 uniform vec4 u_bgcolor;
 uniform float u_pwidth;
 varying vec2 v_st;
+varying float dist;
 uniform sampler2D tex;
 uniform float u_mode;
 void
 main(){
   if (u_mode >= 1.0) {
+    /* Dash array or texture */
     float step = 2.0;
     if (u_mode == 2.0) { // dashed texture
       step = 1.0;
     }
-    vec4 c=texture2D(tex,vec2(abs(mod(v_st.s+1.0,step)),(v_st.t+1.0)*0.5));
-    float fuzz=fwidth(c.a);
-    gl_FragColor=(c * u_color) * smoothstep(0.5-fuzz,0.5+fuzz,c.a);
+    float offset = abs(mod(v_st.s - dist, step));
+    // Use distance to next vertex and add offset to smooth transition at vertex
+    vec4 c = texture2D(tex, vec2(mod(offset + dist + 1.0, step), (v_st.t + 1.0) * 0.5));
+    float fuzz = fwidth(c.a);
+    gl_FragColor = (c * u_color) * smoothstep(0.5 - fuzz, 0.5 + fuzz, c.a);
   }
   else {
+    /* Without dash or texture */
+
     /* distance on perpendicular to the line */
     float dist = abs(v_st.t);
     float fuzz = fwidth(v_st.t);


### PR DESCRIPTION
As I mentioned in #220 the lineLength often was out of short range.
So shapes weren't displayed correctly or reversed.

I added a `distance` value to shader, which now replaces the position calculations of texture. `lineLength` is further needed to avoid minor artifacts at vertices.

In rarely special cases the `distance` could have a value greater than the shorts range as it's an euclidean distance out of two short values. So I added a workaround to split line in those cases.

Works fine with #529, too.