### PR TITLE
Playground renderer: bind with GLState (#601)

### DIFF
--- a/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxModelRenderer.java
+++ b/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxModelRenderer.java
@@ -101,7 +101,9 @@ public class GdxModelRenderer extends LayerRenderer {
         if (v.pos.zoomLevel < 16)
             gl.clear(GL.DEPTH_BUFFER_BIT);
 
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
+        // Unbind via GLState to ensure no buffer is replaced by accident
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
 
         // set state that is expected after modelBatch.end();
         // modelBatch keeps track of its own state
@@ -172,8 +174,8 @@ public class GdxModelRenderer extends LayerRenderer {
         }
 
         gl.depthMask(false);
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
-        gl.bindBuffer(GL.ARRAY_BUFFER, 0);
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
     }
 
     // @Override

--- a/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxRenderer3D.java
+++ b/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxRenderer3D.java
@@ -102,7 +102,9 @@ public class GdxRenderer3D extends LayerRenderer {
         // if (position.zoomLevel < 17)
         // GL.clear(GL20.DEPTH_BUFFER_BIT);
 
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
+        // Unbind via GLState to ensure no buffer is replaced by accident
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
 
         // set state that is expected after modelBatch.end();
         // modelBatch keeps track of its own state
@@ -186,8 +188,8 @@ public class GdxRenderer3D extends LayerRenderer {
         log.debug(">>> " + (System.currentTimeMillis() - time) + " " + cnt + "/" + rnd);
 
         gl.depthMask(false);
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
-        gl.bindBuffer(GL.ARRAY_BUFFER, 0);
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
     }
 
     // @Override

--- a/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxRenderer3D2.java
+++ b/vtm-playground/src/org/oscim/test/gdx/poi3d/GdxRenderer3D2.java
@@ -104,7 +104,9 @@ public class GdxRenderer3D2 extends LayerRenderer {
         if (v.pos.zoomLevel < 17)
             gl.clear(GL.DEPTH_BUFFER_BIT);
 
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
+        // Unbind via GLState to ensure no buffer is replaced by accident
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
 
         // set state that is expected after modelBatch.end();
         // modelBatch keeps track of its own state
@@ -159,8 +161,8 @@ public class GdxRenderer3D2 extends LayerRenderer {
         // GLUtils.checkGlError("<" + TAG);
 
         gl.depthMask(false);
-        gl.bindBuffer(GL.ELEMENT_ARRAY_BUFFER, 0);
-        gl.bindBuffer(GL.ARRAY_BUFFER, 0);
+        GLState.bindElementBuffer(GLState.UNBIND);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
 
         // GLState.bindTex2D(-1);
         // GLState.useProgram(-1);

--- a/vtm-playground/src/org/oscim/test/renderer/CustomRenderer.java
+++ b/vtm-playground/src/org/oscim/test/renderer/CustomRenderer.java
@@ -97,7 +97,7 @@ public class CustomRenderer extends LayerRenderer {
         GLState.test(false, false);
 
         // unbind previously bound VBOs
-        gl.bindBuffer(GL.ARRAY_BUFFER, 0);
+        GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);
 
         // Load the vertex data
         //mVertices.position(0);

--- a/vtm/src/org/oscim/renderer/GLState.java
+++ b/vtm/src/org/oscim/renderer/GLState.java
@@ -29,6 +29,7 @@ public class GLState {
     static final Logger log = LoggerFactory.getLogger(GLState.class);
 
     public final static int DISABLED = -1;
+    public final static int UNBIND = 0;
 
     private final static boolean[] vertexArray = {false, false};
     private static boolean blend = false;


### PR DESCRIPTION
Unbind/bind via GLState to ensure no buffer is replaced by accident without the knowledge of other renderers (fix #601).