### PR TITLE
ExtrusionRenderer: Fix translucency for meshes

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -52,8 +52,10 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     public static boolean POST_AA = false;
 
     /**
-     * Don't draw extrusions which are covered by others.
-     * Especially if the side of extrusion is translucent.
+     * Let vanish extrusions/meshes which are covered by others.
+     * {@link org.oscim.renderer.bucket.RenderBucket#EXTRUSION}: roofs are always translucent.
+     *
+     * To better notice the difference, reduce the alpha value of extrusion colors in themes.
      */
     public static boolean TRANSLUCENT = true;
 
@@ -100,7 +102,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
 
         // Covered extrusions must be drawn for mesh renderer
         mRenderer = new BuildingRenderer(tileLayer.tileRenderer(), mZoomLimiter,
-                mesh, !mesh && TRANSLUCENT);
+                mesh, TRANSLUCENT);
         if (POST_AA)
             mRenderer = new OffscreenRenderer(Mode.SSAO_FXAA, mRenderer);
     }

--- a/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
+++ b/vtm/src/org/oscim/renderer/ExtrusionRenderer.java
@@ -2,6 +2,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2017 Izumi Kawashima
  * Copyright 2017 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -231,6 +232,11 @@ public abstract class ExtrusionRenderer extends LayerRenderer {
 
                 /* draw triangle meshes */
                 if (eb.idx[4] > 0) {
+                    if (mTranslucent) {
+                        gl.depthFunc(GL.EQUAL);
+                        setMatrix(s, v, ebs[i]);
+                    }
+
                     gl.drawElements(GL.TRIANGLES, eb.idx[4],
                             GL.UNSIGNED_SHORT, eb.off[4]);
                 }


### PR DESCRIPTION
This fix let enable translucency for meshes, too. In advance, this reduces flickering at some S3DB buildings.

Attention: this should be tested! I did not check all code dependencies...but I didn't notice any regression.