### PR TITLE
vtm-playground: Poi3D example enhancements

### DIFF
--- a/vtm-playground/src/org/oscim/test/GdxPoi3DTest.java
+++ b/vtm-playground/src/org/oscim/test/GdxPoi3DTest.java
@@ -15,7 +15,7 @@
  * You should have received a copy of the GNU Lesser General Public License along with
  * this program. If not, see <http://www.gnu.org/licenses/>.
  */
-package org.oscim.test.gdx.poi3d;
+package org.oscim.test;
 
 import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxMapApp;
@@ -24,13 +24,12 @@ import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.renderer.MapRenderer;
-import org.oscim.test.MapPreferences;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.OkHttpEngine;
 import org.oscim.tiling.source.oscimap4.OSciMap4TileSource;
 
-public class Gdx3DTest extends GdxMapApp {
+public class GdxPoi3DTest extends GdxMapApp {
 
     @Override
     public void createLayers() {
@@ -82,6 +81,6 @@ public class Gdx3DTest extends GdxMapApp {
 
     public static void main(String[] args) {
         GdxMapApp.init();
-        GdxMapApp.run(new Gdx3DTest());
+        GdxMapApp.run(new GdxPoi3DTest());
     }
 }

--- a/vtm-playground/src/org/oscim/test/MapsforgePoi3DTest.java
+++ b/vtm-playground/src/org/oscim/test/MapsforgePoi3DTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 devemux86
+ * Copyright 2018 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -18,14 +19,14 @@ import org.oscim.gdx.GdxMapApp;
 
 import java.io.File;
 
-public class MapsforgeS3DBTest extends MapsforgeTest {
+public class MapsforgePoi3DTest extends MapsforgeTest {
 
-    private MapsforgeS3DBTest(File mapFile) {
-        super(mapFile, true, false);
+    private MapsforgePoi3DTest(File mapFile) {
+        super(mapFile, false, true);
     }
 
     public static void main(String[] args) {
         GdxMapApp.init();
-        GdxMapApp.run(new MapsforgeS3DBTest(getMapFile(args)));
+        GdxMapApp.run(new MapsforgePoi3DTest(getMapFile(args)));
     }
 }

--- a/vtm-playground/src/org/oscim/test/MapsforgeTest.java
+++ b/vtm-playground/src/org/oscim/test/MapsforgeTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016-2018 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -19,6 +20,7 @@ package org.oscim.test;
 import org.oscim.core.MapPosition;
 import org.oscim.core.Tile;
 import org.oscim.gdx.GdxMapApp;
+import org.oscim.gdx.poi3d.Poi3DLayer;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.buildings.S3DBLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
@@ -40,14 +42,16 @@ public class MapsforgeTest extends GdxMapApp {
 
     private File mapFile;
     private boolean s3db;
+    private boolean poi3d;
 
     MapsforgeTest(File mapFile) {
-        this(mapFile, false);
+        this(mapFile, false, false);
     }
 
-    MapsforgeTest(File mapFile, boolean s3db) {
+    MapsforgeTest(File mapFile, boolean s3db, boolean poi3d) {
         this.mapFile = mapFile;
         this.s3db = s3db;
+        this.poi3d = poi3d;
     }
 
     @Override
@@ -63,6 +67,10 @@ public class MapsforgeTest extends GdxMapApp {
             mMap.layers().add(new S3DBLayer(mMap, l));
         else
             mMap.layers().add(new BuildingLayer(mMap, l));
+
+        if (poi3d)
+            mMap.layers().add(new Poi3DLayer(mMap, l));
+
         mMap.layers().add(new LabelLayer(mMap, l));
 
         DefaultMapScaleBar mapScaleBar = new DefaultMapScaleBar(mMap);


### PR DESCRIPTION
- Poi3D example for Mapsforge maps
- refactor `Gdx3DTest` to `GdxPoi3DTest` and move to other examples as own package seems needless now.