### PR TITLE
Support display density for WebGL

### DIFF
--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -72,7 +72,8 @@ class GwtMap extends GdxMap {
         GwtGdxGraphics.init();
         GdxAssets.init("");
         CanvasAdapter.textScale = 0.7f;
-        CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * CanvasAdapter.DEFAULT_DPI);
+        // 96dpi is the CSS reference-pixel density, see https://www.w3.org/TR/css3-values/#reference-pixel
+        CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * 96.0 * 2);
         Tile.SIZE = Tile.calculateTileSize();
 
         log.debug("GLAdapter.init");

--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -20,12 +20,14 @@ package org.oscim.web.client;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
+import com.badlogic.gdx.backends.gwt.GwtGraphics;
 
 import org.oscim.backend.AssetAdapter;
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.GL;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.MapPosition;
+import org.oscim.core.Tile;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
 import org.oscim.gdx.client.GwtGdxGraphics;
@@ -70,6 +72,8 @@ class GwtMap extends GdxMap {
         GwtGdxGraphics.init();
         GdxAssets.init("");
         CanvasAdapter.textScale = 0.7f;
+        CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * CanvasAdapter.DEFAULT_DPI);
+        Tile.SIZE = Tile.calculateTileSize();
 
         log.debug("GLAdapter.init");
         GLAdapter.init((GL) Gdx.graphics.getGL20());

--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -72,8 +72,7 @@ class GwtMap extends GdxMap {
         GwtGdxGraphics.init();
         GdxAssets.init("");
         CanvasAdapter.textScale = 0.7f;
-        // 96dpi is the CSS reference-pixel density, see https://www.w3.org/TR/css3-values/#reference-pixel
-        CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * 96.0 * 2);
+        CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * CanvasAdapter.DEFAULT_DPI);
         Tile.SIZE = Tile.calculateTileSize();
 
         log.debug("GLAdapter.init");

--- a/vtm-web/src/org/oscim/gdx/emu/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/vtm-web/src/org/oscim/gdx/emu/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -71,11 +71,8 @@ public class GwtGraphics implements Graphics {
     float time = 0;
     int frames;
     GwtApplicationConfiguration config;
-    double pixelRatio;
 
     public GwtGraphics(Panel root, GwtApplicationConfiguration config) {
-        this.pixelRatio = getDevicePixelRatioJSNI();
-
         if (config.canvasId == null) {
             Canvas canvasWidget = Canvas.createIfSupported();
             if (canvasWidget == null)
@@ -85,8 +82,8 @@ public class GwtGraphics implements Graphics {
         } else {
             canvas = (CanvasElement) Document.get().getElementById(config.canvasId);
 
-            canvas.setWidth((int) (config.width * pixelRatio));
-            canvas.setHeight((int) (config.height * pixelRatio));
+            canvas.setWidth((int) (config.width));
+            canvas.setHeight((int) (config.height));
 
             canvas.getStyle().setWidth(config.width, Style.Unit.PX);
             canvas.getStyle().setHeight(config.height, Style.Unit.PX);

--- a/vtm-web/src/org/oscim/gdx/emu/com/badlogic/gdx/backends/gwt/GwtGraphics.java
+++ b/vtm-web/src/org/oscim/gdx/emu/com/badlogic/gdx/backends/gwt/GwtGraphics.java
@@ -71,8 +71,11 @@ public class GwtGraphics implements Graphics {
     float time = 0;
     int frames;
     GwtApplicationConfiguration config;
+    double pixelRatio;
 
     public GwtGraphics(Panel root, GwtApplicationConfiguration config) {
+        this.pixelRatio = getDevicePixelRatioJSNI();
+
         if (config.canvasId == null) {
             Canvas canvasWidget = Canvas.createIfSupported();
             if (canvasWidget == null)
@@ -82,8 +85,8 @@ public class GwtGraphics implements Graphics {
         } else {
             canvas = (CanvasElement) Document.get().getElementById(config.canvasId);
 
-            canvas.setWidth((int) (config.width));
-            canvas.setHeight((int) (config.height));
+            canvas.setWidth((int) (config.width * pixelRatio));
+            canvas.setHeight((int) (config.height * pixelRatio));
 
             canvas.getStyle().setWidth(config.width, Style.Unit.PX);
             canvas.getStyle().setHeight(config.height, Style.Unit.PX);


### PR DESCRIPTION
Set the display density using `window.devicePixelRatio`.