### PR TITLE
Overzoom: separate GeometryType.POINT

### DIFF
--- a/vtm/src/org/oscim/tiling/OverzoomDataSink.java
+++ b/vtm/src/org/oscim/tiling/OverzoomDataSink.java
@@ -46,7 +46,7 @@ class OverzoomDataSink implements ITileDataSink {
 
     @Override
     public void process(MapElement element) {
-        if (element.isBuilding() || element.isBuildingPart()) {
+        if (element.isBuilding() || element.isBuildingPart() || element.isPoint()) {
             if (!separator.separate(element))
                 return;
         } else {

--- a/vtm/src/org/oscim/utils/geom/TileSeparator.java
+++ b/vtm/src/org/oscim/utils/geom/TileSeparator.java
@@ -16,8 +16,13 @@
 package org.oscim.utils.geom;
 
 import org.oscim.core.GeometryBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TileSeparator {
+
+    static final Logger log = LoggerFactory.getLogger(TileSeparator.class);
+
     private float xmin;
     private float xmax;
     private float ymin;
@@ -38,42 +43,56 @@ public class TileSeparator {
     }
 
     /**
-     * Separates a poly geometry from tile (doesn't clip it).
+     * Separates geometry from tile without clipping it. Points and polys only.
      *
      * @param geom the geometry to be separated
      * @return true if geometry is inside the tile, false otherwise
      */
     public boolean separate(GeometryBuffer geom) {
-        if (!geom.isPoly())
-            return false;
 
-        int pointPos = 0;
+        if (geom.isPoint()) {
+            if (geom.index.length > 1 && geom.index[0] == 2) {
+                float cx = geom.points[0];
+                float cy = geom.points[1];
 
-        for (int indexPos = 0, n = geom.index.length; indexPos < n; indexPos++) {
-            int len = geom.index[indexPos];
-            if (len < 0)
-                break;
-
-            if (len < 6) {
-                pointPos += len;
-                continue;
-            }
-
-            int end = pointPos + len;
-
-            for (int i = pointPos; i < end; ) {
-                float cx = geom.points[i++];
-                float cy = geom.points[i++];
-
-                if (cx >= xmin && cx < xmax && cy >= ymin && cy < ymax) {
-                    /* current is inside */
+                if (isInside(cx, cy)) {
                     return true;
                 }
+            } else {
+                log.warn("Geometry (Point) has wrong format: " + geom.toString());
             }
+        } else if (geom.isPoly()) {
+            int pointPos = 0;
 
-            pointPos += len;
+            for (int indexPos = 0, n = geom.index.length; indexPos < n; indexPos++) {
+                int len = geom.index[indexPos];
+                if (len < 0)
+                    break;
+
+                if (len < 6) {
+                    pointPos += len;
+                    continue;
+                }
+
+                int end = pointPos + len;
+
+                for (int i = pointPos; i < end; ) {
+                    float cx = geom.points[i++];
+                    float cy = geom.points[i++];
+
+                    if (isInside(cx, cy)) {
+                        return true;
+                    }
+                }
+
+                pointPos += len;
+            }
         }
         geom.clear();
         return false;
+    }
+
+    private boolean isInside(float cx, float cy) {
+        return cx >= xmin && cx < xmax && cy >= ymin && cy < ymax;
     }
 }


### PR DESCRIPTION
`TileClipper` doesn't clip `GeometryBuffer`s which are points only. As clipping and separating are the same for one node only, I added this to `TileSeparator` as this may processing faster and avoids doubles at the overlapping tile borders.

Background is that if using `TileLoaderProcessHook` the node elements are processed for each tile again, instead of only the tile, it belongs to. (i.a. important for Poi3DLayer).