### PR TITLE
TileClipper: synchronize clip

### DIFF
--- a/vtm/src/org/oscim/utils/geom/TileClipper.java
+++ b/vtm/src/org/oscim/utils/geom/TileClipper.java
@@ -51,7 +51,7 @@ public class TileClipper {
 
     private final GeometryBuffer mGeomOut = new GeometryBuffer(10, 1);
 
-    public boolean clip(GeometryBuffer geom) {
+    public synchronized boolean clip(GeometryBuffer geom) {
         if (geom.isPoly()) {
 
             GeometryBuffer out = mGeomOut;


### PR DESCRIPTION
`TileClipper` hasn't worked flawless with asynchronous calls, and e.g. `mGeoOut` can not be used safely then.