### PR TITLE
CircleBucket (Android): Disable VERTEX_PROGRAM_POINT_SIZE

### DIFF
--- a/vtm/src/org/oscim/backend/GLAdapter.java
+++ b/vtm/src/org/oscim/backend/GLAdapter.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
+ * Copyright 2018 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -29,6 +30,7 @@ public class GLAdapter {
      */
     public static GL gl;
 
+    public static boolean ANDROID_QUIRKS = false;
     public static boolean GDX_DESKTOP_QUIRKS = false;
     public static boolean GDX_WEBGL_QUIRKS = false;
 
@@ -46,6 +48,7 @@ public class GLAdapter {
     public static void init(GL gl20) {
         gl = gl20;
 
+        ANDROID_QUIRKS = (CanvasAdapter.platform == Platform.ANDROID);
         GDX_DESKTOP_QUIRKS = CanvasAdapter.platform.isDesktop();
         GDX_WEBGL_QUIRKS = (CanvasAdapter.platform == Platform.WEBGL);
 

--- a/vtm/src/org/oscim/renderer/bucket/CircleBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/CircleBucket.java
@@ -2,6 +2,7 @@
  * Copyright 2016 Andrey Novikov
  * Copyright 2016 devemux86
  * Copyright 2017 schedul-xor
+ * Copyright 2018 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -94,7 +95,7 @@ public class CircleBucket extends RenderBucket {
             int uMVP, uFill, uRadius, uStroke, uWidth, aPos;
 
             Shader(String shaderFile) {
-                if (!GLAdapter.CIRCLE_QUADS && !GLAdapter.GDX_WEBGL_QUIRKS)
+                if (!GLAdapter.CIRCLE_QUADS && !GLAdapter.GDX_WEBGL_QUIRKS && !GLAdapter.ANDROID_QUIRKS)
                     gl.enable(GL.VERTEX_PROGRAM_POINT_SIZE);
 
                 String version = null;


### PR DESCRIPTION
Call `gl.enable(VERTEX_PROGRAM_POINT_SIZE);` not valid in OpenGL ES. Caused GL error.
See: https://www.khronos.org/registry/OpenGL/specs/es/2.0/es_cm_spec_2.0.pdf page 64
Related: #305 