### PR TITLE
Complete GL20 interface

### DIFF
--- a/vtm-android-example/build.gradle
+++ b/vtm-android-example/build.gradle
@@ -20,7 +20,6 @@ dependencies {
     implementation project(':vtm-android-gdx')
     implementation project(':vtm-gdx')
     implementation project(':vtm-gdx-poi3d')
-    implementation "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
 
     implementation 'org.mapsforge:mapsforge-poi-android:master-SNAPSHOT'
     implementation 'org.mapsforge:sqlite-android:master-SNAPSHOT:natives-armeabi-v7a'

--- a/vtm-android-gdx/build.gradle
+++ b/vtm-android-gdx/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.github.dcendents.android-maven'
 
 dependencies {
     api project(':vtm')
+    api "com.badlogicgames.gdx:gdx-backend-android:$gdxVersion"
 }
 
 android {

--- a/vtm-android-gdx/src/org/oscim/gdx/AndroidGL.java
+++ b/vtm-android-gdx/src/org/oscim/gdx/AndroidGL.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -19,6 +20,8 @@ package org.oscim.gdx;
 import android.annotation.SuppressLint;
 import android.opengl.GLES20;
 
+import com.badlogic.gdx.backends.android.AndroidGL20;
+
 import org.oscim.backend.GL;
 
 import java.nio.Buffer;
@@ -27,6 +30,8 @@ import java.nio.IntBuffer;
 
 @SuppressLint("NewApi")
 public class AndroidGL implements GL {
+
+    private static final AndroidGL20 androidGL = new AndroidGL20();
 
     @Override
     public void attachShader(int program, int shader) {
@@ -104,8 +109,18 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void deleteBuffer(int buffer) {
+        androidGL.glDeleteBuffer(buffer);
+    }
+
+    @Override
     public void deleteBuffers(int n, IntBuffer buffers) {
         GLES20.glDeleteBuffers(n, buffers);
+    }
+
+    @Override
+    public void deleteFramebuffer(int framebuffer) {
+        androidGL.glDeleteFramebuffer(framebuffer);
     }
 
     @Override
@@ -116,6 +131,11 @@ public class AndroidGL implements GL {
     @Override
     public void deleteProgram(int program) {
         GLES20.glDeleteProgram(program);
+    }
+
+    @Override
+    public void deleteRenderbuffer(int renderbuffer) {
+        androidGL.glDeleteRenderbuffer(renderbuffer);
     }
 
     @Override
@@ -161,6 +181,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public int genBuffer() {
+        return androidGL.glGenBuffer();
+    }
+
+    @Override
     public void genBuffers(int n, IntBuffer buffers) {
         GLES20.glGenBuffers(n, buffers);
     }
@@ -171,8 +196,18 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public int genFramebuffer() {
+        return androidGL.glGenFramebuffer();
+    }
+
+    @Override
     public void genFramebuffers(int n, IntBuffer framebuffers) {
         GLES20.glGenFramebuffers(n, framebuffers);
+    }
+
+    @Override
+    public int genRenderbuffer() {
+        return androidGL.glGenRenderbuffer();
     }
 
     @Override
@@ -187,14 +222,12 @@ public class AndroidGL implements GL {
 
     @Override
     public String getActiveUniform(int program, int index, IntBuffer size, Buffer type) {
-        //return GLES20.glGetActiveUniform(program, index, bufsize, length, size, type, name);
-        throw new UnsupportedOperationException("missing implementation");
+        return androidGL.glGetActiveUniform(program, index, size, type);
     }
 
     @Override
     public void getAttachedShaders(int program, int maxcount, Buffer count, IntBuffer shaders) {
-        throw new UnsupportedOperationException("missing implementation");
-        //GLES20.glGetAttachedShaders(program, maxcount, count, shaders);
+        androidGL.glGetAttachedShaders(program, maxcount, count, shaders);
     }
 
     @Override
@@ -204,8 +237,7 @@ public class AndroidGL implements GL {
 
     @Override
     public void getBooleanv(int pname, Buffer params) {
-        throw new UnsupportedOperationException("missing implementation");
-        //GLES20.glGetBooleanv(pname, params);
+        androidGL.glGetBooleanv(pname, params);
     }
 
     @Override
@@ -261,11 +293,6 @@ public class AndroidGL implements GL {
     }
 
     @Override
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source) {
-        throw new UnsupportedOperationException("missing implementation");
-    }
-
-    @Override
     public void getTexParameterfv(int target, int pname, FloatBuffer params) {
         GLES20.glGetTexParameterfv(target, pname, params);
 
@@ -308,8 +335,7 @@ public class AndroidGL implements GL {
 
     @Override
     public void getVertexAttribPointerv(int index, int pname, Buffer pointer) {
-        //GLES20.glGetVertexAttribPointerv(index, pname, pointer);
-        throw new UnsupportedOperationException("missing implementation");
+        androidGL.glGetVertexAttribPointerv(index, pname, pointer);
     }
 
     @Override
@@ -432,6 +458,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform1fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform1fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform1i(int location, int x) {
         GLES20.glUniform1i(location, x);
 
@@ -441,6 +472,11 @@ public class AndroidGL implements GL {
     public void uniform1iv(int location, int count, IntBuffer v) {
         GLES20.glUniform1iv(location, count, v);
 
+    }
+
+    @Override
+    public void uniform1iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform1iv(location, count, v, offset);
     }
 
     @Override
@@ -456,6 +492,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform2fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform2fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform2i(int location, int x, int y) {
         GLES20.glUniform2i(location, x, y);
 
@@ -465,6 +506,11 @@ public class AndroidGL implements GL {
     public void uniform2iv(int location, int count, IntBuffer v) {
         GLES20.glUniform2iv(location, count, v);
 
+    }
+
+    @Override
+    public void uniform2iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform2iv(location, count, v, offset);
     }
 
     @Override
@@ -480,6 +526,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform3fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform3fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform3i(int location, int x, int y, int z) {
         GLES20.glUniform3i(location, x, y, z);
 
@@ -492,6 +543,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform3iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform3iv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform4f(int location, float x, float y, float z, float w) {
         GLES20.glUniform4f(location, x, y, z, w);
     }
@@ -499,6 +555,11 @@ public class AndroidGL implements GL {
     @Override
     public void uniform4fv(int location, int count, FloatBuffer v) {
         GLES20.glUniform4fv(location, count, v);
+    }
+
+    @Override
+    public void uniform4fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform4fv(location, count, v, offset);
     }
 
     @Override
@@ -514,9 +575,19 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform4iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform4iv(location, count, v, offset);
+    }
+
+    @Override
     public void uniformMatrix2fv(int location, int count, boolean transpose, FloatBuffer value) {
         GLES20.glUniformMatrix2fv(location, count, transpose, value);
 
+    }
+
+    @Override
+    public void uniformMatrix2fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix2fv(location, count, transpose, value, offset);
     }
 
     @Override
@@ -526,9 +597,19 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniformMatrix3fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix3fv(location, count, transpose, value, offset);
+    }
+
+    @Override
     public void uniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value) {
         GLES20.glUniformMatrix4fv(location, count, transpose, value);
 
+    }
+
+    @Override
+    public void uniformMatrix4fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix4fv(location, count, transpose, value, offset);
     }
 
     @Override
@@ -656,15 +737,13 @@ public class AndroidGL implements GL {
     @Override
     public void compressedTexImage2D(int target, int level, int internalformat, int width,
                                      int height, int border, int imageSize, Buffer data) {
-        throw new UnsupportedOperationException("missing implementation");
-
+        androidGL.glCompressedTexImage2D(target, level, internalformat, width, height, border, imageSize, data);
     }
 
     @Override
     public void compressedTexSubImage2D(int target, int level, int xoffset, int yoffset,
                                         int width, int height, int format, int imageSize, Buffer data) {
-        throw new UnsupportedOperationException("missing implementation");
-
+        androidGL.glCompressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, data);
     }
 
     @Override
@@ -689,6 +768,11 @@ public class AndroidGL implements GL {
     public void deleteTextures(int n, IntBuffer textures) {
         GLES20.glDeleteTextures(n, textures);
 
+    }
+
+    @Override
+    public void deleteTexture(int texture) {
+        androidGL.glDeleteTexture(texture);
     }
 
     @Override
@@ -755,6 +839,11 @@ public class AndroidGL implements GL {
     public void genTextures(int n, IntBuffer textures) {
         GLES20.glGenTextures(n, textures);
 
+    }
+
+    @Override
+    public int genTexture() {
+        return androidGL.glGenTexture();
     }
 
     @Override
@@ -837,8 +926,7 @@ public class AndroidGL implements GL {
     @Override
     public void texSubImage2D(int target, int level, int xoffset, int yoffset, int width,
                               int height, int format, int type, Buffer pixels) {
-        GLES20
-                .glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+        GLES20.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
 
     }
 

--- a/vtm-android/src/org/oscim/android/gl/AndroidGL.java
+++ b/vtm-android/src/org/oscim/android/gl/AndroidGL.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -25,6 +26,9 @@ import java.nio.Buffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 
+/**
+ * TODO convert or use jni for unimplemented methods: https://github.com/libgdx/libgdx/blob/master/gdx/jni/android/AndroidGL20.cpp
+ */
 @SuppressLint("NewApi")
 public class AndroidGL implements GL {
 
@@ -104,8 +108,18 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void deleteBuffer(int buffer) {
+        throw new UnsupportedOperationException("missing implementation");
+    }
+
+    @Override
     public void deleteBuffers(int n, IntBuffer buffers) {
         GLES20.glDeleteBuffers(n, buffers);
+    }
+
+    @Override
+    public void deleteFramebuffer(int framebuffer) {
+        throw new UnsupportedOperationException("missing implementation");
     }
 
     @Override
@@ -116,6 +130,11 @@ public class AndroidGL implements GL {
     @Override
     public void deleteProgram(int program) {
         GLES20.glDeleteProgram(program);
+    }
+
+    @Override
+    public void deleteRenderbuffer(int renderbuffer) {
+        throw new UnsupportedOperationException("missing implementation");
     }
 
     @Override
@@ -161,6 +180,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public int genBuffer() {
+        throw new UnsupportedOperationException("missing implementation");
+    }
+
+    @Override
     public void genBuffers(int n, IntBuffer buffers) {
         GLES20.glGenBuffers(n, buffers);
     }
@@ -171,8 +195,18 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public int genFramebuffer() {
+        throw new UnsupportedOperationException("missing implementation");
+    }
+
+    @Override
     public void genFramebuffers(int n, IntBuffer framebuffers) {
         GLES20.glGenFramebuffers(n, framebuffers);
+    }
+
+    @Override
+    public int genRenderbuffer() {
+        throw new UnsupportedOperationException("missing implementation");
     }
 
     @Override
@@ -258,11 +292,6 @@ public class AndroidGL implements GL {
     public void getShaderPrecisionFormat(int shadertype, int precisiontype, IntBuffer range,
                                          IntBuffer precision) {
         GLES20.glGetShaderPrecisionFormat(shadertype, precisiontype, range, precision);
-    }
-
-    @Override
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source) {
-        throw new UnsupportedOperationException("missing implementation");
     }
 
     @Override
@@ -432,6 +461,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform1fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform1fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform1i(int location, int x) {
         GLES20.glUniform1i(location, x);
 
@@ -441,6 +475,11 @@ public class AndroidGL implements GL {
     public void uniform1iv(int location, int count, IntBuffer v) {
         GLES20.glUniform1iv(location, count, v);
 
+    }
+
+    @Override
+    public void uniform1iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform1iv(location, count, v, offset);
     }
 
     @Override
@@ -456,6 +495,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform2fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform2fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform2i(int location, int x, int y) {
         GLES20.glUniform2i(location, x, y);
 
@@ -465,6 +509,11 @@ public class AndroidGL implements GL {
     public void uniform2iv(int location, int count, IntBuffer v) {
         GLES20.glUniform2iv(location, count, v);
 
+    }
+
+    @Override
+    public void uniform2iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform2iv(location, count, v, offset);
     }
 
     @Override
@@ -480,6 +529,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform3fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform3fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform3i(int location, int x, int y, int z) {
         GLES20.glUniform3i(location, x, y, z);
 
@@ -492,6 +546,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform3iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform3iv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform4f(int location, float x, float y, float z, float w) {
         GLES20.glUniform4f(location, x, y, z, w);
     }
@@ -499,6 +558,11 @@ public class AndroidGL implements GL {
     @Override
     public void uniform4fv(int location, int count, FloatBuffer v) {
         GLES20.glUniform4fv(location, count, v);
+    }
+
+    @Override
+    public void uniform4fv(int location, int count, float[] v, int offset) {
+        GLES20.glUniform4fv(location, count, v, offset);
     }
 
     @Override
@@ -514,9 +578,19 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniform4iv(int location, int count, int[] v, int offset) {
+        GLES20.glUniform4iv(location, count, v, offset);
+    }
+
+    @Override
     public void uniformMatrix2fv(int location, int count, boolean transpose, FloatBuffer value) {
         GLES20.glUniformMatrix2fv(location, count, transpose, value);
 
+    }
+
+    @Override
+    public void uniformMatrix2fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix2fv(location, count, transpose, value, offset);
     }
 
     @Override
@@ -526,9 +600,19 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void uniformMatrix3fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix3fv(location, count, transpose, value, offset);
+    }
+
+    @Override
     public void uniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value) {
         GLES20.glUniformMatrix4fv(location, count, transpose, value);
 
+    }
+
+    @Override
+    public void uniformMatrix4fv(int location, int count, boolean transpose, float[] value, int offset) {
+        GLES20.glUniformMatrix4fv(location, count, transpose, value, offset);
     }
 
     @Override
@@ -692,6 +776,11 @@ public class AndroidGL implements GL {
     }
 
     @Override
+    public void deleteTexture(int texture) {
+        throw new UnsupportedOperationException("missing implementation");
+    }
+
+    @Override
     public void depthFunc(int func) {
         GLES20.glDepthFunc(func);
 
@@ -755,6 +844,11 @@ public class AndroidGL implements GL {
     public void genTextures(int n, IntBuffer textures) {
         GLES20.glGenTextures(n, textures);
 
+    }
+
+    @Override
+    public int genTexture() {
+        throw new UnsupportedOperationException("missing implementation");
     }
 
     @Override
@@ -837,8 +931,7 @@ public class AndroidGL implements GL {
     @Override
     public void texSubImage2D(int target, int level, int xoffset, int yoffset, int width,
                               int height, int format, int type, Buffer pixels) {
-        GLES20
-                .glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+        GLES20.glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
 
     }
 

--- a/vtm-desktop/src/org/oscim/gdx/LwjglGL20.java
+++ b/vtm-desktop/src/org/oscim/gdx/LwjglGL20.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2016 devemux86
+ * Copyright 2019 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  * <p/>
@@ -38,6 +55,8 @@ import java.nio.ShortBuffer;
 /**
  * An implementation of the {@link GL20} interface based on LWJGL. Note that LWJGL shaders and OpenGL ES shaders will not be 100%
  * compatible. Some glGetXXX methods are not implemented.
+ * <p>
+ * See: https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-lwjgl/src/com/badlogic/gdx/backends/lwjgl/LwjglGL20.java
  *
  * @author mzechner
  */
@@ -241,6 +260,7 @@ public class LwjglGL20 implements GL {
         GL15.glDeleteBuffers(buffers);
     }
 
+    @Override
     public void deleteBuffer(int buffer) {
         GL15.glDeleteBuffers(buffer);
     }
@@ -250,6 +270,7 @@ public class LwjglGL20 implements GL {
         EXTFramebufferObject.glDeleteFramebuffersEXT(framebuffers);
     }
 
+    @Override
     public void deleteFramebuffer(int framebuffer) {
         EXTFramebufferObject.glDeleteFramebuffersEXT(framebuffer);
     }
@@ -264,6 +285,7 @@ public class LwjglGL20 implements GL {
         EXTFramebufferObject.glDeleteRenderbuffersEXT(renderbuffers);
     }
 
+    @Override
     public void deleteRenderbuffer(int renderbuffer) {
         EXTFramebufferObject.glDeleteRenderbuffersEXT(renderbuffer);
     }
@@ -278,6 +300,7 @@ public class LwjglGL20 implements GL {
         GL11.glDeleteTextures(textures);
     }
 
+    @Override
     public void deleteTexture(int texture) {
         GL11.glDeleteTextures(texture);
     }
@@ -370,6 +393,7 @@ public class LwjglGL20 implements GL {
         GL15.glGenBuffers(buffers);
     }
 
+    @Override
     public int genBuffer() {
         return GL15.glGenBuffers();
     }
@@ -379,6 +403,7 @@ public class LwjglGL20 implements GL {
         EXTFramebufferObject.glGenFramebuffersEXT(framebuffers);
     }
 
+    @Override
     public int genFramebuffer() {
         return EXTFramebufferObject.glGenFramebuffersEXT();
     }
@@ -388,6 +413,7 @@ public class LwjglGL20 implements GL {
         EXTFramebufferObject.glGenRenderbuffersEXT(renderbuffers);
     }
 
+    @Override
     public int genRenderbuffer() {
         return EXTFramebufferObject.glGenRenderbuffersEXT();
     }
@@ -397,6 +423,7 @@ public class LwjglGL20 implements GL {
         GL11.glGenTextures(textures);
     }
 
+    @Override
     public int genTexture() {
         return GL11.glGenTextures();
     }
@@ -764,6 +791,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform1(location, v);
     }
 
+    @Override
     public void uniform1fv(int location, int count, float[] v, int offset) {
         GL20.glUniform1(location, toFloatBuffer(v, offset, count));
     }
@@ -778,6 +806,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform1(location, v);
     }
 
+    @Override
     public void uniform1iv(int location, int count, int[] v, int offset) {
         GL20.glUniform1(location, toIntBuffer(v, offset, count));
     }
@@ -792,6 +821,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform2(location, v);
     }
 
+    @Override
     public void uniform2fv(int location, int count, float[] v, int offset) {
         GL20.glUniform2(location, toFloatBuffer(v, offset, count << 1));
     }
@@ -806,6 +836,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform2(location, v);
     }
 
+    @Override
     public void uniform2iv(int location, int count, int[] v, int offset) {
         GL20.glUniform2(location, toIntBuffer(v, offset, count << 1));
     }
@@ -820,6 +851,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform3(location, v);
     }
 
+    @Override
     public void uniform3fv(int location, int count, float[] v, int offset) {
         GL20.glUniform3(location, toFloatBuffer(v, offset, count * 3));
     }
@@ -834,6 +866,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform3(location, v);
     }
 
+    @Override
     public void uniform3iv(int location, int count, int[] v, int offset) {
         GL20.glUniform3(location, toIntBuffer(v, offset, count * 3));
     }
@@ -848,6 +881,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform4(location, v);
     }
 
+    @Override
     public void uniform4fv(int location, int count, float[] v, int offset) {
         GL20.glUniform4(location, toFloatBuffer(v, offset, count << 2));
     }
@@ -862,6 +896,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniform4(location, v);
     }
 
+    @Override
     public void uniform4iv(int location, int count, int[] v, int offset) {
         GL20.glUniform4(location, toIntBuffer(v, offset, count << 2));
     }
@@ -871,6 +906,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniformMatrix2(location, transpose, value);
     }
 
+    @Override
     public void uniformMatrix2fv(int location, int count, boolean transpose, float[] value, int offset) {
         GL20.glUniformMatrix2(location, transpose, toFloatBuffer(value, offset, count << 2));
     }
@@ -880,6 +916,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniformMatrix3(location, transpose, value);
     }
 
+    @Override
     public void uniformMatrix3fv(int location, int count, boolean transpose, float[] value, int offset) {
         GL20.glUniformMatrix3(location, transpose, toFloatBuffer(value, offset, count * 9));
     }
@@ -889,6 +926,7 @@ public class LwjglGL20 implements GL {
         GL20.glUniformMatrix4(location, transpose, value);
     }
 
+    @Override
     public void uniformMatrix4fv(int location, int count, boolean transpose, float[] value, int offset) {
         GL20.glUniformMatrix4(location, transpose, toFloatBuffer(value, offset, count << 4));
     }
@@ -987,9 +1025,5 @@ public class LwjglGL20 implements GL {
     @Override
     public void vertexAttribPointer(int indx, int size, int type, boolean normalized, int stride, int ptr) {
         GL20.glVertexAttribPointer(indx, size, type, normalized, stride, ptr);
-    }
-
-    @Override
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source) {
     }
 }

--- a/vtm-ios/src/org/oscim/ios/backend/IosGL.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosGL.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2016 Longri
+ * Copyright 2019 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -139,6 +140,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void deleteTexture(int texture) {
+        iOSGL.glDeleteTexture(texture);
+    }
+
+    @Override
     public void depthFunc(int func) {
         iOSGL.glDepthFunc(func);
     }
@@ -191,6 +197,11 @@ public class IosGL implements GL {
     @Override
     public void genTextures(int n, IntBuffer textures) {
         iOSGL.glGenTextures(n, textures);
+    }
+
+    @Override
+    public int genTexture() {
+        return iOSGL.glGenTexture();
     }
 
     @Override
@@ -339,6 +350,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void deleteFramebuffer(int framebuffer) {
+        iOSGL.glDeleteFramebuffer(framebuffer);
+    }
+
+    @Override
     public void getBufferParameteriv(int target, int pname, IntBuffer params) {
         iOSGL.glGetBufferParameteriv(target, pname, params);
     }
@@ -444,6 +460,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void deleteBuffer(int buffer) {
+        iOSGL.glDeleteBuffer(buffer);
+    }
+
+    @Override
     public void deleteFramebuffers(int n, IntBuffer framebuffers) {
         iOSGL.glDeleteFramebuffers(n, framebuffers);
     }
@@ -451,6 +472,11 @@ public class IosGL implements GL {
     @Override
     public void deleteProgram(int program) {
         iOSGL.glDeleteProgram(program);
+    }
+
+    @Override
+    public void deleteRenderbuffer(int renderbuffer) {
+        iOSGL.glDeleteRenderbuffer(renderbuffer);
     }
 
     @Override
@@ -502,8 +528,18 @@ public class IosGL implements GL {
     }
 
     @Override
+    public int genBuffer() {
+        return iOSGL.glGenBuffer();
+    }
+
+    @Override
     public void generateMipmap(int target) {
         iOSGL.glGenerateMipmap(target);
+    }
+
+    @Override
+    public int genFramebuffer() {
+        return iOSGL.glGenFramebuffer();
     }
 
     @Override
@@ -512,9 +548,13 @@ public class IosGL implements GL {
     }
 
     @Override
+    public int genRenderbuffer() {
+        return iOSGL.glGenRenderbuffer();
+    }
+
+    @Override
     public void genRenderbuffers(int n, IntBuffer renderbuffers) {
-        iOSGL
-                .glGenRenderbuffers(n, renderbuffers);
+        iOSGL.glGenRenderbuffers(n, renderbuffers);
     }
 
     @Override
@@ -600,11 +640,6 @@ public class IosGL implements GL {
                 precisiontype,
                 range,
                 precision);
-    }
-
-    @Override
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source) {
-        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
@@ -721,6 +756,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniform1fv(int location, int count, float[] v, int offset) {
+        iOSGL.glUniform1fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform1i(int location, int x) {
         iOSGL.glUniform1i(location, x);
     }
@@ -728,6 +768,11 @@ public class IosGL implements GL {
     @Override
     public void uniform1iv(int location, int count, IntBuffer v) {
         iOSGL.glUniform1iv(location, count, v);
+    }
+
+    @Override
+    public void uniform1iv(int location, int count, int[] v, int offset) {
+        iOSGL.glUniform1iv(location, count, v, offset);
     }
 
     @Override
@@ -741,6 +786,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniform2fv(int location, int count, float[] v, int offset) {
+        iOSGL.glUniform2fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform2i(int location, int x, int y) {
         iOSGL.glUniform2i(location, x, y);
     }
@@ -748,6 +798,11 @@ public class IosGL implements GL {
     @Override
     public void uniform2iv(int location, int count, IntBuffer v) {
         iOSGL.glUniform2iv(location, count, v);
+    }
+
+    @Override
+    public void uniform2iv(int location, int count, int[] v, int offset) {
+        iOSGL.glUniform2iv(location, count, v, offset);
     }
 
     @Override
@@ -761,6 +816,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniform3fv(int location, int count, float[] v, int offset) {
+        iOSGL.glUniform3fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform3i(int location, int x, int y, int z) {
         iOSGL.glUniform3i(location, x, y, z);
     }
@@ -768,6 +828,11 @@ public class IosGL implements GL {
     @Override
     public void uniform3iv(int location, int count, IntBuffer v) {
         iOSGL.glUniform3iv(location, count, v);
+    }
+
+    @Override
+    public void uniform3iv(int location, int count, int[] v, int offset) {
+        uniform3iv(location, count, v, offset);
     }
 
     @Override
@@ -781,6 +846,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniform4fv(int location, int count, float[] v, int offset) {
+        iOSGL.glUniform4fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform4i(int location, int x, int y, int z, int w) {
         iOSGL.glUniform4i(location, x, y, z, w);
     }
@@ -788,6 +858,11 @@ public class IosGL implements GL {
     @Override
     public void uniform4iv(int location, int count, IntBuffer v) {
         iOSGL.glUniform4iv(location, count, v);
+    }
+
+    @Override
+    public void uniform4iv(int location, int count, int[] v, int offset) {
+        iOSGL.glUniform4iv(location, count, v, offset);
     }
 
     @Override
@@ -800,6 +875,11 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniformMatrix2fv(int location, int count, boolean transpose, float[] value, int offset) {
+        iOSGL.glUniformMatrix2fv(location, count, transpose, value, offset);
+    }
+
+    @Override
     public void uniformMatrix3fv(int location, int count, boolean transpose, FloatBuffer value) {
         iOSGL.glUniformMatrix3fv(
                 location,
@@ -809,12 +889,22 @@ public class IosGL implements GL {
     }
 
     @Override
+    public void uniformMatrix3fv(int location, int count, boolean transpose, float[] value, int offset) {
+        iOSGL.glUniformMatrix3fv(location, count, transpose, value, offset);
+    }
+
+    @Override
     public void uniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value) {
         iOSGL.glUniformMatrix4fv(
                 location,
                 count,
                 transpose,
                 value);
+    }
+
+    @Override
+    public void uniformMatrix4fv(int location, int count, boolean transpose, float[] value, int offset) {
+        iOSGL.glUniformMatrix4fv(location, count, transpose, value, offset);
     }
 
     @Override

--- a/vtm-web/src/org/oscim/gdx/client/GdxGL.java
+++ b/vtm-web/src/org/oscim/gdx/client/GdxGL.java
@@ -1,5 +1,20 @@
-package org.oscim.gdx.client;
-
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2019 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 /*******************************************************************************
  * Copyright 2011 See AUTHORS file.
  * <p/>
@@ -15,6 +30,8 @@ package org.oscim.gdx.client;
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ******************************************************************************/
+
+package org.oscim.gdx.client;
 
 import com.badlogic.gdx.backends.gwt.GwtGL20;
 import com.badlogic.gdx.graphics.Pixmap;
@@ -37,15 +54,10 @@ public class GdxGL extends GwtGL20 implements GL {
         this.gl = gl;
     }
 
-    //    @Override
-    //    public void glGetShaderSource(int shader, int bufsize, Buffer length, String source) {
-    //
-    //    }
-
     @Override
     public void glTexImage2D(int target, int level, int internalformat, int width, int height,
                              int border, int format, int type, Buffer pixels) {
-
+        /*glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);*/
         if (pixels == null) {
             gl.texImage2D(target, level, internalformat,
                     width, height, border, format,
@@ -166,6 +178,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void deleteTexture(int texture) {
+        glDeleteTexture(texture);
+    }
+
+    @Override
     public void depthFunc(int func) {
         glDepthFunc(func);
     }
@@ -218,6 +235,11 @@ public class GdxGL extends GwtGL20 implements GL {
     @Override
     public void genTextures(int n, IntBuffer textures) {
         glGenTextures(n, textures);
+    }
+
+    @Override
+    public int genTexture() {
+        return glGenTexture();
     }
 
     @Override
@@ -357,6 +379,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void deleteFramebuffer(int framebuffer) {
+        glDeleteFramebuffer(framebuffer);
+    }
+
+    @Override
     public void getBufferParameteriv(int target, int pname, IntBuffer params) {
         glGetBufferParameteriv(target, pname, params);
     }
@@ -462,6 +489,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void deleteBuffer(int buffer) {
+        glDeleteBuffer(buffer);
+    }
+
+    @Override
     public void deleteFramebuffers(int n, IntBuffer framebuffers) {
         glDeleteFramebuffers(n, framebuffers);
     }
@@ -469,6 +501,11 @@ public class GdxGL extends GwtGL20 implements GL {
     @Override
     public void deleteProgram(int program) {
         glDeleteProgram(program);
+    }
+
+    @Override
+    public void deleteRenderbuffer(int renderbuffer) {
+        glDeleteRenderbuffer(renderbuffer);
     }
 
     @Override
@@ -509,13 +546,28 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public int genBuffer() {
+        return glGenBuffer();
+    }
+
+    @Override
     public void generateMipmap(int target) {
         glGenerateMipmap(target);
     }
 
     @Override
+    public int genFramebuffer() {
+        return glGenFramebuffer();
+    }
+
+    @Override
     public void genFramebuffers(int n, IntBuffer framebuffers) {
         glGenFramebuffers(n, framebuffers);
+    }
+
+    @Override
+    public int genRenderbuffer() {
+        return glGenRenderbuffer();
     }
 
     @Override
@@ -598,11 +650,6 @@ public class GdxGL extends GwtGL20 implements GL {
                 precisiontype,
                 range,
                 precision);
-    }
-
-    @Override
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source) {
-        throw new UnsupportedOperationException("Not implemented");
     }
 
     @Override
@@ -715,6 +762,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniform1fv(int location, int count, float[] v, int offset) {
+        glUniform1fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform1i(int location, int x) {
         glUniform1i(location, x);
     }
@@ -722,6 +774,11 @@ public class GdxGL extends GwtGL20 implements GL {
     @Override
     public void uniform1iv(int location, int count, IntBuffer v) {
         glUniform1iv(location, count, v);
+    }
+
+    @Override
+    public void uniform1iv(int location, int count, int[] v, int offset) {
+        glUniform1iv(location, count, v, offset);
     }
 
     @Override
@@ -735,6 +792,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniform2fv(int location, int count, float[] v, int offset) {
+        glUniform2fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform2i(int location, int x, int y) {
         glUniform2i(location, x, y);
     }
@@ -742,6 +804,11 @@ public class GdxGL extends GwtGL20 implements GL {
     @Override
     public void uniform2iv(int location, int count, IntBuffer v) {
         glUniform2iv(location, count, v);
+    }
+
+    @Override
+    public void uniform2iv(int location, int count, int[] v, int offset) {
+        glUniform2iv(location, count, v, offset);
     }
 
     @Override
@@ -755,6 +822,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniform3fv(int location, int count, float[] v, int offset) {
+        glUniform3fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform3i(int location, int x, int y, int z) {
         glUniform3i(location, x, y, z);
     }
@@ -762,6 +834,11 @@ public class GdxGL extends GwtGL20 implements GL {
     @Override
     public void uniform3iv(int location, int count, IntBuffer v) {
         glUniform3iv(location, count, v);
+    }
+
+    @Override
+    public void uniform3iv(int location, int count, int[] v, int offset) {
+        glUniform3iv(location, count, v, offset);
     }
 
     @Override
@@ -775,6 +852,11 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniform4fv(int location, int count, float[] v, int offset) {
+        glUniform4fv(location, count, v, offset);
+    }
+
+    @Override
     public void uniform4i(int location, int x, int y, int z, int w) {
         glUniform4i(location, x, y, z, w);
     }
@@ -785,8 +867,18 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniform4iv(int location, int count, int[] v, int offset) {
+        glUniform4iv(location, count, v, offset);
+    }
+
+    @Override
     public void uniformMatrix2fv(int location, int count, boolean transpose, FloatBuffer value) {
         glUniformMatrix2fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix2fv(int location, int count, boolean transpose, float[] value, int offset) {
+        glUniformMatrix2fv(location, count, transpose, value, offset);
     }
 
     @Override
@@ -795,8 +887,18 @@ public class GdxGL extends GwtGL20 implements GL {
     }
 
     @Override
+    public void uniformMatrix3fv(int location, int count, boolean transpose, float[] value, int offset) {
+        glUniformMatrix3fv(location, count, transpose, value, offset);
+    }
+
+    @Override
     public void uniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value) {
         glUniformMatrix4fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix4fv(int location, int count, boolean transpose, float[] value, int offset) {
+        glUniformMatrix4fv(location, count, transpose, value, offset);
     }
 
     @Override

--- a/vtm/src/org/oscim/backend/GL.java
+++ b/vtm/src/org/oscim/backend/GL.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -386,6 +387,8 @@ public interface GL {
 
     public void deleteTextures(int n, IntBuffer textures);
 
+    public void deleteTexture(int texture);
+
     public void depthFunc(int func);
 
     public void depthMask(boolean flag);
@@ -407,6 +410,8 @@ public interface GL {
     public void frontFace(int mode);
 
     public void genTextures(int n, IntBuffer textures);
+
+    public int genTexture();
 
     public int getError();
 
@@ -472,11 +477,17 @@ public interface GL {
 
     public int createShader(int type);
 
+    public void deleteBuffer(int buffer);
+
     public void deleteBuffers(int n, IntBuffer buffers);
+
+    public void deleteFramebuffer(int framebuffer);
 
     public void deleteFramebuffers(int n, IntBuffer framebuffers);
 
     public void deleteProgram(int program);
+
+    public void deleteRenderbuffer(int renderbuffer);
 
     public void deleteRenderbuffers(int n, IntBuffer renderbuffers);
 
@@ -494,11 +505,17 @@ public interface GL {
 
     public void framebufferTexture2D(int target, int attachment, int textarget, int texture, int level);
 
+    public int genBuffer();
+
     public void genBuffers(int n, IntBuffer buffers);
 
     public void generateMipmap(int target);
 
+    public int genFramebuffer();
+
     public void genFramebuffers(int n, IntBuffer framebuffers);
+
+    public int genRenderbuffer();
 
     public void genRenderbuffers(int n, IntBuffer renderbuffers);
 
@@ -533,8 +550,6 @@ public interface GL {
     public String getShaderInfoLog(int shader);
 
     public void getShaderPrecisionFormat(int shadertype, int precisiontype, IntBuffer range, IntBuffer precision);
-
-    public void getShaderSource(int shader, int bufsize, Buffer length, String source);
 
     public void getTexParameterfv(int target, int pname, FloatBuffer params);
 
@@ -595,39 +610,61 @@ public interface GL {
 
     public void uniform1fv(int location, int count, FloatBuffer v);
 
+    public void uniform1fv(int location, int count, float v[], int offset);
+
     public void uniform1i(int location, int x);
 
     public void uniform1iv(int location, int count, IntBuffer v);
+
+    public void uniform1iv(int location, int count, int v[], int offset);
 
     public void uniform2f(int location, float x, float y);
 
     public void uniform2fv(int location, int count, FloatBuffer v);
 
+    public void uniform2fv(int location, int count, float v[], int offset);
+
     public void uniform2i(int location, int x, int y);
 
     public void uniform2iv(int location, int count, IntBuffer v);
+
+    public void uniform2iv(int location, int count, int[] v, int offset);
 
     public void uniform3f(int location, float x, float y, float z);
 
     public void uniform3fv(int location, int count, FloatBuffer v);
 
+    public void uniform3fv(int location, int count, float[] v, int offset);
+
     public void uniform3i(int location, int x, int y, int z);
 
     public void uniform3iv(int location, int count, IntBuffer v);
+
+    public void uniform3iv(int location, int count, int v[], int offset);
 
     public void uniform4f(int location, float x, float y, float z, float w);
 
     public void uniform4fv(int location, int count, FloatBuffer v);
 
+    public void uniform4fv(int location, int count, float v[], int offset);
+
     public void uniform4i(int location, int x, int y, int z, int w);
 
     public void uniform4iv(int location, int count, IntBuffer v);
 
+    public void uniform4iv(int location, int count, int v[], int offset);
+
     public void uniformMatrix2fv(int location, int count, boolean transpose, FloatBuffer value);
+
+    public void uniformMatrix2fv(int location, int count, boolean transpose, float value[], int offset);
 
     public void uniformMatrix3fv(int location, int count, boolean transpose, FloatBuffer value);
 
+    public void uniformMatrix3fv(int location, int count, boolean transpose, float value[], int offset);
+
     public void uniformMatrix4fv(int location, int count, boolean transpose, FloatBuffer value);
+
+    public void uniformMatrix4fv(int location, int count, boolean transpose, float value[], int offset);
 
     public void useProgram(int program);
 


### PR DESCRIPTION
`AndroidGL` is an implementation by vtm, so I used _"missing implementation"_ message for unsupported operations there (as you said). These unsupported operations are able to be implemented via [JNI](https://github.com/libgdx/libgdx/blob/master/gdx/jni/android/AndroidGL20.cpp) or may can converted to java code.

Sorry for the recent circumstances :)

Related: #640 