### PR TITLE
GdxMap: make createLayers() abstract

### DIFF
--- a/vtm-gdx/src/org/oscim/gdx/GdxMap.java
+++ b/vtm-gdx/src/org/oscim/gdx/GdxMap.java
@@ -99,8 +99,10 @@ public abstract class GdxMap implements ApplicationListener {
         createLayers();
     }
 
-    protected void createLayers() {
-    }
+    /**
+     * Add layers to GdxMap
+     */
+    protected abstract void createLayers();
 
     @Override
     public void dispose() {


### PR DESCRIPTION
Every implementation of `GdxMap` should overwrite createLayers(), to instantly know where to put layers.
Beside that, I think in GdxMap won't be included any default layers (or can write them in `create()` method).