### PR TITLE
S3DBLayer: use transparency of extrusion style

### DIFF
--- a/vtm/src/org/oscim/backend/canvas/Color.java
+++ b/vtm/src/org/oscim/backend/canvas/Color.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
- * 
+ * Copyright 2018 Gustl22
+ *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  * 
  * This program is free software: you can redistribute it and/or modify it under the
@@ -113,6 +114,22 @@ public final class Color {
 
     public static int b(int color) {
         return ((color) & 0xff);
+    }
+
+    public static int setA(int color, int a) {
+        return ((a << 24) | (color & 0xffffff));
+    }
+
+    public static int setR(int color, int r) {
+        return ((r << 16) | (color & 0xff00ffff));
+    }
+
+    public static int setG(int color, int g) {
+        return ((g << 8) | (color & 0xffff00ff));
+    }
+
+    public static int setB(int color, int b) {
+        return (b | (color & 0xffffff00));
     }
 
     public static int parseColorComponents(String str) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -15,6 +15,7 @@
  */
 package org.oscim.layers.tile.buildings;
 
+import org.oscim.backend.canvas.Color;
 import org.oscim.core.Box;
 import org.oscim.core.GeometryBuffer;
 import org.oscim.core.MapElement;
@@ -44,6 +45,7 @@ public class S3DBLayer extends BuildingLayer {
 
     private final float TILE_SCALE = (ExtrusionUtils.REF_TILE_SIZE / (Tile.SIZE * COORD_SCALE));
 
+    private boolean mAdvancedTransparency = true;
     private boolean mColored = true;
 
     public S3DBLayer(Map map, VectorTileLayer tileLayer) {
@@ -60,6 +62,17 @@ public class S3DBLayer extends BuildingLayer {
 
     public void setColored(boolean colored) {
         mColored = colored;
+    }
+
+    public boolean isTransparent() {
+        return mAdvancedTransparency;
+    }
+
+    /**
+     * @param isTransparent if true it adopts transparency of extrusion styles
+     */
+    public void setTransparent(boolean isTransparent) {
+        mAdvancedTransparency = isTransparent;
     }
 
     @Override
@@ -137,6 +150,9 @@ public class S3DBLayer extends BuildingLayer {
 
         if (bColor == null) {
             bColor = extrusion.colorTop;
+        } else if (mAdvancedTransparency) {
+            // Multiply alpha channel of extrusion style
+            bColor = ExtrusionStyle.blendAlpha(bColor, Color.aToFloat(extrusion.colorTop));
         }
 
         // Scale x, y and z axis
@@ -238,7 +254,13 @@ public class S3DBLayer extends BuildingLayer {
 
         GeometryBuffer gElement = new GeometryBuffer(element);
         GeometryBuffer specialParts = null;
-        if (roofColor == null) roofColor = buildingColor;
+        if (roofColor == null)
+            roofColor = buildingColor;
+        else if (mAdvancedTransparency) {
+            // For simplicity use transparency of building, which is identical in nearly all cases
+            roofColor = ExtrusionStyle.blendAlpha(roofColor, Color.aToFloat(buildingColor));
+        }
+
         boolean success = false;
 
         switch (v) {

--- a/vtm/src/org/oscim/theme/styles/ExtrusionStyle.java
+++ b/vtm/src/org/oscim/theme/styles/ExtrusionStyle.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -54,6 +55,19 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
         fillColors(colorSide, colorTop, colorLine, colors);
 
         this.defaultHeight = b.defaultHeight;
+    }
+
+    public static int blendAlpha(int color, float alpha) {
+        if (alpha == 1.0f) return color;
+        return Color.setA(color, (int) (Color.a(color) * alpha));
+    }
+
+    public static void blendAlpha(float colors[], float alpha) {
+        if (alpha != 1.0f) {
+            for (int i = 0; i < colors.length; i++) {
+                colors[i] = alpha * colors[i];
+            }
+        }
     }
 
     public static void fillColors(int side, int top, int line, float[] colors) {


### PR DESCRIPTION
I first played with making transparency available for the whole layer (with BuildingLayer, too), but this leads to inconsistencies. So the colored parts now blending the alpha channel of their extrusion style. Blending because of possible already transparent colors in S3DB.

So every building transparency can be set individually via render themes.