### PR TITLE
vtm-web: fix nested folder in gradle

### DIFF
--- a/vtm-web/build.gradle
+++ b/vtm-web/build.gradle
@@ -12,7 +12,9 @@ apply plugin: 'maven'
 apply plugin: 'gwt-base'
 
 sourceSets {
+    // Exclude nested folder 'emu' from 'src' and add it manually
     main.java.srcDirs = ['src', 'src/org/oscim/gdx/emu']
+    main.java.exclude '**/emu/**'
 }
 
 dependencies {


### PR DESCRIPTION
Cannot import vtm-web project via gradle in eclipse until removing nested 'emu' folder from 'src' source directory (, which is set as source anyway).