### PR TITLE
DateTime adapter

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/GdxActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/GdxActivity.java
@@ -28,6 +28,8 @@ import com.badlogic.gdx.utils.SharedLibraryLoader;
 import org.oscim.android.MapPreferences;
 import org.oscim.android.canvas.AndroidGraphics;
 import org.oscim.backend.CanvasAdapter;
+import org.oscim.backend.DateTime;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.Tile;
 import org.oscim.gdx.AndroidGL;
@@ -65,6 +67,7 @@ public class GdxActivity extends AndroidApplication {
         AndroidGraphics.init();
         GdxAssets.init("");
         GLAdapter.init(new AndroidGL());
+        DateTimeAdapter.init(new DateTime());
 
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         CanvasAdapter.dpi = (int) (metrics.scaledDensity * CanvasAdapter.DEFAULT_DPI);

--- a/vtm-android/src/org/oscim/android/MapView.java
+++ b/vtm-android/src/org/oscim/android/MapView.java
@@ -35,6 +35,8 @@ import org.oscim.android.gl.GlConfigChooser;
 import org.oscim.android.input.AndroidMotionEvent;
 import org.oscim.android.input.GestureHandler;
 import org.oscim.backend.CanvasAdapter;
+import org.oscim.backend.DateTime;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.Tile;
 import org.oscim.map.Map;
@@ -89,6 +91,7 @@ public class MapView extends GLSurfaceView {
         AndroidGraphics.init();
         AndroidAssets.init(context);
         GLAdapter.init(new AndroidGL());
+        DateTimeAdapter.init(new DateTime());
 
         DisplayMetrics metrics = getResources().getDisplayMetrics();
         CanvasAdapter.dpi = (int) (metrics.scaledDensity * CanvasAdapter.DEFAULT_DPI);

--- a/vtm-desktop/src/org/oscim/gdx/GdxMapApp.java
+++ b/vtm-desktop/src/org/oscim/gdx/GdxMapApp.java
@@ -24,6 +24,8 @@ import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 import org.oscim.awt.AwtGraphics;
+import org.oscim.backend.DateTime;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.Tile;
 import org.oscim.tiling.TileSource;
@@ -43,6 +45,7 @@ public class GdxMapApp extends GdxMap {
         AwtGraphics.init();
         GdxAssets.init("assets/");
         GLAdapter.init(new LwjglGL20());
+        DateTimeAdapter.init(new DateTime());
     }
 
     public static void main(String[] args) {

--- a/vtm-ios-example/src/org/oscim/ios/test/IOSMapApp.java
+++ b/vtm-ios-example/src/org/oscim/ios/test/IOSMapApp.java
@@ -17,6 +17,8 @@
  */
 package org.oscim.ios.test;
 
+import org.oscim.backend.DateTime;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
@@ -44,6 +46,7 @@ public class IOSMapApp extends GdxMap {
         IosGraphics.init();
         GdxAssets.init("assets/");
         GLAdapter.init(new IosGL());
+        DateTimeAdapter.init(new DateTime());
     }
 
     @Override

--- a/vtm-tests/test/org/oscim/backend/DateTimeTest.java
+++ b/vtm-tests/test/org/oscim/backend/DateTimeTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.backend;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DateTimeTest {
+
+    private static final Logger log = LoggerFactory.getLogger(DateTimeTest.class);
+
+    @Test
+    public void testDateTime() {
+        DateTimeAdapter.init(new DateTime());
+        log.info("Day of Year\t" + DateTimeAdapter.instance.getDayOfYear());
+        log.info("Hour of Day\t" + DateTimeAdapter.instance.getHour());
+        log.info("Minute of Day\t" + DateTimeAdapter.instance.getMinute());
+        log.info("Second of Day\t" + DateTimeAdapter.instance.getSecond());
+        Assert.assertTrue(true);
+    }
+}

--- a/vtm-theme-comparator/src/org/oscim/theme/comparator/Main.java
+++ b/vtm-theme-comparator/src/org/oscim/theme/comparator/Main.java
@@ -20,6 +20,8 @@ import com.jtattoo.plaf.DecorationHelper;
 import com.jtattoo.plaf.hifi.HiFiLookAndFeel;
 
 import org.oscim.awt.AwtGraphics;
+import org.oscim.backend.DateTime;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.LwjglGL20;
@@ -88,6 +90,7 @@ public class Main {
         AwtGraphics.init();
         GdxAssets.init("assets/");
         GLAdapter.init(new LwjglGL20());
+        DateTimeAdapter.init(new DateTime());
         GLAdapter.GDX_DESKTOP_QUIRKS = true;
         window = new MainWindow();
         window.setSize(800, 600);

--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -24,12 +24,14 @@ import com.badlogic.gdx.backends.gwt.GwtGraphics;
 
 import org.oscim.backend.AssetAdapter;
 import org.oscim.backend.CanvasAdapter;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GL;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.MapPosition;
 import org.oscim.core.Tile;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
+import org.oscim.gdx.client.GwtDateTime;
 import org.oscim.gdx.client.GwtGdxGraphics;
 import org.oscim.gdx.client.MapConfig;
 import org.oscim.gdx.client.MapUrl;
@@ -71,6 +73,7 @@ class GwtMap extends GdxMap {
 
         GwtGdxGraphics.init();
         GdxAssets.init("");
+        DateTimeAdapter.init(new GwtDateTime());
         CanvasAdapter.textScale = 0.7f;
         CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * CanvasAdapter.DEFAULT_DPI);
         Tile.SIZE = Tile.calculateTileSize();

--- a/vtm-web-js/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-js/src/org/oscim/web/client/GwtMap.java
@@ -21,11 +21,13 @@ import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 
 import org.oscim.backend.CanvasAdapter;
+import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GL;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.MapPosition;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
+import org.oscim.gdx.client.GwtDateTime;
 import org.oscim.gdx.client.GwtGdxGraphics;
 import org.oscim.gdx.client.MapConfig;
 import org.oscim.gdx.client.MapUrl;
@@ -42,6 +44,7 @@ public class GwtMap extends GdxMap {
 
         GwtGdxGraphics.init();
         GdxAssets.init("");
+        DateTimeAdapter.init(new GwtDateTime());
         CanvasAdapter.textScale = 0.7f;
         GLAdapter.init((GL) Gdx.graphics.getGL20());
         MapRenderer.setBackgroundColor(0xffffff);

--- a/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
+++ b/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
@@ -42,4 +42,10 @@ public class GwtDateTime extends DateTimeAdapter {
         double diff = year.getTime() - start.getTime();
         return (int) (diff / (DateTimeAdapter.MILLIS_PER_DAY)) + 1;
     }
+
+    @Override
+    public int getTimeZoneOffset() {
+        JsDate date = JsDate.create();
+        return -date.getTimezoneOffset();
+    }
 }

--- a/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
+++ b/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.gdx.client;
+
+import com.google.gwt.core.client.JsDate;
+
+import org.oscim.backend.DateTimeAdapter;
+
+public class GwtDateTime extends DateTimeAdapter {
+
+    @Override
+    public int getHour() {
+        return JsDate.create().getHours();
+    }
+
+    @Override
+    public int getMinute() {
+        return JsDate.create().getMinutes();
+    }
+
+    @Override
+    public int getSecond() {
+        return JsDate.create().getSeconds();
+    }
+
+    @Override
+    public int getDayOfYear() {
+        JsDate year = JsDate.create();
+        JsDate start = JsDate.create(year.getFullYear(), 0);
+        double diff = year.getTime() - start.getTime();
+        return (int) (diff / (DateTimeAdapter.MILLIS_PER_DAY)) + 1;
+    }
+}

--- a/vtm/src/org/oscim/backend/DateTime.java
+++ b/vtm/src/org/oscim/backend/DateTime.java
@@ -37,4 +37,10 @@ public class DateTime extends DateTimeAdapter {
     public int getDayOfYear() {
         return Calendar.getInstance().get(Calendar.DAY_OF_YEAR);
     }
+
+    @Override
+    public int getTimeZoneOffset() {
+        Calendar inst = Calendar.getInstance();
+        return inst.getTimeZone().getOffset(inst.getTimeInMillis()) / 60000;
+    }
 }

--- a/vtm/src/org/oscim/backend/DateTime.java
+++ b/vtm/src/org/oscim/backend/DateTime.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.backend;
+
+import java.util.Calendar;
+
+public class DateTime extends DateTimeAdapter {
+
+    @Override
+    public int getHour() {
+        return Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+    }
+
+    @Override
+    public int getMinute() {
+        return Calendar.getInstance().get(Calendar.MINUTE);
+    }
+
+    @Override
+    public int getSecond() {
+        return Calendar.getInstance().get(Calendar.SECOND);
+    }
+
+    @Override
+    public int getDayOfYear() {
+        return Calendar.getInstance().get(Calendar.DAY_OF_YEAR);
+    }
+}

--- a/vtm/src/org/oscim/backend/DateTimeAdapter.java
+++ b/vtm/src/org/oscim/backend/DateTimeAdapter.java
@@ -37,4 +37,9 @@ public abstract class DateTimeAdapter {
      * Indicates the day number within the current year. The first day of the year has value 1.
      */
     public abstract int getDayOfYear();
+
+    /**
+     * @return the time zone offset in minutes
+     */
+    public abstract int getTimeZoneOffset();
 }

--- a/vtm/src/org/oscim/backend/DateTimeAdapter.java
+++ b/vtm/src/org/oscim/backend/DateTimeAdapter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.backend;
+
+public abstract class DateTimeAdapter {
+
+    public static final long MILLIS_PER_DAY = 86400000L;
+
+    /**
+     * The instance provided by backend
+     */
+    public static DateTimeAdapter instance;
+
+    public static void init(DateTimeAdapter adapter) {
+        DateTimeAdapter.instance = adapter;
+    }
+
+    public abstract int getHour();
+
+    public abstract int getMinute();
+
+    public abstract int getSecond();
+
+    /**
+     * Indicates the day number within the current year. The first day of the year has value 1.
+     */
+    public abstract int getDayOfYear();
+}


### PR DESCRIPTION
For lighting and shadow I want to add a tool which calculates the light direction of current day/time.
Unfortunately GWT doesn't support `java.util.Calendar`.
So here's an adapter to have access to the date on all platforms.

_FYI: I tested the gwt implementation via browser, but didn't manage to run a JUnit test._

If you want, can review and keep on separate branch, so can make it available for shadow implementation.