### PR TITLE
Clarify Translucent flag (#181)

### DIFF
--- a/vtm/src/org/oscim/backend/GLAdapter.java
+++ b/vtm/src/org/oscim/backend/GLAdapter.java
@@ -49,8 +49,8 @@ public class GLAdapter {
         GDX_DESKTOP_QUIRKS = CanvasAdapter.platform.isDesktop();
         GDX_WEBGL_QUIRKS = (CanvasAdapter.platform == Platform.WEBGL);
 
-        // Buildings translucency does not work on macOS, see #61
+        // Buildings rendering does not work on macOS, see #61
         if (CanvasAdapter.platform == Platform.MACOS)
-            BuildingLayer.TRANSLUCENT = false;
+            BuildingLayer.DRAW_COVERED = true;
     }
 }

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -47,7 +47,11 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     public final static int MIN_ZOOM = 17;
 
     public static boolean POST_AA = false;
-    public static boolean TRANSLUCENT = true;
+
+    /**
+     * Draw extrusions which are covered by others (especially if the side of extrusion is translucent).
+     */
+    public static boolean DRAW_COVERED = false;
 
     private static final Object BUILDING_DATA = BuildingLayer.class.getName();
 
@@ -84,7 +88,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
         mZoomLimiter = new ZoomLimiter(tileLayer.getManager(), zoomMin, zoomMax, zoomMin);
 
         mRenderer = new BuildingRenderer(tileLayer.tileRenderer(), mZoomLimiter,
-                mesh, !mesh && TRANSLUCENT); // alpha must be disabled for mesh renderer
+                mesh, mesh || DRAW_COVERED); // covered extrusions must be drawn for mesh renderer
         if (POST_AA)
             mRenderer = new OffscreenRenderer(Mode.SSAO_FXAA, mRenderer);
     }

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingRenderer.java
@@ -54,8 +54,8 @@ public class BuildingRenderer extends ExtrusionRenderer {
     private boolean mShow;
 
     public BuildingRenderer(TileRenderer tileRenderer, ZoomLimiter zoomLimiter,
-                            boolean mesh, boolean alpha) {
-        super(mesh, alpha);
+                            boolean mesh, boolean drawCovered) {
+        super(mesh, drawCovered);
 
         mZoomLimiter = zoomLimiter;
         mTileRenderer = tileRenderer;

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLayer.java
@@ -66,7 +66,7 @@ public class S3DBTileLayer extends TileLayer {
         LayerRenderer mRenderer;
 
         public S3DBTileRenderer(TileManager manager, boolean fxaa, boolean ssao) {
-            mRenderer = new BuildingRenderer(this, new ZoomLimiter(manager, MIN_ZOOM, MAX_ZOOM, MIN_ZOOM), true, false);
+            mRenderer = new BuildingRenderer(this, new ZoomLimiter(manager, MIN_ZOOM, MAX_ZOOM, MIN_ZOOM), true, true);
 
             if (fxaa || ssao) {
                 Mode mode = Mode.FXAA;

--- a/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
+++ b/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
@@ -32,7 +32,7 @@ import static org.oscim.renderer.MapRenderer.COORD_SCALE;
 public abstract class ExtrusionRenderer extends LayerRenderer {
     static final Logger log = LoggerFactory.getLogger(ExtrusionRenderer.class);
 
-    private final boolean mTranslucent;
+    private final boolean mDrawCovered; // draw extrusions which are covered by others.
     private final int mMode;
     private Shader mShader;
 
@@ -42,9 +42,9 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
 
     private float mZLimit = Float.MAX_VALUE;
 
-    public ExtrusionRenderer(boolean mesh, boolean alpha) {
+    public ExtrusionRenderer(boolean mesh, boolean drawCovered) {
         mMode = mesh ? 1 : 0;
-        mTranslucent = alpha;
+        mDrawCovered = drawCovered;
     }
 
     public static class Shader extends GLShader {
@@ -123,7 +123,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
 
         ExtrusionBuckets[] ebs = mExtrusionBucketSet;
 
-        if (mTranslucent) {
+        if (!mDrawCovered) {
             /* only draw to depth buffer */
             GLState.blend(false);
             gl.colorMask(false, false, false, false);
@@ -164,7 +164,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
             ebs[i].ibo.bind();
             ebs[i].vbo.bind();
 
-            if (!mTranslucent)
+            if (mDrawCovered)
                 setMatrix(s, v, ebs[i]);
 
             float alpha = mAlpha * getFade(ebs[i]);
@@ -192,7 +192,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
 
                 /* draw extruded outlines */
                 if (eb.idx[0] > 0) {
-                    if (mTranslucent) {
+                    if (!mDrawCovered) {
                         gl.depthFunc(GL.EQUAL);
                         setMatrix(s, v, ebs[i]);
                     }
@@ -212,7 +212,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
                     gl.drawElements(GL.TRIANGLES, eb.idx[1],
                             GL.UNSIGNED_SHORT, eb.off[1]);
 
-                    if (mTranslucent) {
+                    if (!mDrawCovered) {
                         /* drawing gl_lines with the same coordinates
                          * does not result in same depth values as
                          * polygons, so add offset and draw gl_lequal */
@@ -238,7 +238,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
             ebs[i] = null;
         }
 
-        if (!mTranslucent)
+        if (mDrawCovered)
             gl.depthMask(false);
 
         if (v.pos.zoomLevel < 18)
@@ -265,7 +265,7 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
         v.mvp.setValue(10, scale / 10);
         v.mvp.multiplyLhs(v.viewproj);
 
-        if (mTranslucent) {
+        if (!mDrawCovered) {
             /* should avoid z-fighting of overlapping
              * building from different tiles */
             int zoom = (1 << z);


### PR DESCRIPTION
In issue #181, the `Translucent` flag is declared as non functional:
But it has a meaning:
If switching flag value, other buildings are rendered behind them (only visible, if they are translucent).
To better view the effect, can increase `Viewport.MAX_TILT` and rewrite `default` theme and rewrite extrusions of buildings to:
```
<extrusion line-color="#ffd9d8d6" side-color="#66ecebe9" top-color="#eaf9f8f6" />
```
The extrusions only are rendered if they're covered by side walls, not by top faces.
To better understand I renamed the flag to `DRAW_COVERED` . _Translucent_ is confusing with alpha, transparency, opacity, etc.

BTW: I already implemented a function to adapt opacity of `BuildingLayer` and `S3DBLayer` (separate PR).