### PR TITLE
Glutils: generate / draw buffers, set color

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/GdxActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/GdxActivity.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2018 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -23,6 +23,7 @@ import android.util.DisplayMetrics;
 
 import com.badlogic.gdx.backends.android.AndroidApplication;
 import com.badlogic.gdx.backends.android.AndroidApplicationConfiguration;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 import org.oscim.android.MapPreferences;
@@ -33,6 +34,7 @@ import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.Tile;
 import org.oscim.gdx.AndroidGL;
+import org.oscim.gdx.AndroidGL30;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
 import org.oscim.gdx.poi3d.Poi3DLayer;
@@ -66,7 +68,6 @@ public class GdxActivity extends AndroidApplication {
 
         AndroidGraphics.init();
         GdxAssets.init("");
-        GLAdapter.init(new AndroidGL());
         DateTimeAdapter.init(new DateTime());
 
         DisplayMetrics metrics = getResources().getDisplayMetrics();
@@ -84,6 +85,14 @@ public class GdxActivity extends AndroidApplication {
     }
 
     class GdxMapAndroid extends GdxMap {
+        @Override
+        protected void initGLAdapter(GLVersion version) {
+            if (version.getMajorVersion() >= 3)
+                GLAdapter.init(new AndroidGL30());
+            else
+                GLAdapter.init(new AndroidGL());
+        }
+
         @Override
         public void createLayers() {
             TileSource tileSource = OSciMap4TileSource.builder()

--- a/vtm-android-gdx/src/org/oscim/gdx/AndroidGL30.java
+++ b/vtm-android-gdx/src/org/oscim/gdx/AndroidGL30.java
@@ -1,0 +1,878 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.oscim.gdx;
+
+import android.annotation.SuppressLint;
+import android.opengl.GLES30;
+
+import org.oscim.backend.GL30;
+
+/**
+ * See https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+ */
+@SuppressLint("NewApi")
+public class AndroidGL30 extends AndroidGL implements GL30 {
+    @Override
+    public void readBuffer(int mode) {
+        GLES30.glReadBuffer(mode);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, java.nio.Buffer indices) {
+        GLES30.glDrawRangeElements(mode, start, end, count, type, indices);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, int offset) {
+        GLES30.glDrawRangeElements(mode, start, end, count, type, offset);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, java.nio.Buffer pixels) {
+        if (pixels == null)
+            GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, 0);
+        else
+            GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, int offset) {
+        GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, java.nio.Buffer pixels) {
+        GLES30.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, int offset) {
+        GLES30.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
+    }
+
+    @Override
+    public void copyTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width,
+                                  int height) {
+        GLES30.glCopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    }
+
+//
+// @Override
+// public void compressedTexImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int
+// imageSize, java.nio.Buffer data) {
+// GLES30.glCompressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
+// }
+//
+// @Override
+// public void compressedTexImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int
+// imageSize, int offset) {
+// GLES30.glCompressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
+// }
+//
+// @Override
+// public void compressedTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int
+// depth, int format, int imageSize, java.nio.Buffer data) {
+// GLES30.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+//
+// @Override
+// public void compressedTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int
+// depth, int format, int imageSize, int offset) {
+// GLES30.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
+// }
+
+    @Override
+    public void genQueries(int n, int[] ids, int offset) {
+        GLES30.glGenQueries(n, ids, offset);
+    }
+
+    @Override
+    public void genQueries(int n, java.nio.IntBuffer ids) {
+        GLES30.glGenQueries(n, ids);
+    }
+
+    @Override
+    public void deleteQueries(int n, int[] ids, int offset) {
+        GLES30.glDeleteQueries(n, ids, offset);
+    }
+
+    @Override
+    public void deleteQueries(int n, java.nio.IntBuffer ids) {
+        GLES30.glDeleteQueries(n, ids);
+    }
+
+    @Override
+    public boolean isQuery(int id) {
+        return GLES30.glIsQuery(id);
+    }
+
+    @Override
+    public void beginQuery(int target, int id) {
+        GLES30.glBeginQuery(target, id);
+    }
+
+    @Override
+    public void endQuery(int target) {
+        GLES30.glEndQuery(target);
+    }
+
+// @Override
+// public void getQueryiv(int target, int pname, int[] params, int offset) {
+// GLES30.glGetQueryiv(target, pname, params, offset);
+// }
+
+    @Override
+    public void getQueryiv(int target, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetQueryiv(target, pname, params);
+    }
+
+// @Override
+// public void getQueryObjectuiv(int id, int pname, int[] params, int offset) {
+// GLES30.glGetQueryObjectuiv(id, pname, params, offset);
+// }
+
+    @Override
+    public void getQueryObjectuiv(int id, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetQueryObjectuiv(id, pname, params);
+    }
+
+    @Override
+    public boolean unmapBuffer(int target) {
+        return GLES30.glUnmapBuffer(target);
+    }
+
+    @Override
+    public java.nio.Buffer getBufferPointerv(int target, int pname) {
+        return GLES30.glGetBufferPointerv(target, pname);
+    }
+
+// @Override
+// public void drawBuffers(int n, int[] bufs, int offset) {
+// GLES30.glDrawBuffers(n, bufs, offset);
+// }
+
+    @Override
+    public void drawBuffers(int n, java.nio.IntBuffer bufs) {
+        GLES30.glDrawBuffers(n, bufs);
+    }
+
+// @Override
+// public void uniformMatrix2x3fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix2x3fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix2x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix2x3fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix3x2fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix3x2fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix3x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix3x2fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix2x4fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix2x4fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix2x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix2x4fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix4x2fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix4x2fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix4x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix4x2fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix3x4fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix3x4fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix3x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix3x4fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix4x3fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix4x3fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix4x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix4x3fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void blitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1,
+                                int mask, int filter) {
+        GLES30.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    }
+
+    @Override
+    public void renderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height) {
+        GLES30.glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+    }
+
+    @Override
+    public void framebufferTextureLayer(int target, int attachment, int texture, int level, int layer) {
+        GLES30.glFramebufferTextureLayer(target, attachment, texture, level, layer);
+    }
+
+// @Override
+// public java.nio.Buffer mapBufferRange(int target, int offset, int length, int access) {
+// return GLES30.glMapBufferRange(target, offset, length, access);
+// }
+
+    @Override
+    public void flushMappedBufferRange(int target, int offset, int length) {
+        GLES30.glFlushMappedBufferRange(target, offset, length);
+    }
+
+    @Override
+    public void bindVertexArray(int array) {
+        GLES30.glBindVertexArray(array);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, int[] arrays, int offset) {
+        GLES30.glDeleteVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, java.nio.IntBuffer arrays) {
+        GLES30.glDeleteVertexArrays(n, arrays);
+    }
+
+    @Override
+    public void genVertexArrays(int n, int[] arrays, int offset) {
+        GLES30.glGenVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void genVertexArrays(int n, java.nio.IntBuffer arrays) {
+        GLES30.glGenVertexArrays(n, arrays);
+    }
+
+    @Override
+    public boolean isVertexArray(int array) {
+        return GLES30.glIsVertexArray(array);
+    }
+
+// @Override
+// public void getIntegeri_v(int target, int index, int[] data, int offset) {
+// GLES30.glGetIntegeri_v(target, index, data, offset);
+// }
+
+// @Override
+// public void getIntegeri_v(int target, int index, java.nio.IntBuffer data) {
+// GLES30.glGetIntegeri_v(target, index, data);
+// }
+
+    @Override
+    public void beginTransformFeedback(int primitiveMode) {
+        GLES30.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void endTransformFeedback() {
+        GLES30.glEndTransformFeedback();
+    }
+
+    @Override
+    public void bindBufferRange(int target, int index, int buffer, int offset, int size) {
+        GLES30.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void bindBufferBase(int target, int index, int buffer) {
+        GLES30.glBindBufferBase(target, index, buffer);
+    }
+
+    @Override
+    public void transformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        GLES30.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+// @Override
+// public void getTransformFeedbackVarying(int program, int index, int bufsize, int[] length, int lengthOffset, int[] size, int
+// sizeOffset, int[] type, int typeOffset, byte[] name, int nameOffset) {
+// GLES30.glGetTransformFeedbackVarying(program, index, bufsize, length, lengthOffset, size, sizeOffset, type, typeOffset, name,
+// nameOffset);
+// }
+
+// @Override
+// public void getTransformFeedbackVarying(int program, int index, int bufsize, java.nio.IntBuffer length, java.nio.IntBuffer
+// size, java.nio.IntBuffer type, byte name) {
+// GLES30.glGetTransformFeedbackVarying(program, index, bufsize, length, size, type, name);
+// }
+//
+// @Override
+// public String getTransformFeedbackVarying(int program, int index, int[] size, int sizeOffset, int[] type, int typeOffset) {
+// return GLES30.glGetTransformFeedbackVarying(program, index, size, sizeOffset, type, typeOffset);
+// }
+//
+// @Override
+// public String getTransformFeedbackVarying(int program, int index, java.nio.IntBuffer size, java.nio.IntBuffer type) {
+// return GLES30.glGetTransformFeedbackVarying(program, index, size, type);
+// }
+
+    @Override
+    public void vertexAttribIPointer(int index, int size, int type, int stride, int offset) {
+        GLES30.glVertexAttribIPointer(index, size, type, stride, offset);
+    }
+
+// @Override
+// public void getVertexAttribIiv(int index, int pname, int[] params, int offset) {
+// GLES30.glGetVertexAttribIiv(index, pname, params, offset);
+// }
+
+    @Override
+    public void getVertexAttribIiv(int index, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetVertexAttribIiv(index, pname, params);
+    }
+
+// @Override
+// public void getVertexAttribIuiv(int index, int pname, int[] params, int offset) {
+// GLES30.glGetVertexAttribIuiv(index, pname, params, offset);
+// }
+
+    @Override
+    public void getVertexAttribIuiv(int index, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetVertexAttribIuiv(index, pname, params);
+    }
+
+    @Override
+    public void vertexAttribI4i(int index, int x, int y, int z, int w) {
+        GLES30.glVertexAttribI4i(index, x, y, z, w);
+    }
+
+    @Override
+    public void vertexAttribI4ui(int index, int x, int y, int z, int w) {
+        GLES30.glVertexAttribI4ui(index, x, y, z, w);
+    }
+
+// @Override
+// public void vertexAttribI4iv(int index, int[] v, int offset) {
+// GLES30.glVertexAttribI4iv(index, v, offset);
+// }
+//
+// @Override
+// public void vertexAttribI4iv(int index, java.nio.IntBuffer v) {
+// GLES30.glVertexAttribI4iv(index, v);
+// }
+//
+// @Override
+// public void vertexAttribI4uiv(int index, int[] v, int offset) {
+// GLES30.glVertexAttribI4uiv(index, v, offset);
+// }
+//
+// @Override
+// public void vertexAttribI4uiv(int index, java.nio.IntBuffer v) {
+// GLES30.glVertexAttribI4uiv(index, v);
+// }
+//
+// @Override
+// public void getUniformuiv(int program, int location, int[] params, int offset) {
+// GLES30.glGetUniformuiv(program, location, params, offset);
+// }
+
+    @Override
+    public void getUniformuiv(int program, int location, java.nio.IntBuffer params) {
+        GLES30.glGetUniformuiv(program, location, params);
+    }
+
+    @Override
+    public int getFragDataLocation(int program, String name) {
+        return GLES30.glGetFragDataLocation(program, name);
+    }
+
+// @Override
+// public void uniform1ui(int location, int v0) {
+// GLES30.glUniform1ui(location, v0);
+// }
+//
+// @Override
+// public void uniform2ui(int location, int v0, int v1) {
+// GLES30.glUniform2ui(location, v0, v1);
+// }
+//
+// @Override
+// public void uniform3ui(int location, int v0, int v1, int v2) {
+// GLES30.glUniform3ui(location, v0, v1, v2);
+// }
+
+// @Override
+// public void uniform4ui(int location, int v0, int v1, int v2, int v3) {
+// GLES30.glUniform4ui(location, v0, v1, v2, v3);
+// }
+//
+// @Override
+// public void uniform1uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform1uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform1uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform1uiv(location, count, value);
+    }
+
+// @Override
+// public void uniform2uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform2uiv(location, count, value, offset);
+// }
+//
+// @Override
+// public void uniform2uiv(int location, int count, java.nio.IntBuffer value) {
+// GLES30.glUniform2uiv(location, count, value);
+// }
+//
+// @Override
+// public void uniform3uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform3uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform3uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform3uiv(location, count, value);
+    }
+
+// @Override
+// public void uniform4uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform4uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform4uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform4uiv(location, count, value);
+    }
+
+// @Override
+// public void clearBufferiv(int buffer, int drawbuffer, int[] value, int offset) {
+// GLES30.glClearBufferiv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferiv(int buffer, int drawbuffer, java.nio.IntBuffer value) {
+        GLES30.glClearBufferiv(buffer, drawbuffer, value);
+    }
+
+// @Override
+// public void clearBufferuiv(int buffer, int drawbuffer, int[] value, int offset) {
+// GLES30.glClearBufferuiv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferuiv(int buffer, int drawbuffer, java.nio.IntBuffer value) {
+        GLES30.glClearBufferuiv(buffer, drawbuffer, value);
+    }
+
+//
+// @Override
+// public void clearBufferfv(int buffer, int drawbuffer, float[] value, int offset) {
+// GLES30.glClearBufferfv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferfv(int buffer, int drawbuffer, java.nio.FloatBuffer value) {
+        GLES30.glClearBufferfv(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfi(int buffer, int drawbuffer, float depth, int stencil) {
+        GLES30.glClearBufferfi(buffer, drawbuffer, depth, stencil);
+    }
+
+    @Override
+    public String getStringi(int name, int index) {
+        return GLES30.glGetStringi(name, index);
+    }
+
+    @Override
+    public void copyBufferSubData(int readTarget, int writeTarget, int readOffset, int writeOffset, int size) {
+        GLES30.glCopyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
+    }
+
+//
+// @Override
+// public void getUniformIndices(int program, String[] uniformNames, int[] uniformIndices, int uniformIndicesOffset) {
+// GLES30.glGetUniformIndices(program, uniformNames, uniformIndices, uniformIndicesOffset);
+// }
+
+    @Override
+    public void getUniformIndices(int program, String[] uniformNames, java.nio.IntBuffer uniformIndices) {
+        GLES30.glGetUniformIndices(program, uniformNames, uniformIndices);
+    }
+
+// @Override
+// public void getActiveUniformsiv(int program, int uniformCount, int[] uniformIndices, int uniformIndicesOffset, int pname,
+// int[] params, int paramsOffset) {
+// GLES30.glGetActiveUniformsiv(program, uniformCount, uniformIndices, uniformIndicesOffset, pname, params, paramsOffset);
+// }
+
+    @Override
+    public void getActiveUniformsiv(int program, int uniformCount, java.nio.IntBuffer uniformIndices, int pname,
+                                    java.nio.IntBuffer params) {
+        GLES30.glGetActiveUniformsiv(program, uniformCount, uniformIndices, pname, params);
+    }
+
+    @Override
+    public int getUniformBlockIndex(int program, String uniformBlockName) {
+        return GLES30.glGetUniformBlockIndex(program, uniformBlockName);
+    }
+
+//
+// @Override
+// public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, int[] params, int offset) {
+// GLES30.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params, offset);
+// }
+
+    @Override
+    public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
+    }
+
+//
+// @Override
+// public void getActiveUniformBlockName(int program, int uniformBlockIndex, int bufSize, int[] length, int lengthOffset, byte[]
+// uniformBlockName, int uniformBlockNameOffset) {
+// GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex, bufSize, length, lengthOffset, uniformBlockName,
+// uniformBlockNameOffset);
+// }
+
+    @Override
+    public void getActiveUniformBlockName(int program, int uniformBlockIndex, java.nio.Buffer length,
+                                          java.nio.Buffer uniformBlockName) {
+        GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex, length, uniformBlockName);
+    }
+
+    @Override
+    public String getActiveUniformBlockName(int program, int uniformBlockIndex) {
+        return GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex);
+    }
+
+    @Override
+    public void uniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding) {
+        GLES30.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    }
+
+    @Override
+    public void drawArraysInstanced(int mode, int first, int count, int instanceCount) {
+        GLES30.glDrawArraysInstanced(mode, first, count, instanceCount);
+    }
+
+// @Override
+// public void drawElementsInstanced(int mode, int count, int type, java.nio.Buffer indices, int instanceCount) {
+// GLES30.glDrawElementsInstanced(mode, count, type, indices, instanceCount);
+// }
+
+    @Override
+    public void drawElementsInstanced(int mode, int count, int type, int indicesOffset, int instanceCount) {
+        GLES30.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
+    }
+
+// @Override
+// public long fenceSync(int condition, int flags) {
+// return GLES30.glFenceSync(condition, flags);
+// }
+//
+// @Override
+// public boolean isSync(long sync) {
+// return GLES30.glIsSync(sync);
+// }
+//
+// @Override
+// public void deleteSync(long sync) {
+// GLES30.glDeleteSync(sync);
+// }
+//
+// @Override
+// public int clientWaitSync(long sync, int flags, long timeout) {
+// return GLES30.glClientWaitSync(sync, flags, timeout);
+// }
+
+// @Override
+// public void waitSync(long sync, int flags, long timeout) {
+// GLES30.glWaitSync(sync, flags, timeout);
+// }
+//
+// @Override
+// public void getInteger64v(int pname, long[] params, int offset) {
+// GLES30.glGetInteger64v(pname, params, offset);
+// }
+
+    @Override
+    public void getInteger64v(int pname, java.nio.LongBuffer params) {
+        GLES30.glGetInteger64v(pname, params);
+    }
+
+// @Override
+// public void getSynciv(long sync, int pname, int bufSize, int[] length, int lengthOffset, int[] values, int valuesOffset) {
+// GLES30.glGetSynciv(sync, pname, bufSize, length, lengthOffset, values, valuesOffset);
+// }
+//
+// @Override
+// public void getSynciv(long sync, int pname, int bufSize, java.nio.IntBuffer length, java.nio.IntBuffer values) {
+// GLES30.glGetSynciv(sync, pname, bufSize, length, values);
+// }
+//
+// @Override
+// public void getInteger64i_v(int target, int index, long[] data, int offset) {
+// GLES30.glGetInteger64i_v(target, index, data, offset);
+// }
+//
+// @Override
+// public void getInteger64i_v(int target, int index, java.nio.LongBuffer data) {
+// GLES30.glGetInteger64i_v(target, index, data);
+// }
+//
+// @Override
+// public void getBufferParameteri64v(int target, int pname, long[] params, int offset) {
+// GLES30.glGetBufferParameteri64v(target, pname, params, offset);
+// }
+
+    @Override
+    public void getBufferParameteri64v(int target, int pname, java.nio.LongBuffer params) {
+        GLES30.glGetBufferParameteri64v(target, pname, params);
+    }
+
+    @Override
+    public void genSamplers(int count, int[] samplers, int offset) {
+        GLES30.glGenSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void genSamplers(int count, java.nio.IntBuffer samplers) {
+        GLES30.glGenSamplers(count, samplers);
+    }
+
+    @Override
+    public void deleteSamplers(int count, int[] samplers, int offset) {
+        GLES30.glDeleteSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void deleteSamplers(int count, java.nio.IntBuffer samplers) {
+        GLES30.glDeleteSamplers(count, samplers);
+    }
+
+    @Override
+    public boolean isSampler(int sampler) {
+        return GLES30.glIsSampler(sampler);
+    }
+
+    @Override
+    public void bindSampler(int unit, int sampler) {
+        GLES30.glBindSampler(unit, sampler);
+    }
+
+    @Override
+    public void samplerParameteri(int sampler, int pname, int param) {
+        GLES30.glSamplerParameteri(sampler, pname, param);
+    }
+
+//
+// @Override
+// public void samplerParameteriv(int sampler, int pname, int[] param, int offset) {
+// GLES30.glSamplerParameteriv(sampler, pname, param, offset);
+// }
+
+    @Override
+    public void samplerParameteriv(int sampler, int pname, java.nio.IntBuffer param) {
+        GLES30.glSamplerParameteriv(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterf(int sampler, int pname, float param) {
+        GLES30.glSamplerParameterf(sampler, pname, param);
+    }
+
+// @Override
+// public void samplerParameterfv(int sampler, int pname, float[] param, int offset) {
+// GLES30.glSamplerParameterfv(sampler, pname, param, offset);
+// }
+
+    @Override
+    public void samplerParameterfv(int sampler, int pname, java.nio.FloatBuffer param) {
+        GLES30.glSamplerParameterfv(sampler, pname, param);
+    }
+
+//
+// @Override
+// public void getSamplerParameteriv(int sampler, int pname, int[] params, int offset) {
+// GLES30.glGetSamplerParameteriv(sampler, pname, params, offset);
+// }
+
+    @Override
+    public void getSamplerParameteriv(int sampler, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetSamplerParameteriv(sampler, pname, params);
+    }
+
+// @Override
+// public void getSamplerParameterfv(int sampler, int pname, float[] params, int offset) {
+// GLES30.glGetSamplerParameterfv(sampler, pname, params, offset);
+// }
+
+    @Override
+    public void getSamplerParameterfv(int sampler, int pname, java.nio.FloatBuffer params) {
+        GLES30.glGetSamplerParameterfv(sampler, pname, params);
+    }
+
+    @Override
+    public void vertexAttribDivisor(int index, int divisor) {
+        GLES30.glVertexAttribDivisor(index, divisor);
+    }
+
+    @Override
+    public void bindTransformFeedback(int target, int id) {
+        GLES30.glBindTransformFeedback(target, id);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, int[] ids, int offset) {
+        GLES30.glDeleteTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, java.nio.IntBuffer ids) {
+        GLES30.glDeleteTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, int[] ids, int offset) {
+        GLES30.glGenTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, java.nio.IntBuffer ids) {
+        GLES30.glGenTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public boolean isTransformFeedback(int id) {
+        return GLES30.glIsTransformFeedback(id);
+    }
+
+    @Override
+    public void pauseTransformFeedback() {
+        GLES30.glPauseTransformFeedback();
+    }
+
+    @Override
+    public void resumeTransformFeedback() {
+        GLES30.glResumeTransformFeedback();
+    }
+
+// @Override
+// public void getProgramBinary(int program, int bufSize, int[] length, int lengthOffset, int[] binaryFormat, int
+// binaryFormatOffset, java.nio.Buffer binary) {
+// GLES30.glGetProgramBinary(program, bufSize, length, lengthOffset, binaryFormat, binaryFormatOffset, binary);
+// }
+//
+// @Override
+// public void getProgramBinary(int program, int bufSize, java.nio.IntBuffer length, java.nio.IntBuffer binaryFormat,
+// java.nio.Buffer binary) {
+// GLES30.glGetProgramBinary(program, bufSize, length, binaryFormat, binary);
+// }
+
+// @Override
+// public void programBinary(int program, int binaryFormat, java.nio.Buffer binary, int length) {
+// GLES30.glProgramBinary(program, binaryFormat, binary, length);
+// }
+
+    @Override
+    public void programParameteri(int program, int pname, int value) {
+        GLES30.glProgramParameteri(program, pname, value);
+    }
+
+// @Override
+// public void invalidateFramebuffer(int target, int numAttachments, int[] attachments, int offset) {
+// GLES30.glInvalidateFramebuffer(target, numAttachments, attachments, offset);
+// }
+
+    @Override
+    public void invalidateFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments) {
+        GLES30.glInvalidateFramebuffer(target, numAttachments, attachments);
+    }
+
+//
+// @Override
+// public void invalidateSubFramebuffer(int target, int numAttachments, int[] attachments, int offset, int x, int y, int width,
+// int height) {
+// GLES30.glInvalidateSubFramebuffer(target, numAttachments, attachments, offset, x, y, width, height);
+// }
+
+    @Override
+    public void invalidateSubFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments, int x, int y,
+                                         int width, int height) {
+        GLES30.glInvalidateSubFramebuffer(target, numAttachments, attachments, x, y, width, height);
+    }
+
+// @Override
+// public void texStorage2D(int target, int levels, int internalformat, int width, int height) {
+// GLES30.glTexStorage2D(target, levels, internalformat, width, height);
+// }
+
+// @Override
+// public void texStorage3D(int target, int levels, int internalformat, int width, int height, int depth) {
+// GLES30.glTexStorage3D(target, levels, internalformat, width, height, depth);
+// }
+//
+// @Override
+// public void getInternalformativ(int target, int internalformat, int pname, int bufSize, int[] params, int offset) {
+// GLES30.glGetInternalformativ(target, internalformat, pname, bufSize, params, offset);
+// }
+//
+// @Override
+// public void getInternalformativ(int target, int internalformat, int pname, int bufSize, java.nio.IntBuffer params) {
+// GLES30.glGetInternalformativ(target, internalformat, pname, bufSize, params);
+// }
+}

--- a/vtm-android/src/org/oscim/android/gl/AndroidGL30.java
+++ b/vtm-android/src/org/oscim/android/gl/AndroidGL30.java
@@ -1,0 +1,878 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*******************************************************************************
+ * Copyright 2014 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.oscim.android.gl;
+
+import android.annotation.SuppressLint;
+import android.opengl.GLES30;
+
+import org.oscim.backend.GL30;
+
+/**
+ * See https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/AndroidGL30.java
+ */
+@SuppressLint("NewApi")
+public class AndroidGL30 extends AndroidGL implements GL30 {
+    @Override
+    public void readBuffer(int mode) {
+        GLES30.glReadBuffer(mode);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, java.nio.Buffer indices) {
+        GLES30.glDrawRangeElements(mode, start, end, count, type, indices);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, int offset) {
+        GLES30.glDrawRangeElements(mode, start, end, count, type, offset);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, java.nio.Buffer pixels) {
+        if (pixels == null)
+            GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, 0);
+        else
+            GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, int offset) {
+        GLES30.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, java.nio.Buffer pixels) {
+        GLES30.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, int offset) {
+        GLES30.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
+    }
+
+    @Override
+    public void copyTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width,
+                                  int height) {
+        GLES30.glCopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    }
+
+//
+// @Override
+// public void compressedTexImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int
+// imageSize, java.nio.Buffer data) {
+// GLES30.glCompressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, data);
+// }
+//
+// @Override
+// public void compressedTexImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int
+// imageSize, int offset) {
+// GLES30.glCompressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
+// }
+//
+// @Override
+// public void compressedTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int
+// depth, int format, int imageSize, java.nio.Buffer data) {
+// GLES30.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, data);
+// }
+//
+// @Override
+// public void compressedTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int
+// depth, int format, int imageSize, int offset) {
+// GLES30.glCompressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
+// }
+
+    @Override
+    public void genQueries(int n, int[] ids, int offset) {
+        GLES30.glGenQueries(n, ids, offset);
+    }
+
+    @Override
+    public void genQueries(int n, java.nio.IntBuffer ids) {
+        GLES30.glGenQueries(n, ids);
+    }
+
+    @Override
+    public void deleteQueries(int n, int[] ids, int offset) {
+        GLES30.glDeleteQueries(n, ids, offset);
+    }
+
+    @Override
+    public void deleteQueries(int n, java.nio.IntBuffer ids) {
+        GLES30.glDeleteQueries(n, ids);
+    }
+
+    @Override
+    public boolean isQuery(int id) {
+        return GLES30.glIsQuery(id);
+    }
+
+    @Override
+    public void beginQuery(int target, int id) {
+        GLES30.glBeginQuery(target, id);
+    }
+
+    @Override
+    public void endQuery(int target) {
+        GLES30.glEndQuery(target);
+    }
+
+// @Override
+// public void getQueryiv(int target, int pname, int[] params, int offset) {
+// GLES30.glGetQueryiv(target, pname, params, offset);
+// }
+
+    @Override
+    public void getQueryiv(int target, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetQueryiv(target, pname, params);
+    }
+
+// @Override
+// public void getQueryObjectuiv(int id, int pname, int[] params, int offset) {
+// GLES30.glGetQueryObjectuiv(id, pname, params, offset);
+// }
+
+    @Override
+    public void getQueryObjectuiv(int id, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetQueryObjectuiv(id, pname, params);
+    }
+
+    @Override
+    public boolean unmapBuffer(int target) {
+        return GLES30.glUnmapBuffer(target);
+    }
+
+    @Override
+    public java.nio.Buffer getBufferPointerv(int target, int pname) {
+        return GLES30.glGetBufferPointerv(target, pname);
+    }
+
+// @Override
+// public void drawBuffers(int n, int[] bufs, int offset) {
+// GLES30.glDrawBuffers(n, bufs, offset);
+// }
+
+    @Override
+    public void drawBuffers(int n, java.nio.IntBuffer bufs) {
+        GLES30.glDrawBuffers(n, bufs);
+    }
+
+// @Override
+// public void uniformMatrix2x3fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix2x3fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix2x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix2x3fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix3x2fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix3x2fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix3x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix3x2fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix2x4fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix2x4fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix2x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix2x4fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix4x2fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix4x2fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix4x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix4x2fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix3x4fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix3x4fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix3x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix3x4fv(location, count, transpose, value);
+    }
+
+// @Override
+// public void uniformMatrix4x3fv(int location, int count, boolean transpose, float[] value, int offset) {
+// GLES30.glUniformMatrix4x3fv(location, count, transpose, value, offset);
+// }
+
+    @Override
+    public void uniformMatrix4x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value) {
+        GLES30.glUniformMatrix4x3fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void blitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1,
+                                int mask, int filter) {
+        GLES30.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    }
+
+    @Override
+    public void renderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height) {
+        GLES30.glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+    }
+
+    @Override
+    public void framebufferTextureLayer(int target, int attachment, int texture, int level, int layer) {
+        GLES30.glFramebufferTextureLayer(target, attachment, texture, level, layer);
+    }
+
+// @Override
+// public java.nio.Buffer mapBufferRange(int target, int offset, int length, int access) {
+// return GLES30.glMapBufferRange(target, offset, length, access);
+// }
+
+    @Override
+    public void flushMappedBufferRange(int target, int offset, int length) {
+        GLES30.glFlushMappedBufferRange(target, offset, length);
+    }
+
+    @Override
+    public void bindVertexArray(int array) {
+        GLES30.glBindVertexArray(array);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, int[] arrays, int offset) {
+        GLES30.glDeleteVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, java.nio.IntBuffer arrays) {
+        GLES30.glDeleteVertexArrays(n, arrays);
+    }
+
+    @Override
+    public void genVertexArrays(int n, int[] arrays, int offset) {
+        GLES30.glGenVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void genVertexArrays(int n, java.nio.IntBuffer arrays) {
+        GLES30.glGenVertexArrays(n, arrays);
+    }
+
+    @Override
+    public boolean isVertexArray(int array) {
+        return GLES30.glIsVertexArray(array);
+    }
+
+// @Override
+// public void getIntegeri_v(int target, int index, int[] data, int offset) {
+// GLES30.glGetIntegeri_v(target, index, data, offset);
+// }
+
+// @Override
+// public void getIntegeri_v(int target, int index, java.nio.IntBuffer data) {
+// GLES30.glGetIntegeri_v(target, index, data);
+// }
+
+    @Override
+    public void beginTransformFeedback(int primitiveMode) {
+        GLES30.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void endTransformFeedback() {
+        GLES30.glEndTransformFeedback();
+    }
+
+    @Override
+    public void bindBufferRange(int target, int index, int buffer, int offset, int size) {
+        GLES30.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void bindBufferBase(int target, int index, int buffer) {
+        GLES30.glBindBufferBase(target, index, buffer);
+    }
+
+    @Override
+    public void transformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        GLES30.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+// @Override
+// public void getTransformFeedbackVarying(int program, int index, int bufsize, int[] length, int lengthOffset, int[] size, int
+// sizeOffset, int[] type, int typeOffset, byte[] name, int nameOffset) {
+// GLES30.glGetTransformFeedbackVarying(program, index, bufsize, length, lengthOffset, size, sizeOffset, type, typeOffset, name,
+// nameOffset);
+// }
+
+// @Override
+// public void getTransformFeedbackVarying(int program, int index, int bufsize, java.nio.IntBuffer length, java.nio.IntBuffer
+// size, java.nio.IntBuffer type, byte name) {
+// GLES30.glGetTransformFeedbackVarying(program, index, bufsize, length, size, type, name);
+// }
+//
+// @Override
+// public String getTransformFeedbackVarying(int program, int index, int[] size, int sizeOffset, int[] type, int typeOffset) {
+// return GLES30.glGetTransformFeedbackVarying(program, index, size, sizeOffset, type, typeOffset);
+// }
+//
+// @Override
+// public String getTransformFeedbackVarying(int program, int index, java.nio.IntBuffer size, java.nio.IntBuffer type) {
+// return GLES30.glGetTransformFeedbackVarying(program, index, size, type);
+// }
+
+    @Override
+    public void vertexAttribIPointer(int index, int size, int type, int stride, int offset) {
+        GLES30.glVertexAttribIPointer(index, size, type, stride, offset);
+    }
+
+// @Override
+// public void getVertexAttribIiv(int index, int pname, int[] params, int offset) {
+// GLES30.glGetVertexAttribIiv(index, pname, params, offset);
+// }
+
+    @Override
+    public void getVertexAttribIiv(int index, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetVertexAttribIiv(index, pname, params);
+    }
+
+// @Override
+// public void getVertexAttribIuiv(int index, int pname, int[] params, int offset) {
+// GLES30.glGetVertexAttribIuiv(index, pname, params, offset);
+// }
+
+    @Override
+    public void getVertexAttribIuiv(int index, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetVertexAttribIuiv(index, pname, params);
+    }
+
+    @Override
+    public void vertexAttribI4i(int index, int x, int y, int z, int w) {
+        GLES30.glVertexAttribI4i(index, x, y, z, w);
+    }
+
+    @Override
+    public void vertexAttribI4ui(int index, int x, int y, int z, int w) {
+        GLES30.glVertexAttribI4ui(index, x, y, z, w);
+    }
+
+// @Override
+// public void vertexAttribI4iv(int index, int[] v, int offset) {
+// GLES30.glVertexAttribI4iv(index, v, offset);
+// }
+//
+// @Override
+// public void vertexAttribI4iv(int index, java.nio.IntBuffer v) {
+// GLES30.glVertexAttribI4iv(index, v);
+// }
+//
+// @Override
+// public void vertexAttribI4uiv(int index, int[] v, int offset) {
+// GLES30.glVertexAttribI4uiv(index, v, offset);
+// }
+//
+// @Override
+// public void vertexAttribI4uiv(int index, java.nio.IntBuffer v) {
+// GLES30.glVertexAttribI4uiv(index, v);
+// }
+//
+// @Override
+// public void getUniformuiv(int program, int location, int[] params, int offset) {
+// GLES30.glGetUniformuiv(program, location, params, offset);
+// }
+
+    @Override
+    public void getUniformuiv(int program, int location, java.nio.IntBuffer params) {
+        GLES30.glGetUniformuiv(program, location, params);
+    }
+
+    @Override
+    public int getFragDataLocation(int program, String name) {
+        return GLES30.glGetFragDataLocation(program, name);
+    }
+
+// @Override
+// public void uniform1ui(int location, int v0) {
+// GLES30.glUniform1ui(location, v0);
+// }
+//
+// @Override
+// public void uniform2ui(int location, int v0, int v1) {
+// GLES30.glUniform2ui(location, v0, v1);
+// }
+//
+// @Override
+// public void uniform3ui(int location, int v0, int v1, int v2) {
+// GLES30.glUniform3ui(location, v0, v1, v2);
+// }
+
+// @Override
+// public void uniform4ui(int location, int v0, int v1, int v2, int v3) {
+// GLES30.glUniform4ui(location, v0, v1, v2, v3);
+// }
+//
+// @Override
+// public void uniform1uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform1uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform1uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform1uiv(location, count, value);
+    }
+
+// @Override
+// public void uniform2uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform2uiv(location, count, value, offset);
+// }
+//
+// @Override
+// public void uniform2uiv(int location, int count, java.nio.IntBuffer value) {
+// GLES30.glUniform2uiv(location, count, value);
+// }
+//
+// @Override
+// public void uniform3uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform3uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform3uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform3uiv(location, count, value);
+    }
+
+// @Override
+// public void uniform4uiv(int location, int count, int[] value, int offset) {
+// GLES30.glUniform4uiv(location, count, value, offset);
+// }
+
+    @Override
+    public void uniform4uiv(int location, int count, java.nio.IntBuffer value) {
+        GLES30.glUniform4uiv(location, count, value);
+    }
+
+// @Override
+// public void clearBufferiv(int buffer, int drawbuffer, int[] value, int offset) {
+// GLES30.glClearBufferiv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferiv(int buffer, int drawbuffer, java.nio.IntBuffer value) {
+        GLES30.glClearBufferiv(buffer, drawbuffer, value);
+    }
+
+// @Override
+// public void clearBufferuiv(int buffer, int drawbuffer, int[] value, int offset) {
+// GLES30.glClearBufferuiv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferuiv(int buffer, int drawbuffer, java.nio.IntBuffer value) {
+        GLES30.glClearBufferuiv(buffer, drawbuffer, value);
+    }
+
+//
+// @Override
+// public void clearBufferfv(int buffer, int drawbuffer, float[] value, int offset) {
+// GLES30.glClearBufferfv(buffer, drawbuffer, value, offset);
+// }
+
+    @Override
+    public void clearBufferfv(int buffer, int drawbuffer, java.nio.FloatBuffer value) {
+        GLES30.glClearBufferfv(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfi(int buffer, int drawbuffer, float depth, int stencil) {
+        GLES30.glClearBufferfi(buffer, drawbuffer, depth, stencil);
+    }
+
+    @Override
+    public String getStringi(int name, int index) {
+        return GLES30.glGetStringi(name, index);
+    }
+
+    @Override
+    public void copyBufferSubData(int readTarget, int writeTarget, int readOffset, int writeOffset, int size) {
+        GLES30.glCopyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
+    }
+
+//
+// @Override
+// public void getUniformIndices(int program, String[] uniformNames, int[] uniformIndices, int uniformIndicesOffset) {
+// GLES30.glGetUniformIndices(program, uniformNames, uniformIndices, uniformIndicesOffset);
+// }
+
+    @Override
+    public void getUniformIndices(int program, String[] uniformNames, java.nio.IntBuffer uniformIndices) {
+        GLES30.glGetUniformIndices(program, uniformNames, uniformIndices);
+    }
+
+// @Override
+// public void getActiveUniformsiv(int program, int uniformCount, int[] uniformIndices, int uniformIndicesOffset, int pname,
+// int[] params, int paramsOffset) {
+// GLES30.glGetActiveUniformsiv(program, uniformCount, uniformIndices, uniformIndicesOffset, pname, params, paramsOffset);
+// }
+
+    @Override
+    public void getActiveUniformsiv(int program, int uniformCount, java.nio.IntBuffer uniformIndices, int pname,
+                                    java.nio.IntBuffer params) {
+        GLES30.glGetActiveUniformsiv(program, uniformCount, uniformIndices, pname, params);
+    }
+
+    @Override
+    public int getUniformBlockIndex(int program, String uniformBlockName) {
+        return GLES30.glGetUniformBlockIndex(program, uniformBlockName);
+    }
+
+//
+// @Override
+// public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, int[] params, int offset) {
+// GLES30.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params, offset);
+// }
+
+    @Override
+    public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname, params);
+    }
+
+//
+// @Override
+// public void getActiveUniformBlockName(int program, int uniformBlockIndex, int bufSize, int[] length, int lengthOffset, byte[]
+// uniformBlockName, int uniformBlockNameOffset) {
+// GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex, bufSize, length, lengthOffset, uniformBlockName,
+// uniformBlockNameOffset);
+// }
+
+    @Override
+    public void getActiveUniformBlockName(int program, int uniformBlockIndex, java.nio.Buffer length,
+                                          java.nio.Buffer uniformBlockName) {
+        GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex, length, uniformBlockName);
+    }
+
+    @Override
+    public String getActiveUniformBlockName(int program, int uniformBlockIndex) {
+        return GLES30.glGetActiveUniformBlockName(program, uniformBlockIndex);
+    }
+
+    @Override
+    public void uniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding) {
+        GLES30.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    }
+
+    @Override
+    public void drawArraysInstanced(int mode, int first, int count, int instanceCount) {
+        GLES30.glDrawArraysInstanced(mode, first, count, instanceCount);
+    }
+
+// @Override
+// public void drawElementsInstanced(int mode, int count, int type, java.nio.Buffer indices, int instanceCount) {
+// GLES30.glDrawElementsInstanced(mode, count, type, indices, instanceCount);
+// }
+
+    @Override
+    public void drawElementsInstanced(int mode, int count, int type, int indicesOffset, int instanceCount) {
+        GLES30.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
+    }
+
+// @Override
+// public long fenceSync(int condition, int flags) {
+// return GLES30.glFenceSync(condition, flags);
+// }
+//
+// @Override
+// public boolean isSync(long sync) {
+// return GLES30.glIsSync(sync);
+// }
+//
+// @Override
+// public void deleteSync(long sync) {
+// GLES30.glDeleteSync(sync);
+// }
+//
+// @Override
+// public int clientWaitSync(long sync, int flags, long timeout) {
+// return GLES30.glClientWaitSync(sync, flags, timeout);
+// }
+
+// @Override
+// public void waitSync(long sync, int flags, long timeout) {
+// GLES30.glWaitSync(sync, flags, timeout);
+// }
+//
+// @Override
+// public void getInteger64v(int pname, long[] params, int offset) {
+// GLES30.glGetInteger64v(pname, params, offset);
+// }
+
+    @Override
+    public void getInteger64v(int pname, java.nio.LongBuffer params) {
+        GLES30.glGetInteger64v(pname, params);
+    }
+
+// @Override
+// public void getSynciv(long sync, int pname, int bufSize, int[] length, int lengthOffset, int[] values, int valuesOffset) {
+// GLES30.glGetSynciv(sync, pname, bufSize, length, lengthOffset, values, valuesOffset);
+// }
+//
+// @Override
+// public void getSynciv(long sync, int pname, int bufSize, java.nio.IntBuffer length, java.nio.IntBuffer values) {
+// GLES30.glGetSynciv(sync, pname, bufSize, length, values);
+// }
+//
+// @Override
+// public void getInteger64i_v(int target, int index, long[] data, int offset) {
+// GLES30.glGetInteger64i_v(target, index, data, offset);
+// }
+//
+// @Override
+// public void getInteger64i_v(int target, int index, java.nio.LongBuffer data) {
+// GLES30.glGetInteger64i_v(target, index, data);
+// }
+//
+// @Override
+// public void getBufferParameteri64v(int target, int pname, long[] params, int offset) {
+// GLES30.glGetBufferParameteri64v(target, pname, params, offset);
+// }
+
+    @Override
+    public void getBufferParameteri64v(int target, int pname, java.nio.LongBuffer params) {
+        GLES30.glGetBufferParameteri64v(target, pname, params);
+    }
+
+    @Override
+    public void genSamplers(int count, int[] samplers, int offset) {
+        GLES30.glGenSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void genSamplers(int count, java.nio.IntBuffer samplers) {
+        GLES30.glGenSamplers(count, samplers);
+    }
+
+    @Override
+    public void deleteSamplers(int count, int[] samplers, int offset) {
+        GLES30.glDeleteSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void deleteSamplers(int count, java.nio.IntBuffer samplers) {
+        GLES30.glDeleteSamplers(count, samplers);
+    }
+
+    @Override
+    public boolean isSampler(int sampler) {
+        return GLES30.glIsSampler(sampler);
+    }
+
+    @Override
+    public void bindSampler(int unit, int sampler) {
+        GLES30.glBindSampler(unit, sampler);
+    }
+
+    @Override
+    public void samplerParameteri(int sampler, int pname, int param) {
+        GLES30.glSamplerParameteri(sampler, pname, param);
+    }
+
+//
+// @Override
+// public void samplerParameteriv(int sampler, int pname, int[] param, int offset) {
+// GLES30.glSamplerParameteriv(sampler, pname, param, offset);
+// }
+
+    @Override
+    public void samplerParameteriv(int sampler, int pname, java.nio.IntBuffer param) {
+        GLES30.glSamplerParameteriv(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterf(int sampler, int pname, float param) {
+        GLES30.glSamplerParameterf(sampler, pname, param);
+    }
+
+// @Override
+// public void samplerParameterfv(int sampler, int pname, float[] param, int offset) {
+// GLES30.glSamplerParameterfv(sampler, pname, param, offset);
+// }
+
+    @Override
+    public void samplerParameterfv(int sampler, int pname, java.nio.FloatBuffer param) {
+        GLES30.glSamplerParameterfv(sampler, pname, param);
+    }
+
+//
+// @Override
+// public void getSamplerParameteriv(int sampler, int pname, int[] params, int offset) {
+// GLES30.glGetSamplerParameteriv(sampler, pname, params, offset);
+// }
+
+    @Override
+    public void getSamplerParameteriv(int sampler, int pname, java.nio.IntBuffer params) {
+        GLES30.glGetSamplerParameteriv(sampler, pname, params);
+    }
+
+// @Override
+// public void getSamplerParameterfv(int sampler, int pname, float[] params, int offset) {
+// GLES30.glGetSamplerParameterfv(sampler, pname, params, offset);
+// }
+
+    @Override
+    public void getSamplerParameterfv(int sampler, int pname, java.nio.FloatBuffer params) {
+        GLES30.glGetSamplerParameterfv(sampler, pname, params);
+    }
+
+    @Override
+    public void vertexAttribDivisor(int index, int divisor) {
+        GLES30.glVertexAttribDivisor(index, divisor);
+    }
+
+    @Override
+    public void bindTransformFeedback(int target, int id) {
+        GLES30.glBindTransformFeedback(target, id);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, int[] ids, int offset) {
+        GLES30.glDeleteTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, java.nio.IntBuffer ids) {
+        GLES30.glDeleteTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, int[] ids, int offset) {
+        GLES30.glGenTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, java.nio.IntBuffer ids) {
+        GLES30.glGenTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public boolean isTransformFeedback(int id) {
+        return GLES30.glIsTransformFeedback(id);
+    }
+
+    @Override
+    public void pauseTransformFeedback() {
+        GLES30.glPauseTransformFeedback();
+    }
+
+    @Override
+    public void resumeTransformFeedback() {
+        GLES30.glResumeTransformFeedback();
+    }
+
+// @Override
+// public void getProgramBinary(int program, int bufSize, int[] length, int lengthOffset, int[] binaryFormat, int
+// binaryFormatOffset, java.nio.Buffer binary) {
+// GLES30.glGetProgramBinary(program, bufSize, length, lengthOffset, binaryFormat, binaryFormatOffset, binary);
+// }
+//
+// @Override
+// public void getProgramBinary(int program, int bufSize, java.nio.IntBuffer length, java.nio.IntBuffer binaryFormat,
+// java.nio.Buffer binary) {
+// GLES30.glGetProgramBinary(program, bufSize, length, binaryFormat, binary);
+// }
+
+// @Override
+// public void programBinary(int program, int binaryFormat, java.nio.Buffer binary, int length) {
+// GLES30.glProgramBinary(program, binaryFormat, binary, length);
+// }
+
+    @Override
+    public void programParameteri(int program, int pname, int value) {
+        GLES30.glProgramParameteri(program, pname, value);
+    }
+
+// @Override
+// public void invalidateFramebuffer(int target, int numAttachments, int[] attachments, int offset) {
+// GLES30.glInvalidateFramebuffer(target, numAttachments, attachments, offset);
+// }
+
+    @Override
+    public void invalidateFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments) {
+        GLES30.glInvalidateFramebuffer(target, numAttachments, attachments);
+    }
+
+//
+// @Override
+// public void invalidateSubFramebuffer(int target, int numAttachments, int[] attachments, int offset, int x, int y, int width,
+// int height) {
+// GLES30.glInvalidateSubFramebuffer(target, numAttachments, attachments, offset, x, y, width, height);
+// }
+
+    @Override
+    public void invalidateSubFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments, int x, int y,
+                                         int width, int height) {
+        GLES30.glInvalidateSubFramebuffer(target, numAttachments, attachments, x, y, width, height);
+    }
+
+// @Override
+// public void texStorage2D(int target, int levels, int internalformat, int width, int height) {
+// GLES30.glTexStorage2D(target, levels, internalformat, width, height);
+// }
+
+// @Override
+// public void texStorage3D(int target, int levels, int internalformat, int width, int height, int depth) {
+// GLES30.glTexStorage3D(target, levels, internalformat, width, height, depth);
+// }
+//
+// @Override
+// public void getInternalformativ(int target, int internalformat, int pname, int bufSize, int[] params, int offset) {
+// GLES30.glGetInternalformativ(target, internalformat, pname, bufSize, params, offset);
+// }
+//
+// @Override
+// public void getInternalformativ(int target, int internalformat, int pname, int bufSize, java.nio.IntBuffer params) {
+// GLES30.glGetInternalformativ(target, internalformat, pname, bufSize, params);
+// }
+}

--- a/vtm-android/src/org/oscim/android/gl/GlConfigChooser.java
+++ b/vtm-android/src/org/oscim/android/gl/GlConfigChooser.java
@@ -20,7 +20,7 @@ public class GlConfigChooser implements GLSurfaceView.EGLConfigChooser {
                 EGL10.EGL_ALPHA_SIZE, 8,
                 EGL10.EGL_DEPTH_SIZE, 16,
                 // Requires that setEGLContextClientVersion(2) is called on the view.
-                EGL10.EGL_RENDERABLE_TYPE, 4 /* EGL_OPENGL_ES2_BIT */,
+                EGL10.EGL_RENDERABLE_TYPE, 4 /*EGL14.EGL_OPENGL_ES2_BIT*/ /*0x40 /*EGLExt.EGL_OPENGL_ES3_BIT_KHR*/,
                 EGL10.EGL_STENCIL_SIZE, 8,
                 EGL10.EGL_NONE};
 
@@ -38,7 +38,7 @@ public class GlConfigChooser implements GLSurfaceView.EGLConfigChooser {
                     EGL10.EGL_BLUE_SIZE, 8,
                     EGL10.EGL_ALPHA_SIZE, 8,
                     EGL10.EGL_DEPTH_SIZE, 16,
-                    EGL10.EGL_RENDERABLE_TYPE, 4 /* EGL_OPENGL_ES2_BIT */,
+                    EGL10.EGL_RENDERABLE_TYPE, 4 /*EGL14.EGL_OPENGL_ES2_BIT*/ /*0x40 /*EGLExt.EGL_OPENGL_ES3_BIT_KHR*/,
                     EGL10.EGL_STENCIL_SIZE, 8,
                     EGL10.EGL_NONE};
 

--- a/vtm-android/src/org/oscim/android/gl/GlContextFactory.java
+++ b/vtm-android/src/org/oscim/android/gl/GlContextFactory.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Copyright (C) 2009 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.oscim.android.gl;
+
+import android.opengl.GLSurfaceView;
+
+import org.oscim.android.MapView;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+
+/**
+ * See https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-android/src/com/badlogic/gdx/backends/android/surfaceview/GLSurfaceView20.java
+ */
+public class GlContextFactory implements GLSurfaceView.EGLContextFactory {
+
+    private static final Logger log = LoggerFactory.getLogger(GlContextFactory.class);
+
+    private static final int EGL_CONTEXT_CLIENT_VERSION = 0x3098;
+
+    @Override
+    public EGLContext createContext(EGL10 egl, EGLDisplay display, EGLConfig eglConfig) {
+        log.info("creating OpenGL ES " + MapView.targetGLESVersion + ".0 context");
+        checkEglError("Before eglCreateContext " + MapView.targetGLESVersion, egl);
+        int[] attrib_list = {EGL_CONTEXT_CLIENT_VERSION, MapView.targetGLESVersion, EGL10.EGL_NONE};
+        EGLContext context = egl.eglCreateContext(display, eglConfig, EGL10.EGL_NO_CONTEXT, attrib_list);
+        boolean success = checkEglError("After eglCreateContext " + MapView.targetGLESVersion, egl);
+
+        if ((!success || context == null) && MapView.targetGLESVersion > 2) {
+            log.warn("Falling back to GLES 2");
+            MapView.targetGLESVersion = 2;
+            return createContext(egl, display, eglConfig);
+        }
+        log.info("Returning a GLES " + MapView.targetGLESVersion + " context");
+        return context;
+    }
+
+    @Override
+    public void destroyContext(EGL10 egl, EGLDisplay display, EGLContext context) {
+        egl.eglDestroyContext(display, context);
+    }
+
+    private static boolean checkEglError(String prompt, EGL10 egl) {
+        int error;
+        boolean result = true;
+        while ((error = egl.eglGetError()) != EGL10.EGL_SUCCESS) {
+            result = false;
+            log.error(String.format("%s: EGL error: 0x%x", prompt, error));
+        }
+        return result;
+    }
+}

--- a/vtm-desktop/src/org/oscim/gdx/GdxMapApp.java
+++ b/vtm-desktop/src/org/oscim/gdx/GdxMapApp.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2018 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -21,6 +21,7 @@ package org.oscim.gdx;
 import com.badlogic.gdx.Files;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplication;
 import com.badlogic.gdx.backends.lwjgl.LwjglApplicationConfiguration;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.utils.SharedLibraryLoader;
 
 import org.oscim.awt.AwtGraphics;
@@ -44,7 +45,6 @@ public class GdxMapApp extends GdxMap {
         // init globals
         AwtGraphics.init();
         GdxAssets.init("assets/");
-        GLAdapter.init(new LwjglGL20());
         DateTimeAdapter.init(new DateTime());
     }
 
@@ -82,6 +82,14 @@ public class GdxMapApp extends GdxMap {
         cfg.backgroundFPS = 10;
         cfg.forceExit = false;
         return cfg;
+    }
+
+    @Override
+    protected void initGLAdapter(GLVersion version) {
+        if (version.getMajorVersion() >= 3)
+            GLAdapter.init(new LwjglGL30());
+        else
+            GLAdapter.init(new LwjglGL20());
     }
 
     @Override

--- a/vtm-desktop/src/org/oscim/gdx/LwjglGL30.java
+++ b/vtm-desktop/src/org/oscim/gdx/LwjglGL30.java
@@ -1,0 +1,657 @@
+/*******************************************************************************
+ * Copyright 2011 See AUTHORS file.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+package org.oscim.gdx;
+
+import com.badlogic.gdx.utils.GdxRuntimeException;
+
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GL12;
+import org.lwjgl.opengl.GL15;
+import org.lwjgl.opengl.GL20;
+import org.lwjgl.opengl.GL21;
+import org.lwjgl.opengl.GL31;
+import org.lwjgl.opengl.GL32;
+import org.lwjgl.opengl.GL33;
+import org.lwjgl.opengl.GL40;
+import org.lwjgl.opengl.GL41;
+import org.lwjgl.opengl.GL43;
+import org.oscim.backend.GL30;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+import java.nio.ShortBuffer;
+
+/**
+ * See https://github.com/libgdx/libgdx/blob/master/backends/gdx-backend-lwjgl3/src/com/badlogic/gdx/backends/lwjgl3/Lwjgl3GL30.java
+ */
+public class LwjglGL30 extends LwjglGL20 implements GL30 {
+    @Override
+    public void readBuffer(int mode) {
+        GL11.glReadBuffer(mode);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, Buffer indices) {
+        if (indices instanceof ByteBuffer)
+            GL12.glDrawRangeElements(mode, start, end, (ByteBuffer) indices);
+        else if (indices instanceof ShortBuffer)
+            GL12.glDrawRangeElements(mode, start, end, (ShortBuffer) indices);
+        else if (indices instanceof IntBuffer)
+            GL12.glDrawRangeElements(mode, start, end, (IntBuffer) indices);
+        else throw new GdxRuntimeException("indices must be byte, short or int buffer");
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, int offset) {
+        GL12.glDrawRangeElements(mode, start, end, count, type, offset);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, Buffer pixels) {
+        if (pixels == null)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (ByteBuffer) null);
+        else if (pixels instanceof ByteBuffer)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (ByteBuffer) pixels);
+        else if (pixels instanceof ShortBuffer)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (ShortBuffer) pixels);
+        else if (pixels instanceof IntBuffer)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (IntBuffer) pixels);
+        else if (pixels instanceof FloatBuffer)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (FloatBuffer) pixels);
+        else if (pixels instanceof DoubleBuffer)
+            GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, (DoubleBuffer) pixels);
+        else
+            throw new GdxRuntimeException("Can't use " + pixels.getClass().getName()
+                    + " with this method. Use ByteBuffer, ShortBuffer, IntBuffer, FloatBuffer or DoubleBuffer instead. Blame LWJGL");
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, int offset) {
+        GL12.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, Buffer pixels) {
+        if (pixels instanceof ByteBuffer)
+            GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (ByteBuffer) pixels);
+        else if (pixels instanceof ShortBuffer)
+            GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (ShortBuffer) pixels);
+        else if (pixels instanceof IntBuffer)
+            GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (IntBuffer) pixels);
+        else if (pixels instanceof FloatBuffer)
+            GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (FloatBuffer) pixels);
+        else if (pixels instanceof DoubleBuffer)
+            GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, (DoubleBuffer) pixels);
+        else
+            throw new GdxRuntimeException("Can't use " + pixels.getClass().getName()
+                    + " with this method. Use ByteBuffer, ShortBuffer, IntBuffer, FloatBuffer or DoubleBuffer instead. Blame LWJGL");
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, int offset) {
+        GL12.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
+    }
+
+    @Override
+    public void copyTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width,
+                                  int height) {
+        GL12.glCopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    }
+
+    @Override
+    public void genQueries(int n, int[] ids, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            ids[i] = GL15.glGenQueries();
+        }
+    }
+
+    @Override
+    public void genQueries(int n, IntBuffer ids) {
+        for (int i = 0; i < n; i++) {
+            ids.put(GL15.glGenQueries());
+        }
+    }
+
+    @Override
+    public void deleteQueries(int n, int[] ids, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            GL15.glDeleteQueries(ids[i]);
+        }
+    }
+
+    @Override
+    public void deleteQueries(int n, IntBuffer ids) {
+        for (int i = 0; i < n; i++) {
+            GL15.glDeleteQueries(ids.get());
+        }
+    }
+
+    @Override
+    public boolean isQuery(int id) {
+        return GL15.glIsQuery(id);
+    }
+
+    @Override
+    public void beginQuery(int target, int id) {
+        GL15.glBeginQuery(target, id);
+    }
+
+    @Override
+    public void endQuery(int target) {
+        GL15.glEndQuery(target);
+    }
+
+    @Override
+    public void getQueryiv(int target, int pname, IntBuffer params) {
+        GL15.glGetQuery(target, pname, params);
+    }
+
+    @Override
+    public void getQueryObjectuiv(int id, int pname, IntBuffer params) {
+        GL15.glGetQueryObjectu(id, pname, params);
+    }
+
+    @Override
+    public boolean unmapBuffer(int target) {
+        return GL15.glUnmapBuffer(target);
+    }
+
+    @Override
+    public Buffer getBufferPointerv(int target, int pname) {
+        return GL15.glGetBufferPointer(target, pname);
+    }
+
+    @Override
+    public void drawBuffers(int n, IntBuffer bufs) {
+        GL20.glDrawBuffers(bufs);
+    }
+
+    @Override
+    public void uniformMatrix2x3fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix2x3(location, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix3x2fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix3x2(location, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix2x4fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix2x4(location, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix4x2fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix4x2(location, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix3x4fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix3x4(location, transpose, value);
+    }
+
+
+    @Override
+    public void uniformMatrix4x3fv(int location, int count, boolean transpose, FloatBuffer value) {
+        GL21.glUniformMatrix4x3(location, transpose, value);
+    }
+
+    @Override
+    public void blitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1,
+                                int mask, int filter) {
+        org.lwjgl.opengl.GL30.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    }
+
+    @Override
+    public void bindFramebuffer(int target, int framebuffer) {
+        org.lwjgl.opengl.GL30.glBindFramebuffer(target, framebuffer);
+    }
+
+    @Override
+    public void bindRenderbuffer(int target, int renderbuffer) {
+        org.lwjgl.opengl.GL30.glBindRenderbuffer(target, renderbuffer);
+    }
+
+    @Override
+    public int checkFramebufferStatus(int target) {
+        return org.lwjgl.opengl.GL30.glCheckFramebufferStatus(target);
+    }
+
+    @Override
+    public void deleteFramebuffers(int n, IntBuffer framebuffers) {
+        org.lwjgl.opengl.GL30.glDeleteFramebuffers(framebuffers);
+    }
+
+    @Override
+    public void deleteFramebuffer(int framebuffer) {
+        org.lwjgl.opengl.GL30.glDeleteFramebuffers(framebuffer);
+    }
+
+    @Override
+    public void deleteRenderbuffers(int n, IntBuffer renderbuffers) {
+        org.lwjgl.opengl.GL30.glDeleteRenderbuffers(renderbuffers);
+    }
+
+    @Override
+    public void deleteRenderbuffer(int renderbuffer) {
+        org.lwjgl.opengl.GL30.glDeleteRenderbuffers(renderbuffer);
+    }
+
+    @Override
+    public void generateMipmap(int target) {
+        org.lwjgl.opengl.GL30.glGenerateMipmap(target);
+    }
+
+    @Override
+    public void genFramebuffers(int n, IntBuffer framebuffers) {
+        org.lwjgl.opengl.GL30.glGenFramebuffers(framebuffers);
+    }
+
+    @Override
+    public int genFramebuffer() {
+        return org.lwjgl.opengl.GL30.glGenFramebuffers();
+    }
+
+    @Override
+    public void genRenderbuffers(int n, IntBuffer renderbuffers) {
+        org.lwjgl.opengl.GL30.glGenRenderbuffers(renderbuffers);
+    }
+
+    @Override
+    public int genRenderbuffer() {
+        return org.lwjgl.opengl.GL30.glGenRenderbuffers();
+    }
+
+    @Override
+    public void getRenderbufferParameteriv(int target, int pname, IntBuffer params) {
+        org.lwjgl.opengl.GL30.glGetRenderbufferParameter(target, pname, params);
+    }
+
+    @Override
+    public boolean isFramebuffer(int framebuffer) {
+        return org.lwjgl.opengl.GL30.glIsFramebuffer(framebuffer);
+    }
+
+    @Override
+    public boolean isRenderbuffer(int renderbuffer) {
+        return org.lwjgl.opengl.GL30.glIsRenderbuffer(renderbuffer);
+    }
+
+    @Override
+    public void renderbufferStorage(int target, int internalformat, int width, int height) {
+        org.lwjgl.opengl.GL30.glRenderbufferStorage(target, internalformat, width, height);
+    }
+
+    @Override
+    public void renderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height) {
+        org.lwjgl.opengl.GL30.glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+    }
+
+    @Override
+    public void framebufferTexture2D(int target, int attachment, int textarget, int texture, int level) {
+        org.lwjgl.opengl.GL30.glFramebufferTexture2D(target, attachment, textarget, texture, level);
+    }
+
+    @Override
+    public void framebufferRenderbuffer(int target, int attachment, int renderbuffertarget, int renderbuffer) {
+        org.lwjgl.opengl.GL30.glFramebufferRenderbuffer(target, attachment, renderbuffertarget, renderbuffer);
+    }
+
+    @Override
+    public void framebufferTextureLayer(int target, int attachment, int texture, int level, int layer) {
+        org.lwjgl.opengl.GL30.glFramebufferTextureLayer(target, attachment, texture, level, layer);
+    }
+
+    @Override
+    public void flushMappedBufferRange(int target, int offset, int length) {
+        org.lwjgl.opengl.GL30.glFlushMappedBufferRange(target, offset, length);
+    }
+
+    @Override
+    public void bindVertexArray(int array) {
+        org.lwjgl.opengl.GL30.glBindVertexArray(array);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, int[] arrays, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            org.lwjgl.opengl.GL30.glDeleteVertexArrays(arrays[i]);
+        }
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, IntBuffer arrays) {
+        org.lwjgl.opengl.GL30.glDeleteVertexArrays(arrays);
+    }
+
+    @Override
+    public void genVertexArrays(int n, int[] arrays, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            arrays[i] = org.lwjgl.opengl.GL30.glGenVertexArrays();
+        }
+    }
+
+    @Override
+    public void genVertexArrays(int n, IntBuffer arrays) {
+        org.lwjgl.opengl.GL30.glGenVertexArrays(arrays);
+    }
+
+    @Override
+    public boolean isVertexArray(int array) {
+        return org.lwjgl.opengl.GL30.glIsVertexArray(array);
+    }
+
+    @Override
+    public void beginTransformFeedback(int primitiveMode) {
+        org.lwjgl.opengl.GL30.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void endTransformFeedback() {
+        org.lwjgl.opengl.GL30.glEndTransformFeedback();
+    }
+
+    @Override
+    public void bindBufferRange(int target, int index, int buffer, int offset, int size) {
+        org.lwjgl.opengl.GL30.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void bindBufferBase(int target, int index, int buffer) {
+        org.lwjgl.opengl.GL30.glBindBufferBase(target, index, buffer);
+    }
+
+    @Override
+    public void transformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        org.lwjgl.opengl.GL30.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+    @Override
+    public void vertexAttribIPointer(int index, int size, int type, int stride, int offset) {
+        org.lwjgl.opengl.GL30.glVertexAttribIPointer(index, size, type, stride, offset);
+    }
+
+    @Override
+    public void getVertexAttribIiv(int index, int pname, IntBuffer params) {
+        org.lwjgl.opengl.GL30.glGetVertexAttribI(index, pname, params);
+    }
+
+    @Override
+    public void getVertexAttribIuiv(int index, int pname, IntBuffer params) {
+        org.lwjgl.opengl.GL30.glGetVertexAttribIu(index, pname, params);
+    }
+
+    @Override
+    public void vertexAttribI4i(int index, int x, int y, int z, int w) {
+        org.lwjgl.opengl.GL30.glVertexAttribI4i(index, x, y, z, w);
+    }
+
+    @Override
+    public void vertexAttribI4ui(int index, int x, int y, int z, int w) {
+        org.lwjgl.opengl.GL30.glVertexAttribI4ui(index, x, y, z, w);
+    }
+
+    @Override
+    public void getUniformuiv(int program, int location, IntBuffer params) {
+        org.lwjgl.opengl.GL30.glGetUniformu(program, location, params);
+    }
+
+    @Override
+    public int getFragDataLocation(int program, String name) {
+        return org.lwjgl.opengl.GL30.glGetFragDataLocation(program, name);
+    }
+
+    @Override
+    public void uniform1uiv(int location, int count, IntBuffer value) {
+        org.lwjgl.opengl.GL30.glUniform1u(location, value);
+    }
+
+    @Override
+    public void uniform3uiv(int location, int count, IntBuffer value) {
+        org.lwjgl.opengl.GL30.glUniform3u(location, value);
+    }
+
+    @Override
+    public void uniform4uiv(int location, int count, IntBuffer value) {
+        org.lwjgl.opengl.GL30.glUniform4u(location, value);
+    }
+
+    @Override
+    public void clearBufferiv(int buffer, int drawbuffer, IntBuffer value) {
+        org.lwjgl.opengl.GL30.glClearBuffer(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferuiv(int buffer, int drawbuffer, IntBuffer value) {
+        org.lwjgl.opengl.GL30.glClearBufferu(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfv(int buffer, int drawbuffer, FloatBuffer value) {
+        org.lwjgl.opengl.GL30.glClearBuffer(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfi(int buffer, int drawbuffer, float depth, int stencil) {
+        org.lwjgl.opengl.GL30.glClearBufferfi(buffer, drawbuffer, depth, stencil);
+    }
+
+    @Override
+    public String getStringi(int name, int index) {
+        return org.lwjgl.opengl.GL30.glGetStringi(name, index);
+    }
+
+    @Override
+    public void copyBufferSubData(int readTarget, int writeTarget, int readOffset, int writeOffset, int size) {
+        GL31.glCopyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
+    }
+
+    @Override
+    public void getUniformIndices(int program, String[] uniformNames, IntBuffer uniformIndices) {
+        GL31.glGetUniformIndices(program, uniformNames, uniformIndices);
+    }
+
+    @Override
+    public void getActiveUniformsiv(int program, int uniformCount, IntBuffer uniformIndices, int pname, IntBuffer params) {
+        GL31.glGetActiveUniforms(program, uniformIndices, pname, params);
+    }
+
+    @Override
+    public int getUniformBlockIndex(int program, String uniformBlockName) {
+        return GL31.glGetUniformBlockIndex(program, uniformBlockName);
+    }
+
+    @Override
+    public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, IntBuffer params) {
+        params.put(GL31.glGetActiveUniformBlocki(program, uniformBlockIndex, pname));
+    }
+
+    @Override
+    public void getActiveUniformBlockName(int program, int uniformBlockIndex, Buffer length, Buffer uniformBlockName) {
+        GL31.glGetActiveUniformBlockName(program, uniformBlockIndex, (IntBuffer) length, (ByteBuffer) uniformBlockName);
+    }
+
+    @Override
+    public String getActiveUniformBlockName(int program, int uniformBlockIndex) {
+        return GL31.glGetActiveUniformBlockName(program, uniformBlockIndex, 1024);
+    }
+
+    @Override
+    public void uniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding) {
+        GL31.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    }
+
+    @Override
+    public void drawArraysInstanced(int mode, int first, int count, int instanceCount) {
+        GL31.glDrawArraysInstanced(mode, first, count, instanceCount);
+    }
+
+    @Override
+    public void drawElementsInstanced(int mode, int count, int type, int indicesOffset, int instanceCount) {
+        GL31.glDrawElementsInstanced(mode, count, type, indicesOffset, instanceCount);
+
+    }
+
+    @Override
+    public void getInteger64v(int pname, LongBuffer params) {
+        GL32.glGetInteger64(pname, params);
+    }
+
+    @Override
+    public void getBufferParameteri64v(int target, int pname, LongBuffer params) {
+        params.put(GL32.glGetBufferParameteri64(target, pname));
+    }
+
+    @Override
+    public void genSamplers(int count, int[] samplers, int offset) {
+        for (int i = offset; i < offset + count; i++) {
+            samplers[i] = GL33.glGenSamplers();
+        }
+    }
+
+    @Override
+    public void genSamplers(int count, IntBuffer samplers) {
+        GL33.glGenSamplers(samplers);
+    }
+
+    @Override
+    public void deleteSamplers(int count, int[] samplers, int offset) {
+        for (int i = offset; i < offset + count; i++) {
+            GL33.glDeleteSamplers(samplers[i]);
+        }
+    }
+
+    @Override
+    public void deleteSamplers(int count, IntBuffer samplers) {
+        GL33.glDeleteSamplers(samplers);
+    }
+
+    @Override
+    public boolean isSampler(int sampler) {
+        return GL33.glIsSampler(sampler);
+    }
+
+    @Override
+    public void bindSampler(int unit, int sampler) {
+        GL33.glBindSampler(unit, sampler);
+    }
+
+    @Override
+    public void samplerParameteri(int sampler, int pname, int param) {
+        GL33.glSamplerParameteri(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameteriv(int sampler, int pname, IntBuffer param) {
+        GL33.glSamplerParameter(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterf(int sampler, int pname, float param) {
+        GL33.glSamplerParameterf(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterfv(int sampler, int pname, FloatBuffer param) {
+        GL33.glSamplerParameter(sampler, pname, param);
+    }
+
+    @Override
+    public void getSamplerParameteriv(int sampler, int pname, IntBuffer params) {
+        GL33.glGetSamplerParameterI(sampler, pname, params);
+    }
+
+    @Override
+    public void getSamplerParameterfv(int sampler, int pname, FloatBuffer params) {
+        GL33.glGetSamplerParameter(sampler, pname, params);
+
+    }
+
+    @Override
+    public void vertexAttribDivisor(int index, int divisor) {
+        GL33.glVertexAttribDivisor(index, divisor);
+    }
+
+    @Override
+    public void bindTransformFeedback(int target, int id) {
+        GL40.glBindTransformFeedback(target, id);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, int[] ids, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            GL40.glDeleteTransformFeedbacks(ids[i]);
+        }
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, IntBuffer ids) {
+        GL40.glDeleteTransformFeedbacks(ids);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, int[] ids, int offset) {
+        for (int i = offset; i < offset + n; i++) {
+            ids[i] = GL40.glGenTransformFeedbacks();
+        }
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, IntBuffer ids) {
+        GL40.glGenTransformFeedbacks(ids);
+    }
+
+    @Override
+    public boolean isTransformFeedback(int id) {
+        return GL40.glIsTransformFeedback(id);
+    }
+
+    @Override
+    public void pauseTransformFeedback() {
+        GL40.glPauseTransformFeedback();
+    }
+
+    @Override
+    public void resumeTransformFeedback() {
+        GL40.glResumeTransformFeedback();
+    }
+
+    @Override
+    public void programParameteri(int program, int pname, int value) {
+        GL41.glProgramParameteri(program, pname, value);
+    }
+
+    @Override
+    public void invalidateFramebuffer(int target, int numAttachments, IntBuffer attachments) {
+        GL43.glInvalidateFramebuffer(target, attachments);
+    }
+
+    @Override
+    public void invalidateSubFramebuffer(int target, int numAttachments, IntBuffer attachments, int x, int y, int width,
+                                         int height) {
+        GL43.glInvalidateSubFramebuffer(target, attachments, x, y, width, height);
+    }
+}

--- a/vtm-gdx/src/org/oscim/gdx/GdxMap.java
+++ b/vtm-gdx/src/org/oscim/gdx/GdxMap.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2018 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -22,6 +22,7 @@ import com.badlogic.gdx.Application;
 import com.badlogic.gdx.ApplicationListener;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputMultiplexer;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 import com.badlogic.gdx.input.GestureDetector;
 import com.badlogic.gdx.utils.Timer;
 import com.badlogic.gdx.utils.Timer.Task;
@@ -36,8 +37,12 @@ import org.oscim.renderer.MapRenderer;
 import org.oscim.theme.VtmThemes;
 import org.oscim.tiling.TileSource;
 import org.oscim.utils.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class GdxMap implements ApplicationListener {
+
+    private static final Logger log = LoggerFactory.getLogger(GdxMap.class);
 
     protected Map mMap;
     protected GestureDetector mGestureDetector;
@@ -68,6 +73,10 @@ public abstract class GdxMap implements ApplicationListener {
 
     @Override
     public void create() {
+        final GLVersion version = Gdx.graphics.getGLVersion();
+        log.info(version.getDebugVersionString());
+        initGLAdapter(version);
+
         if (!Parameters.CUSTOM_COORD_SCALE) {
             if (Math.min(Gdx.graphics.getDisplayMode().width, Gdx.graphics.getDisplayMode().height) > 1080)
                 MapRenderer.COORD_SCALE = 4.0f;
@@ -98,6 +107,8 @@ public abstract class GdxMap implements ApplicationListener {
 
         createLayers();
     }
+
+    protected abstract void initGLAdapter(GLVersion version);
 
     protected void createLayers() {
     }

--- a/vtm-ios-example/src/org/oscim/ios/test/IOSLineTexBucketTest.java
+++ b/vtm-ios-example/src/org/oscim/ios/test/IOSLineTexBucketTest.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017 Longri
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -16,6 +17,8 @@
  */
 package org.oscim.ios.test;
 
+import com.badlogic.gdx.graphics.glutils.GLVersion;
+
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.GeometryBuffer;
@@ -24,6 +27,7 @@ import org.oscim.core.TagSet;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
 import org.oscim.ios.backend.IosGL;
+import org.oscim.ios.backend.IosGL30;
 import org.oscim.ios.backend.IosGraphics;
 import org.oscim.layers.GenericLayer;
 import org.oscim.renderer.BucketRenderer;
@@ -45,12 +49,19 @@ public class IOSLineTexBucketTest extends GdxMap {
         // init globals
         IosGraphics.init();
         GdxAssets.init("assets/");
-        GLAdapter.init(new IosGL());
     }
 
     GeometryBuffer mLine = new GeometryBuffer(2, 1);
 
     LineTest l = new LineTest();
+
+    @Override
+    protected void initGLAdapter(GLVersion version) {
+        if (version.getMajorVersion() >= 3)
+            GLAdapter.init(new IosGL30());
+        else
+            GLAdapter.init(new IosGL());
+    }
 
     @Override
     public void createLayers() {

--- a/vtm-ios-example/src/org/oscim/ios/test/IOSMapApp.java
+++ b/vtm-ios-example/src/org/oscim/ios/test/IOSMapApp.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 Longri
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -17,12 +18,15 @@
  */
 package org.oscim.ios.test;
 
+import com.badlogic.gdx.graphics.glutils.GLVersion;
+
 import org.oscim.backend.DateTime;
 import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GLAdapter;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
 import org.oscim.ios.backend.IosGL;
+import org.oscim.ios.backend.IosGL30;
 import org.oscim.ios.backend.IosGraphics;
 import org.oscim.layers.GroupLayer;
 import org.oscim.layers.tile.buildings.BuildingLayer;
@@ -45,8 +49,15 @@ public class IOSMapApp extends GdxMap {
         // init globals
         IosGraphics.init();
         GdxAssets.init("assets/");
-        GLAdapter.init(new IosGL());
         DateTimeAdapter.init(new DateTime());
+    }
+
+    @Override
+    protected void initGLAdapter(GLVersion version) {
+        if (version.getMajorVersion() >= 3)
+            GLAdapter.init(new IosGL30());
+        else
+            GLAdapter.init(new IosGL());
     }
 
     @Override

--- a/vtm-ios-example/src/org/oscim/ios/test/IOSPathLayerTest.java
+++ b/vtm-ios-example/src/org/oscim/ios/test/IOSPathLayerTest.java
@@ -1,6 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 Longri
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -17,6 +18,8 @@
  */
 package org.oscim.ios.test;
 
+import com.badlogic.gdx.graphics.glutils.GLVersion;
+
 import org.oscim.backend.GLAdapter;
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeoPoint;
@@ -25,6 +28,7 @@ import org.oscim.event.Event;
 import org.oscim.gdx.GdxAssets;
 import org.oscim.gdx.GdxMap;
 import org.oscim.ios.backend.IosGL;
+import org.oscim.ios.backend.IosGL30;
 import org.oscim.ios.backend.IosGraphics;
 import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
@@ -46,13 +50,20 @@ public class IOSPathLayerTest extends GdxMap {
         // init globals
         IosGraphics.init();
         GdxAssets.init("assets/");
-        GLAdapter.init(new IosGL());
     }
 
     private static final boolean ANIMATION = false;
 
     private List<PathLayer> mPathLayers = new ArrayList<>();
     private TextureItem tex;
+
+    @Override
+    protected void initGLAdapter(GLVersion version) {
+        if (version.getMajorVersion() >= 3)
+            GLAdapter.init(new IosGL30());
+        else
+            GLAdapter.init(new IosGL());
+    }
 
     @Override
     public void createLayers() {

--- a/vtm-ios/src/org/oscim/ios/backend/IosGL30.java
+++ b/vtm-ios/src/org/oscim/ios/backend/IosGL30.java
@@ -1,0 +1,506 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.oscim.ios.backend;
+
+import com.badlogic.gdx.backends.iosrobovm.IOSGLES30;
+
+import org.oscim.backend.GL30;
+
+import java.nio.Buffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
+
+/**
+ * iOS specific implementation of {@link GL30}.
+ */
+public class IosGL30 extends IosGL implements GL30 {
+
+    private static final IOSGLES30 iOSGL = new IOSGLES30();
+
+    @Override
+    public void readBuffer(int mode) {
+        iOSGL.glReadBuffer(mode);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, Buffer indices) {
+        iOSGL.glDrawRangeElements(mode, start, end, count, type, indices);
+    }
+
+    @Override
+    public void drawRangeElements(int mode, int start, int end, int count, int type, int offset) {
+        iOSGL.glDrawRangeElements(mode, start, end, count, type, offset);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format, int type, Buffer pixels) {
+        iOSGL.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, pixels);
+    }
+
+    @Override
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format, int type, int offset) {
+        iOSGL.glTexImage3D(target, level, internalformat, width, height, depth, border, format, type, offset);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int format, int type, Buffer pixels) {
+        iOSGL.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
+    }
+
+    @Override
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth, int format, int type, int offset) {
+        iOSGL.glTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, offset);
+    }
+
+    @Override
+    public void copyTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width, int height) {
+        iOSGL.glCopyTexSubImage3D(target, level, xoffset, yoffset, zoffset, x, y, width, height);
+    }
+
+    @Override
+    public void genQueries(int n, int[] ids, int offset) {
+        iOSGL.glGenQueries(n, ids, offset);
+    }
+
+    @Override
+    public void genQueries(int n, IntBuffer ids) {
+        iOSGL.glGenQueries(n, ids);
+    }
+
+    @Override
+    public void deleteQueries(int n, int[] ids, int offset) {
+        iOSGL.glDeleteQueries(n, ids, offset);
+    }
+
+    @Override
+    public void deleteQueries(int n, IntBuffer ids) {
+        iOSGL.glDeleteQueries(n, ids);
+    }
+
+    @Override
+    public boolean isQuery(int id) {
+        iOSGL.glIsQuery(id);
+        return false;
+    }
+
+    @Override
+    public void beginQuery(int target, int id) {
+        iOSGL.glBeginQuery(target, id);
+    }
+
+    @Override
+    public void endQuery(int target) {
+        iOSGL.glEndQuery(target);
+    }
+
+    @Override
+    public void getQueryiv(int target, int pname, IntBuffer params) {
+        iOSGL.glGetQueryiv(target, pname, params);
+    }
+
+    @Override
+    public void getQueryObjectuiv(int id, int pname, IntBuffer params) {
+        iOSGL.glGetQueryObjectuiv(id, pname, params);
+    }
+
+    @Override
+    public boolean unmapBuffer(int target) {
+        iOSGL.glUnmapBuffer(target);
+        return false;
+    }
+
+    @Override
+    public Buffer getBufferPointerv(int target, int pname) {
+        iOSGL.glGetBufferPointerv(target, pname);
+        return null;
+    }
+
+    @Override
+    public void drawBuffers(int n, IntBuffer bufs) {
+        iOSGL.glDrawBuffers(n, bufs);
+    }
+
+    @Override
+    public void uniformMatrix2x3fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix2x3fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix3x2fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix3x2fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix2x4fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix2x4fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix4x2fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix4x2fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix3x4fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix3x4fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void uniformMatrix4x3fv(int location, int count, boolean transpose, FloatBuffer value) {
+        iOSGL.glUniformMatrix4x3fv(location, count, transpose, value);
+    }
+
+    @Override
+    public void blitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1, int mask, int filter) {
+        iOSGL.glBlitFramebuffer(srcX0, srcY0, srcX1, srcY1, dstX0, dstY0, dstX1, dstY1, mask, filter);
+    }
+
+    @Override
+    public void renderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height) {
+        iOSGL.glRenderbufferStorageMultisample(target, samples, internalformat, width, height);
+    }
+
+    @Override
+    public void framebufferTextureLayer(int target, int attachment, int texture, int level, int layer) {
+        iOSGL.glFramebufferTextureLayer(target, attachment, texture, level, layer);
+    }
+
+    @Override
+    public void flushMappedBufferRange(int target, int offset, int length) {
+        iOSGL.glFlushMappedBufferRange(target, offset, length);
+    }
+
+    @Override
+    public void bindVertexArray(int array) {
+        iOSGL.glBindVertexArray(array);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, int[] arrays, int offset) {
+        iOSGL.glDeleteVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void deleteVertexArrays(int n, IntBuffer arrays) {
+        iOSGL.glDeleteVertexArrays(n, arrays);
+    }
+
+    @Override
+    public void genVertexArrays(int n, int[] arrays, int offset) {
+        iOSGL.glGenVertexArrays(n, arrays, offset);
+    }
+
+    @Override
+    public void genVertexArrays(int n, IntBuffer arrays) {
+        iOSGL.glGenVertexArrays(n, arrays);
+    }
+
+    @Override
+    public boolean isVertexArray(int array) {
+        iOSGL.glIsVertexArray(array);
+        return false;
+    }
+
+    @Override
+    public void beginTransformFeedback(int primitiveMode) {
+        iOSGL.glBeginTransformFeedback(primitiveMode);
+    }
+
+    @Override
+    public void endTransformFeedback() {
+        iOSGL.glEndTransformFeedback();
+    }
+
+    @Override
+    public void bindBufferRange(int target, int index, int buffer, int offset, int size) {
+        iOSGL.glBindBufferRange(target, index, buffer, offset, size);
+    }
+
+    @Override
+    public void bindBufferBase(int target, int index, int buffer) {
+        iOSGL.glBindBufferBase(target, index, buffer);
+    }
+
+    @Override
+    public void transformFeedbackVaryings(int program, String[] varyings, int bufferMode) {
+        iOSGL.glTransformFeedbackVaryings(program, varyings, bufferMode);
+    }
+
+    @Override
+    public void vertexAttribIPointer(int index, int size, int type, int stride, int offset) {
+        iOSGL.glVertexAttribIPointer(index, size, type, stride, offset);
+    }
+
+    @Override
+    public void getVertexAttribIiv(int index, int pname, IntBuffer params) {
+        iOSGL.glGetVertexAttribIiv(index, pname, params);
+    }
+
+    @Override
+    public void getVertexAttribIuiv(int index, int pname, IntBuffer params) {
+        iOSGL.glGetVertexAttribIuiv(index, pname, params);
+    }
+
+    @Override
+    public void vertexAttribI4i(int index, int x, int y, int z, int w) {
+        iOSGL.glVertexAttribI4i(index, x, y, z, w);
+    }
+
+    @Override
+    public void vertexAttribI4ui(int index, int x, int y, int z, int w) {
+        iOSGL.glVertexAttribI4ui(index, x, y, z, w);
+    }
+
+    @Override
+    public void getUniformuiv(int program, int location, IntBuffer params) {
+        iOSGL.glGetUniformuiv(program, location, params);
+    }
+
+    @Override
+    public int getFragDataLocation(int program, String name) {
+        iOSGL.glGetFragDataLocation(program, name);
+        return 0;
+    }
+
+    @Override
+    public void uniform1uiv(int location, int count, IntBuffer value) {
+        iOSGL.glUniform1uiv(location, count, value);
+    }
+
+    @Override
+    public void uniform3uiv(int location, int count, IntBuffer value) {
+        iOSGL.glUniform3uiv(location, count, value);
+    }
+
+    @Override
+    public void uniform4uiv(int location, int count, IntBuffer value) {
+        iOSGL.glUniform4uiv(location, count, value);
+    }
+
+    @Override
+    public void clearBufferiv(int buffer, int drawbuffer, IntBuffer value) {
+        iOSGL.glClearBufferiv(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferuiv(int buffer, int drawbuffer, IntBuffer value) {
+        iOSGL.glClearBufferuiv(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfv(int buffer, int drawbuffer, FloatBuffer value) {
+        iOSGL.glClearBufferfv(buffer, drawbuffer, value);
+    }
+
+    @Override
+    public void clearBufferfi(int buffer, int drawbuffer, float depth, int stencil) {
+        iOSGL.glClearBufferfi(buffer, drawbuffer, depth, stencil);
+    }
+
+    @Override
+    public String getStringi(int name, int index) {
+        iOSGL.glGetStringi(name, index);
+        return null;
+    }
+
+    @Override
+    public void copyBufferSubData(int readTarget, int writeTarget, int readOffset, int writeOffset, int size) {
+        iOSGL.glCopyBufferSubData(readTarget, writeTarget, readOffset, writeOffset, size);
+    }
+
+    @Override
+    public void getUniformIndices(int program, String[] uniformNames, IntBuffer uniformIndices) {
+        iOSGL.glGetUniformIndices(program, uniformNames, uniformIndices);
+    }
+
+    @Override
+    public void getActiveUniformsiv(int program, int uniformCount, IntBuffer uniformIndices, int pname, IntBuffer params) {
+        iOSGL.glGetActiveUniformsiv(program, uniformCount, uniformIndices, pname, params);
+    }
+
+    @Override
+    public int getUniformBlockIndex(int program, String uniformBlockName) {
+        return
+                iOSGL.glGetUniformBlockIndex(program, uniformBlockName);
+    }
+
+    @Override
+    public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, IntBuffer params) {
+        iOSGL.glGetActiveUniformBlockiv(program, uniformBlockIndex, pname,
+                params);
+    }
+
+    @Override
+    public void getActiveUniformBlockName(int program, int uniformBlockIndex, Buffer length, Buffer uniformBlockName) {
+        iOSGL.glGetActiveUniformBlockName(program, uniformBlockIndex, length,
+                uniformBlockName);
+    }
+
+    @Override
+    public String getActiveUniformBlockName(int program, int uniformBlockIndex) {
+        iOSGL.glGetActiveUniformBlockName(program, uniformBlockIndex);
+        return null;
+    }
+
+    @Override
+    public void uniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding) {
+        iOSGL.glUniformBlockBinding(program, uniformBlockIndex, uniformBlockBinding);
+    }
+
+    @Override
+    public void drawArraysInstanced(int mode, int first, int count, int instanceCount) {
+        iOSGL.glDrawArraysInstanced(mode, first, count, instanceCount);
+    }
+
+    @Override
+    public void drawElementsInstanced(int mode, int count, int type, int indicesOffset, int instanceCount) {
+        iOSGL.glDrawElementsInstanced(mode, count, type, indicesOffset,
+                instanceCount);
+    }
+
+    @Override
+    public void getInteger64v(int pname, LongBuffer params) {
+        iOSGL.glGetInteger64v(pname, params);
+    }
+
+    @Override
+    public void getBufferParameteri64v(int target, int pname, LongBuffer params) {
+        iOSGL.glGetBufferParameteri64v(target, pname, params);
+    }
+
+    @Override
+    public void genSamplers(int count, int[] samplers, int offset) {
+        iOSGL.glGenSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void genSamplers(int count, IntBuffer samplers) {
+        iOSGL.glGenSamplers(count, samplers);
+    }
+
+    @Override
+    public void deleteSamplers(int count, int[] samplers, int offset) {
+        iOSGL.glDeleteSamplers(count, samplers, offset);
+    }
+
+    @Override
+    public void deleteSamplers(int count, IntBuffer samplers) {
+        iOSGL.glDeleteSamplers(count, samplers);
+    }
+
+    @Override
+    public boolean isSampler(int sampler) {
+        iOSGL.glIsSampler(sampler);
+        return false;
+    }
+
+    @Override
+    public void bindSampler(int unit, int sampler) {
+        iOSGL.glBindSampler(unit, sampler);
+    }
+
+    @Override
+    public void samplerParameteri(int sampler, int pname, int param) {
+        iOSGL.glSamplerParameteri(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameteriv(int sampler, int pname, IntBuffer param) {
+        iOSGL.glSamplerParameteriv(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterf(int sampler, int pname, float param) {
+        iOSGL.glSamplerParameterf(sampler, pname, param);
+    }
+
+    @Override
+    public void samplerParameterfv(int sampler, int pname, FloatBuffer param) {
+        iOSGL.glSamplerParameterfv(sampler, pname, param);
+    }
+
+    @Override
+    public void getSamplerParameteriv(int sampler, int pname, IntBuffer params) {
+        iOSGL.glGetSamplerParameteriv(sampler, pname, params);
+    }
+
+    @Override
+    public void getSamplerParameterfv(int sampler, int pname, FloatBuffer params) {
+        iOSGL.glGetSamplerParameterfv(sampler, pname, params);
+    }
+
+    @Override
+    public void vertexAttribDivisor(int index, int divisor) {
+        iOSGL.glVertexAttribDivisor(index, divisor);
+    }
+
+    @Override
+    public void bindTransformFeedback(int target, int id) {
+        iOSGL.glBindTransformFeedback(target, id);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, int[] ids, int offset) {
+        iOSGL.glDeleteTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void deleteTransformFeedbacks(int n, IntBuffer ids) {
+        iOSGL.glDeleteTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, int[] ids, int offset) {
+        iOSGL.glGenTransformFeedbacks(n, ids, offset);
+    }
+
+    @Override
+    public void genTransformFeedbacks(int n, IntBuffer ids) {
+        iOSGL.glGenTransformFeedbacks(n, ids);
+    }
+
+    @Override
+    public boolean isTransformFeedback(int id) {
+        iOSGL.glIsTransformFeedback(id);
+        return false;
+    }
+
+    @Override
+    public void pauseTransformFeedback() {
+        iOSGL.glPauseTransformFeedback();
+    }
+
+    @Override
+    public void resumeTransformFeedback() {
+        iOSGL.glResumeTransformFeedback();
+    }
+
+    @Override
+    public void programParameteri(int program, int pname, int value) {
+        iOSGL.glProgramParameteri(program, pname, value);
+    }
+
+    @Override
+    public void invalidateFramebuffer(int target, int numAttachments, IntBuffer attachments) {
+        iOSGL.glInvalidateFramebuffer(target, numAttachments, attachments);
+    }
+
+    @Override
+    public void invalidateSubFramebuffer(int target, int numAttachments, IntBuffer attachments, int x, int y, int width, int height) {
+        iOSGL.glInvalidateSubFramebuffer(target, numAttachments, attachments,
+                x, y, width, height);
+    }
+}

--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -2,6 +2,7 @@
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2018 Izumi Kawashima
  * Copyright 2017-2018 devemux86
+ * Copyright 2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -21,11 +22,13 @@ package org.oscim.web.client;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtGraphics;
+import com.badlogic.gdx.graphics.glutils.GLVersion;
 
 import org.oscim.backend.AssetAdapter;
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.DateTimeAdapter;
 import org.oscim.backend.GL;
+import org.oscim.backend.GL30;
 import org.oscim.backend.GLAdapter;
 import org.oscim.core.MapPosition;
 import org.oscim.core.Tile;
@@ -79,7 +82,6 @@ class GwtMap extends GdxMap {
         Tile.SIZE = Tile.calculateTileSize();
 
         log.debug("GLAdapter.init");
-        GLAdapter.init((GL) Gdx.graphics.getGL20());
         MapRenderer.setBackgroundColor(0xffffff);
         //Gdx.app.setLogLevel(Application.LOG_DEBUG);
 
@@ -164,6 +166,14 @@ class GwtMap extends GdxMap {
         }
 
         mSearchBox = new SearchBox(mMap);
+    }
+
+    @Override
+    protected void initGLAdapter(GLVersion version) {
+        if (version.getMajorVersion() >= 3)
+            GLAdapter.init((GL30) Gdx.graphics.getGL30());
+        else
+            GLAdapter.init((GL) Gdx.graphics.getGL20());
     }
 
     @Override

--- a/vtm/src/org/oscim/backend/GL30.java
+++ b/vtm/src/org/oscim/backend/GL30.java
@@ -1,0 +1,1427 @@
+/*
+ * Copyright 2019 Gustl22
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ **
+ ** Copyright 2013, The Android Open Source Project
+ **
+ ** Licensed under the Apache License, Version 2.0 (the "License");
+ ** you may not use this file except in compliance with the License.
+ ** You may obtain a copy of the License at
+ **
+ **     http://www.apache.org/licenses/LICENSE-2.0
+ **
+ ** Unless required by applicable law or agreed to in writing, software
+ ** distributed under the License is distributed on an "AS IS" BASIS,
+ ** WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ** See the License for the specific language governing permissions and
+ ** limitations under the License.
+ */
+
+// This source file is automatically generated
+
+package org.oscim.backend;
+
+import java.nio.Buffer;
+
+/**
+ * OpenGL ES 3.0
+ * <p>
+ * See https://github.com/libgdx/libgdx/blob/master/gdx/src/com/badlogic/gdx/graphics/GL30.java
+ */
+public interface GL30 extends GL {
+    public final int READ_BUFFER = 0x0C02;
+    public final int UNPACK_ROW_LENGTH = 0x0CF2;
+    public final int UNPACK_SKIP_ROWS = 0x0CF3;
+    public final int UNPACK_SKIP_PIXELS = 0x0CF4;
+    public final int PACK_ROW_LENGTH = 0x0D02;
+    public final int PACK_SKIP_ROWS = 0x0D03;
+    public final int PACK_SKIP_PIXELS = 0x0D04;
+    public final int COLOR = 0x1800;
+    public final int DEPTH = 0x1801;
+    public final int STENCIL = 0x1802;
+    public final int RED = 0x1903;
+    public final int RGB8 = 0x8051;
+    public final int RGBA8 = 0x8058;
+    public final int RGB10_A2 = 0x8059;
+    public final int TEXTURE_BINDING_3D = 0x806A;
+    public final int UNPACK_SKIP_IMAGES = 0x806D;
+    public final int UNPACK_IMAGE_HEIGHT = 0x806E;
+    public final int TEXTURE_3D = 0x806F;
+    public final int TEXTURE_WRAP_R = 0x8072;
+    public final int MAX_3D_TEXTURE_SIZE = 0x8073;
+    public final int UNSIGNED_INT_2_10_10_10_REV = 0x8368;
+    public final int MAX_ELEMENTS_VERTICES = 0x80E8;
+    public final int MAX_ELEMENTS_INDICES = 0x80E9;
+    public final int TEXTURE_MIN_LOD = 0x813A;
+    public final int TEXTURE_MAX_LOD = 0x813B;
+    public final int TEXTURE_BASE_LEVEL = 0x813C;
+    public final int TEXTURE_MAX_LEVEL = 0x813D;
+    public final int MIN = 0x8007;
+    public final int MAX = 0x8008;
+    public final int DEPTH_COMPONENT24 = 0x81A6;
+    public final int MAX_TEXTURE_LOD_BIAS = 0x84FD;
+    public final int TEXTURE_COMPARE_MODE = 0x884C;
+    public final int TEXTURE_COMPARE_FUNC = 0x884D;
+    public final int CURRENT_QUERY = 0x8865;
+    public final int QUERY_RESULT = 0x8866;
+    public final int QUERY_RESULT_AVAILABLE = 0x8867;
+    public final int BUFFER_MAPPED = 0x88BC;
+    public final int BUFFER_MAP_POINTER = 0x88BD;
+    public final int STREAM_READ = 0x88E1;
+    public final int STREAM_COPY = 0x88E2;
+    public final int STATIC_READ = 0x88E5;
+    public final int STATIC_COPY = 0x88E6;
+    public final int DYNAMIC_READ = 0x88E9;
+    public final int DYNAMIC_COPY = 0x88EA;
+    public final int MAX_DRAW_BUFFERS = 0x8824;
+    public final int DRAW_BUFFER0 = 0x8825;
+    public final int DRAW_BUFFER1 = 0x8826;
+    public final int DRAW_BUFFER2 = 0x8827;
+    public final int DRAW_BUFFER3 = 0x8828;
+    public final int DRAW_BUFFER4 = 0x8829;
+    public final int DRAW_BUFFER5 = 0x882A;
+    public final int DRAW_BUFFER6 = 0x882B;
+    public final int DRAW_BUFFER7 = 0x882C;
+    public final int DRAW_BUFFER8 = 0x882D;
+    public final int DRAW_BUFFER9 = 0x882E;
+    public final int DRAW_BUFFER10 = 0x882F;
+    public final int DRAW_BUFFER11 = 0x8830;
+    public final int DRAW_BUFFER12 = 0x8831;
+    public final int DRAW_BUFFER13 = 0x8832;
+    public final int DRAW_BUFFER14 = 0x8833;
+    public final int DRAW_BUFFER15 = 0x8834;
+    public final int MAX_FRAGMENT_UNIFORM_COMPONENTS = 0x8B49;
+    public final int MAX_VERTEX_UNIFORM_COMPONENTS = 0x8B4A;
+    public final int SAMPLER_3D = 0x8B5F;
+    public final int SAMPLER_2D_SHADOW = 0x8B62;
+    public final int FRAGMENT_SHADER_DERIVATIVE_HINT = 0x8B8B;
+    public final int PIXEL_PACK_BUFFER = 0x88EB;
+    public final int PIXEL_UNPACK_BUFFER = 0x88EC;
+    public final int PIXEL_PACK_BUFFER_BINDING = 0x88ED;
+    public final int PIXEL_UNPACK_BUFFER_BINDING = 0x88EF;
+    public final int FLOAT_MAT2x3 = 0x8B65;
+    public final int FLOAT_MAT2x4 = 0x8B66;
+    public final int FLOAT_MAT3x2 = 0x8B67;
+    public final int FLOAT_MAT3x4 = 0x8B68;
+    public final int FLOAT_MAT4x2 = 0x8B69;
+    public final int FLOAT_MAT4x3 = 0x8B6A;
+    public final int SRGB = 0x8C40;
+    public final int SRGB8 = 0x8C41;
+    public final int SRGB8_ALPHA8 = 0x8C43;
+    public final int COMPARE_REF_TO_TEXTURE = 0x884E;
+    public final int MAJOR_VERSION = 0x821B;
+    public final int MINOR_VERSION = 0x821C;
+    public final int NUM_EXTENSIONS = 0x821D;
+    public final int RGBA32F = 0x8814;
+    public final int RGB32F = 0x8815;
+    public final int RGBA16F = 0x881A;
+    public final int RGB16F = 0x881B;
+    public final int VERTEX_ATTRIB_ARRAY_INTEGER = 0x88FD;
+    public final int MAX_ARRAY_TEXTURE_LAYERS = 0x88FF;
+    public final int MIN_PROGRAM_TEXEL_OFFSET = 0x8904;
+    public final int MAX_PROGRAM_TEXEL_OFFSET = 0x8905;
+    public final int MAX_VARYING_COMPONENTS = 0x8B4B;
+    public final int TEXTURE_2D_ARRAY = 0x8C1A;
+    public final int TEXTURE_BINDING_2D_ARRAY = 0x8C1D;
+    public final int R11F_G11F_B10F = 0x8C3A;
+    public final int UNSIGNED_INT_10F_11F_11F_REV = 0x8C3B;
+    public final int RGB9_E5 = 0x8C3D;
+    public final int UNSIGNED_INT_5_9_9_9_REV = 0x8C3E;
+    public final int TRANSFORM_FEEDBACK_VARYING_MAX_LENGTH = 0x8C76;
+    public final int TRANSFORM_FEEDBACK_BUFFER_MODE = 0x8C7F;
+    public final int MAX_TRANSFORM_FEEDBACK_SEPARATE_COMPONENTS = 0x8C80;
+    public final int TRANSFORM_FEEDBACK_VARYINGS = 0x8C83;
+    public final int TRANSFORM_FEEDBACK_BUFFER_START = 0x8C84;
+    public final int TRANSFORM_FEEDBACK_BUFFER_SIZE = 0x8C85;
+    public final int TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN = 0x8C88;
+    public final int RASTERIZER_DISCARD = 0x8C89;
+    public final int MAX_TRANSFORM_FEEDBACK_INTERLEAVED_COMPONENTS = 0x8C8A;
+    public final int MAX_TRANSFORM_FEEDBACK_SEPARATE_ATTRIBS = 0x8C8B;
+    public final int INTERLEAVED_ATTRIBS = 0x8C8C;
+    public final int SEPARATE_ATTRIBS = 0x8C8D;
+    public final int TRANSFORM_FEEDBACK_BUFFER = 0x8C8E;
+    public final int TRANSFORM_FEEDBACK_BUFFER_BINDING = 0x8C8F;
+    public final int RGBA32UI = 0x8D70;
+    public final int RGB32UI = 0x8D71;
+    public final int RGBA16UI = 0x8D76;
+    public final int RGB16UI = 0x8D77;
+    public final int RGBA8UI = 0x8D7C;
+    public final int RGB8UI = 0x8D7D;
+    public final int RGBA32I = 0x8D82;
+    public final int RGB32I = 0x8D83;
+    public final int RGBA16I = 0x8D88;
+    public final int RGB16I = 0x8D89;
+    public final int RGBA8I = 0x8D8E;
+    public final int RGB8I = 0x8D8F;
+    public final int RED_INTEGER = 0x8D94;
+    public final int RGB_INTEGER = 0x8D98;
+    public final int RGBA_INTEGER = 0x8D99;
+    public final int SAMPLER_2D_ARRAY = 0x8DC1;
+    public final int SAMPLER_2D_ARRAY_SHADOW = 0x8DC4;
+    public final int SAMPLER_CUBE_SHADOW = 0x8DC5;
+    public final int UNSIGNED_INT_VEC2 = 0x8DC6;
+    public final int UNSIGNED_INT_VEC3 = 0x8DC7;
+    public final int UNSIGNED_INT_VEC4 = 0x8DC8;
+    public final int INT_SAMPLER_2D = 0x8DCA;
+    public final int INT_SAMPLER_3D = 0x8DCB;
+    public final int INT_SAMPLER_CUBE = 0x8DCC;
+    public final int INT_SAMPLER_2D_ARRAY = 0x8DCF;
+    public final int UNSIGNED_INT_SAMPLER_2D = 0x8DD2;
+    public final int UNSIGNED_INT_SAMPLER_3D = 0x8DD3;
+    public final int UNSIGNED_INT_SAMPLER_CUBE = 0x8DD4;
+    public final int UNSIGNED_INT_SAMPLER_2D_ARRAY = 0x8DD7;
+    public final int BUFFER_ACCESS_FLAGS = 0x911F;
+    public final int BUFFER_MAP_LENGTH = 0x9120;
+    public final int BUFFER_MAP_OFFSET = 0x9121;
+    public final int DEPTH_COMPONENT32F = 0x8CAC;
+    public final int DEPTH32F_STENCIL8 = 0x8CAD;
+    public final int FLOAT_32_UNSIGNED_INT_24_8_REV = 0x8DAD;
+    public final int FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING = 0x8210;
+    public final int FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE = 0x8211;
+    public final int FRAMEBUFFER_ATTACHMENT_RED_SIZE = 0x8212;
+    public final int FRAMEBUFFER_ATTACHMENT_GREEN_SIZE = 0x8213;
+    public final int FRAMEBUFFER_ATTACHMENT_BLUE_SIZE = 0x8214;
+    public final int FRAMEBUFFER_ATTACHMENT_ALPHA_SIZE = 0x8215;
+    public final int FRAMEBUFFER_ATTACHMENT_DEPTH_SIZE = 0x8216;
+    public final int FRAMEBUFFER_ATTACHMENT_STENCIL_SIZE = 0x8217;
+    public final int FRAMEBUFFER_DEFAULT = 0x8218;
+    public final int FRAMEBUFFER_UNDEFINED = 0x8219;
+    public final int DEPTH_STENCIL_ATTACHMENT = 0x821A;
+    public final int DEPTH_STENCIL = 0x84F9;
+    public final int UNSIGNED_INT_24_8 = 0x84FA;
+    public final int DEPTH24_STENCIL8 = 0x88F0;
+    public final int UNSIGNED_NORMALIZED = 0x8C17;
+    public final int DRAW_FRAMEBUFFER_BINDING = FRAMEBUFFER_BINDING;
+    public final int READ_FRAMEBUFFER = 0x8CA8;
+    public final int DRAW_FRAMEBUFFER = 0x8CA9;
+    public final int READ_FRAMEBUFFER_BINDING = 0x8CAA;
+    public final int RENDERBUFFER_SAMPLES = 0x8CAB;
+    public final int FRAMEBUFFER_ATTACHMENT_TEXTURE_LAYER = 0x8CD4;
+    public final int MAX_COLOR_ATTACHMENTS = 0x8CDF;
+    public final int COLOR_ATTACHMENT1 = 0x8CE1;
+    public final int COLOR_ATTACHMENT2 = 0x8CE2;
+    public final int COLOR_ATTACHMENT3 = 0x8CE3;
+    public final int COLOR_ATTACHMENT4 = 0x8CE4;
+    public final int COLOR_ATTACHMENT5 = 0x8CE5;
+    public final int COLOR_ATTACHMENT6 = 0x8CE6;
+    public final int COLOR_ATTACHMENT7 = 0x8CE7;
+    public final int COLOR_ATTACHMENT8 = 0x8CE8;
+    public final int COLOR_ATTACHMENT9 = 0x8CE9;
+    public final int COLOR_ATTACHMENT10 = 0x8CEA;
+    public final int COLOR_ATTACHMENT11 = 0x8CEB;
+    public final int COLOR_ATTACHMENT12 = 0x8CEC;
+    public final int COLOR_ATTACHMENT13 = 0x8CED;
+    public final int COLOR_ATTACHMENT14 = 0x8CEE;
+    public final int COLOR_ATTACHMENT15 = 0x8CEF;
+    public final int FRAMEBUFFER_INCOMPLETE_MULTISAMPLE = 0x8D56;
+    public final int MAX_SAMPLES = 0x8D57;
+    public final int HALF_FLOAT = 0x140B;
+    public final int MAP_READ_BIT = 0x0001;
+    public final int MAP_WRITE_BIT = 0x0002;
+    public final int MAP_INVALIDATE_RANGE_BIT = 0x0004;
+    public final int MAP_INVALIDATE_BUFFER_BIT = 0x0008;
+    public final int MAP_FLUSH_EXPLICIT_BIT = 0x0010;
+    public final int MAP_UNSYNCHRONIZED_BIT = 0x0020;
+    public final int RG = 0x8227;
+    public final int RG_INTEGER = 0x8228;
+    public final int R8 = 0x8229;
+    public final int RG8 = 0x822B;
+    public final int R16F = 0x822D;
+    public final int R32F = 0x822E;
+    public final int RG16F = 0x822F;
+    public final int RG32F = 0x8230;
+    public final int R8I = 0x8231;
+    public final int R8UI = 0x8232;
+    public final int R16I = 0x8233;
+    public final int R16UI = 0x8234;
+    public final int R32I = 0x8235;
+    public final int R32UI = 0x8236;
+    public final int RG8I = 0x8237;
+    public final int RG8UI = 0x8238;
+    public final int RG16I = 0x8239;
+    public final int RG16UI = 0x823A;
+    public final int RG32I = 0x823B;
+    public final int RG32UI = 0x823C;
+    public final int VERTEX_ARRAY_BINDING = 0x85B5;
+    public final int R8_SNORM = 0x8F94;
+    public final int RG8_SNORM = 0x8F95;
+    public final int RGB8_SNORM = 0x8F96;
+    public final int RGBA8_SNORM = 0x8F97;
+    public final int SIGNED_NORMALIZED = 0x8F9C;
+    public final int PRIMITIVE_RESTART_FIXED_INDEX = 0x8D69;
+    public final int COPY_READ_BUFFER = 0x8F36;
+    public final int COPY_WRITE_BUFFER = 0x8F37;
+    public final int COPY_READ_BUFFER_BINDING = COPY_READ_BUFFER;
+    public final int COPY_WRITE_BUFFER_BINDING = COPY_WRITE_BUFFER;
+    public final int UNIFORM_BUFFER = 0x8A11;
+    public final int UNIFORM_BUFFER_BINDING = 0x8A28;
+    public final int UNIFORM_BUFFER_START = 0x8A29;
+    public final int UNIFORM_BUFFER_SIZE = 0x8A2A;
+    public final int MAX_VERTEX_UNIFORM_BLOCKS = 0x8A2B;
+    public final int MAX_FRAGMENT_UNIFORM_BLOCKS = 0x8A2D;
+    public final int MAX_COMBINED_UNIFORM_BLOCKS = 0x8A2E;
+    public final int MAX_UNIFORM_BUFFER_BINDINGS = 0x8A2F;
+    public final int MAX_UNIFORM_BLOCK_SIZE = 0x8A30;
+    public final int MAX_COMBINED_VERTEX_UNIFORM_COMPONENTS = 0x8A31;
+    public final int MAX_COMBINED_FRAGMENT_UNIFORM_COMPONENTS = 0x8A33;
+    public final int UNIFORM_BUFFER_OFFSET_ALIGNMENT = 0x8A34;
+    public final int ACTIVE_UNIFORM_BLOCK_MAX_NAME_LENGTH = 0x8A35;
+    public final int ACTIVE_UNIFORM_BLOCKS = 0x8A36;
+    public final int UNIFORM_TYPE = 0x8A37;
+    public final int UNIFORM_SIZE = 0x8A38;
+    public final int UNIFORM_NAME_LENGTH = 0x8A39;
+    public final int UNIFORM_BLOCK_INDEX = 0x8A3A;
+    public final int UNIFORM_OFFSET = 0x8A3B;
+    public final int UNIFORM_ARRAY_STRIDE = 0x8A3C;
+    public final int UNIFORM_MATRIX_STRIDE = 0x8A3D;
+    public final int UNIFORM_IS_ROW_MAJOR = 0x8A3E;
+    public final int UNIFORM_BLOCK_BINDING = 0x8A3F;
+    public final int UNIFORM_BLOCK_DATA_SIZE = 0x8A40;
+    public final int UNIFORM_BLOCK_NAME_LENGTH = 0x8A41;
+    public final int UNIFORM_BLOCK_ACTIVE_UNIFORMS = 0x8A42;
+    public final int UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES = 0x8A43;
+    public final int UNIFORM_BLOCK_REFERENCED_BY_VERTEX_SHADER = 0x8A44;
+    public final int UNIFORM_BLOCK_REFERENCED_BY_FRAGMENT_SHADER = 0x8A46;
+    // INVALID_INDEX is defined as 0xFFFFFFFFu in C.
+    public final int INVALID_INDEX = -1;
+    public final int MAX_VERTEX_OUTPUT_COMPONENTS = 0x9122;
+    public final int MAX_FRAGMENT_INPUT_COMPONENTS = 0x9125;
+    public final int MAX_SERVER_WAIT_TIMEOUT = 0x9111;
+    public final int OBJECT_TYPE = 0x9112;
+    public final int SYNC_CONDITION = 0x9113;
+    public final int SYNC_STATUS = 0x9114;
+    public final int SYNC_FLAGS = 0x9115;
+    public final int SYNC_FENCE = 0x9116;
+    public final int SYNC_GPU_COMMANDS_COMPLETE = 0x9117;
+    public final int UNSIGNALED = 0x9118;
+    public final int SIGNALED = 0x9119;
+    public final int ALREADY_SIGNALED = 0x911A;
+    public final int TIMEOUT_EXPIRED = 0x911B;
+    public final int CONDITION_SATISFIED = 0x911C;
+    public final int WAIT_FAILED = 0x911D;
+    public final int SYNC_FLUSH_COMMANDS_BIT = 0x00000001;
+    // TIMEOUT_IGNORED is defined as 0xFFFFFFFFFFFFFFFFull in C.
+    public final long TIMEOUT_IGNORED = -1;
+    public final int VERTEX_ATTRIB_ARRAY_DIVISOR = 0x88FE;
+    public final int ANY_SAMPLES_PASSED = 0x8C2F;
+    public final int ANY_SAMPLES_PASSED_CONSERVATIVE = 0x8D6A;
+    public final int SAMPLER_BINDING = 0x8919;
+    public final int RGB10_A2UI = 0x906F;
+    public final int TEXTURE_SWIZZLE_R = 0x8E42;
+    public final int TEXTURE_SWIZZLE_G = 0x8E43;
+    public final int TEXTURE_SWIZZLE_B = 0x8E44;
+    public final int TEXTURE_SWIZZLE_A = 0x8E45;
+    public final int GREEN = 0x1904;
+    public final int BLUE = 0x1905;
+    public final int INT_2_10_10_10_REV = 0x8D9F;
+    public final int TRANSFORM_FEEDBACK = 0x8E22;
+    public final int TRANSFORM_FEEDBACK_PAUSED = 0x8E23;
+    public final int TRANSFORM_FEEDBACK_ACTIVE = 0x8E24;
+    public final int TRANSFORM_FEEDBACK_BINDING = 0x8E25;
+    public final int PROGRAM_BINARY_RETRIEVABLE_HINT = 0x8257;
+    public final int PROGRAM_BINARY_LENGTH = 0x8741;
+    public final int NUM_PROGRAM_BINARY_FORMATS = 0x87FE;
+    public final int PROGRAM_BINARY_FORMATS = 0x87FF;
+    public final int COMPRESSED_R11_EAC = 0x9270;
+    public final int COMPRESSED_SIGNED_R11_EAC = 0x9271;
+    public final int COMPRESSED_RG11_EAC = 0x9272;
+    public final int COMPRESSED_SIGNED_RG11_EAC = 0x9273;
+    public final int COMPRESSED_RGB8_ETC2 = 0x9274;
+    public final int COMPRESSED_SRGB8_ETC2 = 0x9275;
+    public final int COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9276;
+    public final int COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x9277;
+    public final int COMPRESSED_RGBA8_ETC2_EAC = 0x9278;
+    public final int COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = 0x9279;
+    public final int TEXTURE_IMMUTABLE_FORMAT = 0x912F;
+    public final int MAX_ELEMENT_INDEX = 0x8D6B;
+    public final int NUM_SAMPLE_COUNTS = 0x9380;
+    public final int TEXTURE_IMMUTABLE_LEVELS = 0x82DF;
+
+    // C function void readBuffer  ( GLenum mode )
+
+    public void readBuffer(int mode);
+
+    // C function void drawRangeElements  ( GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const GLvoid
+// *indices )
+
+    public void drawRangeElements(int mode, int start, int end, int count, int type, java.nio.Buffer indices);
+
+    // C function void drawRangeElements  ( GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, GLsizei offset )
+
+    public void drawRangeElements(int mode, int start, int end, int count, int type, int offset);
+
+    // C function void texImage3D  ( GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei
+// depth, GLint border, GLenum format, GLenum type, const GLvoid *pixels )
+
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, java.nio.Buffer pixels);
+
+    // C function void texImage3D  ( GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLsizei
+// depth, GLint border, GLenum format, GLenum type, GLsizei offset )
+
+    public void texImage3D(int target, int level, int internalformat, int width, int height, int depth, int border, int format,
+                           int type, int offset);
+
+    // C function void texSubImage3D  ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width,
+// GLsizei height, GLsizei depth, GLenum format, GLenum type, const GLvoid *pixels )
+
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, java.nio.Buffer pixels);
+
+    // C function void texSubImage3D  ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width,
+// GLsizei height, GLsizei depth, GLenum format, GLenum type, GLsizei offset )
+
+    public void texSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int width, int height, int depth,
+                              int format, int type, int offset);
+
+    // C function void copyTexSubImage3D  ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x,
+// GLint y, GLsizei width, GLsizei height )
+
+    public void copyTexSubImage3D(int target, int level, int xoffset, int yoffset, int zoffset, int x, int y, int width,
+                                  int height);
+
+// // C function void compressedTexImage3D  ( GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height,
+// GLsizei depth, GLint border, GLsizei imageSize, const GLvoid *data )
+//
+// public void compressedTexImage3D (
+// int target,
+// int level,
+// int internalformat,
+// int width,
+// int height,
+// int depth,
+// int border,
+// int imageSize,
+// java.nio.Buffer data
+// );
+//
+// // C function void compressedTexImage3D  ( GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height,
+// GLsizei depth, GLint border, GLsizei imageSize, GLsizei offset )
+//
+// public void compressedTexImage3D (
+// int target,
+// int level,
+// int internalformat,
+// int width,
+// int height,
+// int depth,
+// int border,
+// int imageSize,
+// int offset
+// );
+//
+// // C function void compressedTexSubImage3D  ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei
+// width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, const GLvoid *data )
+//
+// public void compressedTexSubImage3D (
+// int target,
+// int level,
+// int xoffset,
+// int yoffset,
+// int zoffset,
+// int width,
+// int height,
+// int depth,
+// int format,
+// int imageSize,
+// java.nio.Buffer data
+// );
+//
+// // C function void compressedTexSubImage3D  ( GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei
+// width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, GLsizei offset )
+//
+// public void compressedTexSubImage3D (
+// int target,
+// int level,
+// int xoffset,
+// int yoffset,
+// int zoffset,
+// int width,
+// int height,
+// int depth,
+// int format,
+// int imageSize,
+// int offset
+// );
+
+    // C function void genQueries  ( GLsizei n, GLuint *ids )
+
+    public void genQueries(int n, int[] ids, int offset);
+
+    // C function void genQueries  ( GLsizei n, GLuint *ids )
+
+    public void genQueries(int n, java.nio.IntBuffer ids);
+
+    // C function void deleteQueries  ( GLsizei n, const GLuint *ids )
+
+    public void deleteQueries(int n, int[] ids, int offset);
+
+    // C function void deleteQueries  ( GLsizei n, const GLuint *ids )
+
+    public void deleteQueries(int n, java.nio.IntBuffer ids);
+
+    // C function boolean glIsQuery  ( GLuint id )
+
+    public boolean isQuery(int id);
+
+    // C function void beginQuery  ( GLenum target, GLuint id )
+
+    public void beginQuery(int target, int id);
+
+    // C function void endQuery  ( GLenum target )
+
+    public void endQuery(int target);
+
+// // C function void getQueryiv  ( GLenum target, GLenum pname, GLint *params )
+//
+// public void getQueryiv (
+// int target,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getQueryiv  ( GLenum target, GLenum pname, GLint *params )
+
+    public void getQueryiv(int target, int pname, java.nio.IntBuffer params);
+
+// // C function void getQueryObjectuiv  ( GLuint id, GLenum pname, GLuint *params )
+//
+// public void getQueryObjectuiv (
+// int id,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getQueryObjectuiv  ( GLuint id, GLenum pname, GLuint *params )
+
+    public void getQueryObjectuiv(int id, int pname, java.nio.IntBuffer params);
+
+    // C function boolean glUnmapBuffer  ( GLenum target )
+
+    public boolean unmapBuffer(int target);
+
+    // C function void getBufferPointerv  ( GLenum target, GLenum pname, GLvoid** params )
+
+    public java.nio.Buffer getBufferPointerv(int target, int pname);
+
+// // C function void drawBuffers  ( GLsizei n, const GLenum *bufs )
+//
+// public void drawBuffers (
+// int n,
+// int[] bufs,
+// int offset
+// );
+
+    // C function void drawBuffers  ( GLsizei n, const GLenum *bufs )
+
+    public void drawBuffers(int n, java.nio.IntBuffer bufs);
+
+// // C function void uniformMatrix2x3fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix2x3fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix2x3fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix2x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+// // C function void uniformMatrix3x2fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix3x2fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix3x2fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix3x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+// // C function void uniformMatrix2x4fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix2x4fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix2x4fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix2x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+// // C function void uniformMatrix4x2fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix4x2fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix4x2fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix4x2fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+// // C function void uniformMatrix3x4fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix3x4fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix3x4fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix3x4fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+// // C function void uniformMatrix4x3fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+//
+// public void uniformMatrix4x3fv (
+// int location,
+// int count,
+// boolean transpose,
+// float[] value,
+// int offset
+// );
+
+    // C function void uniformMatrix4x3fv  ( GLint location, GLsizei count, GLboolean transpose, const GLfloat *value )
+
+    public void uniformMatrix4x3fv(int location, int count, boolean transpose, java.nio.FloatBuffer value);
+
+    // C function void blitFramebuffer  ( GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint
+// dstX1, GLint dstY1, GLbitfield mask, GLenum filter )
+
+    public void blitFramebuffer(int srcX0, int srcY0, int srcX1, int srcY1, int dstX0, int dstY0, int dstX1, int dstY1,
+                                int mask, int filter);
+
+    // C function void renderbufferStorageMultisample  ( GLenum target, GLsizei samples, GLenum internalformat, GLsizei width,
+// GLsizei height )
+
+    public void renderbufferStorageMultisample(int target, int samples, int internalformat, int width, int height);
+
+    // C function void framebufferTextureLayer  ( GLenum target, GLenum attachment, GLuint texture, GLint level, GLint layer )
+
+    public void framebufferTextureLayer(int target, int attachment, int texture, int level, int layer);
+
+// // C function void * glMapBufferRange  ( GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access )
+//
+// public java.nio.Buffer mapBufferRange (
+// int target,
+// int offset,
+// int length,
+// int access
+// );
+
+    // C function void flushMappedBufferRange  ( GLenum target, GLintptr offset, GLsizeiptr length )
+
+    public void flushMappedBufferRange(int target, int offset, int length);
+
+    // C function void bindVertexArray  ( GLuint array )
+
+    public void bindVertexArray(int array);
+
+    // C function void deleteVertexArrays  ( GLsizei n, const GLuint *arrays )
+
+    public void deleteVertexArrays(int n, int[] arrays, int offset);
+
+    // C function void deleteVertexArrays  ( GLsizei n, const GLuint *arrays )
+
+    public void deleteVertexArrays(int n, java.nio.IntBuffer arrays);
+
+    // C function void genVertexArrays  ( GLsizei n, GLuint *arrays )
+
+    public void genVertexArrays(int n, int[] arrays, int offset);
+
+    // C function void genVertexArrays  ( GLsizei n, GLuint *arrays )
+
+    public void genVertexArrays(int n, java.nio.IntBuffer arrays);
+
+    // C function boolean glIsVertexArray  ( GLuint array )
+
+    public boolean isVertexArray(int array);
+
+//
+// // C function void getIntegeri_v  ( GLenum target, GLuint index, GLint *data )
+//
+// public void getIntegeri_v (
+// int target,
+// int index,
+// int[] data,
+// int offset
+// );
+//
+// // C function void getIntegeri_v  ( GLenum target, GLuint index, GLint *data )
+//
+// public void getIntegeri_v (
+// int target,
+// int index,
+// java.nio.IntBuffer data
+// );
+
+    // C function void beginTransformFeedback  ( GLenum primitiveMode )
+
+    public void beginTransformFeedback(int primitiveMode);
+
+    // C function void endTransformFeedback  ( void )
+
+    public void endTransformFeedback();
+
+    // C function void bindBufferRange  ( GLenum target, GLuint index, GLuint buffer, GLintptr offset, GLsizeiptr size )
+
+    public void bindBufferRange(int target, int index, int buffer, int offset, int size);
+
+    // C function void bindBufferBase  ( GLenum target, GLuint index, GLuint buffer )
+
+    public void bindBufferBase(int target, int index, int buffer);
+
+    // C function void transformFeedbackVaryings  ( GLuint program, GLsizei count, const GLchar *varyings, GLenum bufferMode )
+
+    public void transformFeedbackVaryings(int program, String[] varyings, int bufferMode);
+
+// // C function void getTransformFeedbackVarying  ( GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+// GLenum *type, GLchar *name )
+//
+// public void getTransformFeedbackVarying (
+// int program,
+// int index,
+// int bufsize,
+// int[] length,
+// int lengthOffset,
+// int[] size,
+// int sizeOffset,
+// int[] type,
+// int typeOffset,
+// byte[] name,
+// int nameOffset
+// );
+//
+// // C function void getTransformFeedbackVarying  ( GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+// GLenum *type, GLchar *name )
+//
+// public void getTransformFeedbackVarying (
+// int program,
+// int index,
+// int bufsize,
+// java.nio.IntBuffer length,
+// java.nio.IntBuffer size,
+// java.nio.IntBuffer type,
+// byte name
+// );
+//
+// // C function void getTransformFeedbackVarying  ( GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+// GLenum *type, GLchar *name )
+//
+// public String getTransformFeedbackVarying (
+// int program,
+// int index,
+// int[] size,
+// int sizeOffset,
+// int[] type,
+// int typeOffset
+// );
+//
+// // C function void getTransformFeedbackVarying  ( GLuint program, GLuint index, GLsizei bufSize, GLsizei *length, GLint *size,
+// GLenum *type, GLchar *name )
+//
+// public String getTransformFeedbackVarying (
+// int program,
+// int index,
+// java.nio.IntBuffer size,
+// java.nio.IntBuffer type
+// );
+
+    // C function void vertexAttribIPointer  ( GLuint index, GLint size, GLenum type, GLsizei stride, GLsizei offset )
+
+    public void vertexAttribIPointer(int index, int size, int type, int stride, int offset);
+
+// // C function void getVertexAttribIiv  ( GLuint index, GLenum pname, GLint *params )
+//
+// public void getVertexAttribIiv (
+// int index,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getVertexAttribIiv  ( GLuint index, GLenum pname, GLint *params )
+
+    public void getVertexAttribIiv(int index, int pname, java.nio.IntBuffer params);
+
+// // C function void getVertexAttribIuiv  ( GLuint index, GLenum pname, GLuint *params )
+//
+// public void getVertexAttribIuiv (
+// int index,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getVertexAttribIuiv  ( GLuint index, GLenum pname, GLuint *params )
+
+    public void getVertexAttribIuiv(int index, int pname, java.nio.IntBuffer params);
+
+    // C function void vertexAttribI4i  ( GLuint index, GLint x, GLint y, GLint z, GLint w )
+
+    public void vertexAttribI4i(int index, int x, int y, int z, int w);
+
+    // C function void vertexAttribI4ui  ( GLuint index, GLuint x, GLuint y, GLuint z, GLuint w )
+
+    public void vertexAttribI4ui(int index, int x, int y, int z, int w);
+
+// // C function void vertexAttribI4iv  ( GLuint index, const GLint *v )
+//
+// public void vertexAttribI4iv (
+// int index,
+// int[] v,
+// int offset
+// );
+//
+// // C function void vertexAttribI4iv  ( GLuint index, const GLint *v )
+//
+// public void vertexAttribI4iv (
+// int index,
+// java.nio.IntBuffer v
+// );
+//
+// // C function void vertexAttribI4uiv  ( GLuint index, const GLuint *v )
+//
+// public void vertexAttribI4uiv (
+// int index,
+// int[] v,
+// int offset
+// );
+//
+// // C function void vertexAttribI4uiv  ( GLuint index, const GLuint *v )
+//
+// public void vertexAttribI4uiv (
+// int index,
+// java.nio.IntBuffer v
+// );
+//
+// // C function void getUniformuiv  ( GLuint program, GLint location, GLuint *params )
+//
+// public void getUniformuiv (
+// int program,
+// int location,
+// int[] params,
+// int offset
+// );
+
+    // C function void getUniformuiv  ( GLuint program, GLint location, GLuint *params )
+
+    public void getUniformuiv(int program, int location, java.nio.IntBuffer params);
+
+    // C function int glGetFragDataLocation  ( GLuint program, const GLchar *name )
+
+    public int getFragDataLocation(int program, String name);
+
+// // C function void uniform1ui  ( GLint location, GLuint v0 )
+//
+// public void uniform1ui (
+// int location,
+// int v0
+// );
+//
+// // C function void uniform2ui  ( GLint location, GLuint v0, GLuint v1 )
+//
+// public void uniform2ui (
+// int location,
+// int v0,
+// int v1
+// );
+//
+// // C function void uniform3ui  ( GLint location, GLuint v0, GLuint v1, GLuint v2 )
+//
+// public void uniform3ui (
+// int location,
+// int v0,
+// int v1,
+// int v2
+// );
+//
+// // C function void uniform4ui  ( GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3 )
+//
+// public void uniform4ui (
+// int location,
+// int v0,
+// int v1,
+// int v2,
+// int v3
+// );
+//
+// // C function void uniform1uiv  ( GLint location, GLsizei count, const GLuint *value )
+//
+// public void uniform1uiv (
+// int location,
+// int count,
+// int[] value,
+// int offset
+// );
+
+    // C function void uniform1uiv  ( GLint location, GLsizei count, const GLuint *value )
+
+    public void uniform1uiv(int location, int count, java.nio.IntBuffer value);
+
+// // C function void uniform2uiv  ( GLint location, GLsizei count, const GLuint *value )
+//
+// public void uniform2uiv (
+// int location,
+// int count,
+// int[] value,
+// int offset
+// );
+//
+// // C function void uniform2uiv  ( GLint location, GLsizei count, const GLuint *value )
+//
+// public void uniform2uiv (
+// int location,
+// int count,
+// java.nio.IntBuffer value
+// );
+//
+// // C function void uniform3uiv  ( GLint location, GLsizei count, const GLuint *value )
+//
+// public void uniform3uiv (
+// int location,
+// int count,
+// int[] value,
+// int offset
+// );
+
+    // C function void uniform3uiv  ( GLint location, GLsizei count, const GLuint *value )
+
+    public void uniform3uiv(int location, int count, java.nio.IntBuffer value);
+
+// // C function void uniform4uiv  ( GLint location, GLsizei count, const GLuint *value )
+//
+// public void uniform4uiv (
+// int location,
+// int count,
+// int[] value,
+// int offset
+// );
+
+    // C function void uniform4uiv  ( GLint location, GLsizei count, const GLuint *value )
+
+    public void uniform4uiv(int location, int count, java.nio.IntBuffer value);
+
+// // C function void clearBufferiv  ( GLenum buffer, GLint drawbuffer, const GLint *value )
+//
+// public void clearBufferiv (
+// int buffer,
+// int drawbuffer,
+// int[] value,
+// int offset
+// );
+
+    // C function void clearBufferiv  ( GLenum buffer, GLint drawbuffer, const GLint *value )
+
+    public void clearBufferiv(int buffer, int drawbuffer, java.nio.IntBuffer value);
+
+// // C function void clearBufferuiv  ( GLenum buffer, GLint drawbuffer, const GLuint *value )
+//
+// public void clearBufferuiv (
+// int buffer,
+// int drawbuffer,
+// int[] value,
+// int offset
+// );
+
+    // C function void clearBufferuiv  ( GLenum buffer, GLint drawbuffer, const GLuint *value )
+
+    public void clearBufferuiv(int buffer, int drawbuffer, java.nio.IntBuffer value);
+
+// // C function void clearBufferfv  ( GLenum buffer, GLint drawbuffer, const GLfloat *value )
+//
+// public void clearBufferfv (
+// int buffer,
+// int drawbuffer,
+// float[] value,
+// int offset
+// );
+
+    // C function void clearBufferfv  ( GLenum buffer, GLint drawbuffer, const GLfloat *value )
+
+    public void clearBufferfv(int buffer, int drawbuffer, java.nio.FloatBuffer value);
+
+    // C function void clearBufferfi  ( GLenum buffer, GLint drawbuffer, GLfloat depth, GLint stencil )
+
+    public void clearBufferfi(int buffer, int drawbuffer, float depth, int stencil);
+
+    // C function const ubyte * glGetStringi  ( GLenum name, GLuint index )
+
+    public String getStringi(int name, int index);
+
+    // C function void copyBufferSubData  ( GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset,
+// GLsizeiptr size )
+
+    public void copyBufferSubData(int readTarget, int writeTarget, int readOffset, int writeOffset, int size);
+
+// // C function void getUniformIndices  ( GLuint program, GLsizei uniformCount, const GLchar *const *uniformNames, GLuint
+// *uniformIndices )
+//
+// public void getUniformIndices (
+// int program,
+// String[] uniformNames,
+// int[] uniformIndices,
+// int uniformIndicesOffset
+// );
+
+    // C function void getUniformIndices  ( GLuint program, GLsizei uniformCount, const GLchar *const *uniformNames, GLuint
+// *uniformIndices )
+
+    public void getUniformIndices(int program, String[] uniformNames, java.nio.IntBuffer uniformIndices);
+
+// // C function void getActiveUniformsiv  ( GLuint program, GLsizei uniformCount, const GLuint *uniformIndices, GLenum pname,
+// GLint *params )
+//
+// public void getActiveUniformsiv (
+// int program,
+// int uniformCount,
+// int[] uniformIndices,
+// int uniformIndicesOffset,
+// int pname,
+// int[] params,
+// int paramsOffset
+// );
+
+    // C function void getActiveUniformsiv  ( GLuint program, GLsizei uniformCount, const GLuint *uniformIndices, GLenum pname,
+// GLint *params )
+
+    public void getActiveUniformsiv(int program, int uniformCount, java.nio.IntBuffer uniformIndices, int pname,
+                                    java.nio.IntBuffer params);
+
+    // C function uint glGetUniformBlockIndex  ( GLuint program, const GLchar *uniformBlockName )
+
+    public int getUniformBlockIndex(int program, String uniformBlockName);
+
+// // C function void getActiveUniformBlockiv  ( GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint *params )
+//
+// public void getActiveUniformBlockiv (
+// int program,
+// int uniformBlockIndex,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getActiveUniformBlockiv  ( GLuint program, GLuint uniformBlockIndex, GLenum pname, GLint *params )
+
+    public void getActiveUniformBlockiv(int program, int uniformBlockIndex, int pname, java.nio.IntBuffer params);
+
+// // C function void getActiveUniformBlockName  ( GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+// GLchar *uniformBlockName )
+//
+// public void getActiveUniformBlockName (
+// int program,
+// int uniformBlockIndex,
+// int bufSize,
+// int[] length,
+// int lengthOffset,
+// byte[] uniformBlockName,
+// int uniformBlockNameOffset
+// );
+
+    // C function void getActiveUniformBlockName  ( GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+// GLchar *uniformBlockName )
+
+    public void getActiveUniformBlockName(int program, int uniformBlockIndex, java.nio.Buffer length,
+                                          java.nio.Buffer uniformBlockName);
+
+    // C function void getActiveUniformBlockName  ( GLuint program, GLuint uniformBlockIndex, GLsizei bufSize, GLsizei *length,
+// GLchar *uniformBlockName )
+
+    public String getActiveUniformBlockName(int program, int uniformBlockIndex);
+
+    // C function void uniformBlockBinding  ( GLuint program, GLuint uniformBlockIndex, GLuint uniformBlockBinding )
+
+    public void uniformBlockBinding(int program, int uniformBlockIndex, int uniformBlockBinding);
+
+    // C function void drawArraysInstanced  ( GLenum mode, GLint first, GLsizei count, GLsizei instanceCount )
+
+    public void drawArraysInstanced(int mode, int first, int count, int instanceCount);
+
+// // C function void drawElementsInstanced  ( GLenum mode, GLsizei count, GLenum type, const GLvoid *indices, GLsizei
+// instanceCount )
+//
+// public void drawElementsInstanced (
+// int mode,
+// int count,
+// int type,
+// java.nio.Buffer indices,
+// int instanceCount
+// );
+
+    // C function void drawElementsInstanced  ( GLenum mode, GLsizei count, GLenum type, const GLvoid *indices, GLsizei
+// instanceCount )
+
+    public void drawElementsInstanced(int mode, int count, int type, int indicesOffset, int instanceCount);
+
+// // C function sync glFenceSync  ( GLenum condition, GLbitfield flags )
+//
+// public long fenceSync (
+// int condition,
+// int flags
+// );
+//
+// // C function boolean glIsSync  ( GLsync sync )
+//
+// public boolean isSync (
+// long sync
+// );
+//
+// // C function void deleteSync  ( GLsync sync )
+//
+// public void deleteSync (
+// long sync
+// );
+//
+// // C function enum glClientWaitSync  ( GLsync sync, GLbitfield flags, GLuint64 timeout )
+//
+// public int clientWaitSync (
+// long sync,
+// int flags,
+// long timeout
+// );
+//
+// // C function void waitSync  ( GLsync sync, GLbitfield flags, GLuint64 timeout )
+//
+// public void waitSync (
+// long sync,
+// int flags,
+// long timeout
+// );
+
+// // C function void getInteger64v  ( GLenum pname, GLint64 *params )
+//
+// public void getInteger64v (
+// int pname,
+// long[] params,
+// int offset
+// );
+
+    // C function void getInteger64v  ( GLenum pname, GLint64 *params )
+
+    public void getInteger64v(int pname, java.nio.LongBuffer params);
+
+// // C function void getSynciv  ( GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values )
+//
+// public void getSynciv (
+// long sync,
+// int pname,
+// int bufSize,
+// int[] length,
+// int lengthOffset,
+// int[] values,
+// int valuesOffset
+// );
+//
+// // C function void getSynciv  ( GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values )
+//
+// public void getSynciv (
+// long sync,
+// int pname,
+// int bufSize,
+// java.nio.IntBuffer length,
+// java.nio.IntBuffer values
+// );
+//
+// // C function void getInteger64i_v  ( GLenum target, GLuint index, GLint64 *data )
+//
+// public void getInteger64i_v (
+// int target,
+// int index,
+// long[] data,
+// int offset
+// );
+//
+// // C function void getInteger64i_v  ( GLenum target, GLuint index, GLint64 *data )
+//
+// public void getInteger64i_v (
+// int target,
+// int index,
+// java.nio.LongBuffer data
+// );
+//
+// // C function void getBufferParameteri64v  ( GLenum target, GLenum pname, GLint64 *params )
+//
+// public void getBufferParameteri64v (
+// int target,
+// int pname,
+// long[] params,
+// int offset
+// );
+
+    // C function void getBufferParameteri64v  ( GLenum target, GLenum pname, GLint64 *params )
+
+    public void getBufferParameteri64v(int target, int pname, java.nio.LongBuffer params);
+
+    // C function void genSamplers  ( GLsizei count, GLuint *samplers )
+
+    public void genSamplers(int count, int[] samplers, int offset);
+
+    // C function void genSamplers  ( GLsizei count, GLuint *samplers )
+
+    public void genSamplers(int count, java.nio.IntBuffer samplers);
+
+    // C function void deleteSamplers  ( GLsizei count, const GLuint *samplers )
+
+    public void deleteSamplers(int count, int[] samplers, int offset);
+
+    // C function void deleteSamplers  ( GLsizei count, const GLuint *samplers )
+
+    public void deleteSamplers(int count, java.nio.IntBuffer samplers);
+
+    // C function boolean glIsSampler  ( GLuint sampler )
+
+    public boolean isSampler(int sampler);
+
+    // C function void bindSampler  ( GLuint unit, GLuint sampler )
+
+    public void bindSampler(int unit, int sampler);
+
+    // C function void samplerParameteri  ( GLuint sampler, GLenum pname, GLint param )
+
+    public void samplerParameteri(int sampler, int pname, int param);
+
+// // C function void samplerParameteriv  ( GLuint sampler, GLenum pname, const GLint *param )
+//
+// public void samplerParameteriv (
+// int sampler,
+// int pname,
+// int[] param,
+// int offset
+// );
+
+    // C function void samplerParameteriv  ( GLuint sampler, GLenum pname, const GLint *param )
+
+    public void samplerParameteriv(int sampler, int pname, java.nio.IntBuffer param);
+
+    // C function void samplerParameterf  ( GLuint sampler, GLenum pname, GLfloat param )
+
+    public void samplerParameterf(int sampler, int pname, float param);
+
+// // C function void samplerParameterfv  ( GLuint sampler, GLenum pname, const GLfloat *param )
+//
+// public void samplerParameterfv (
+// int sampler,
+// int pname,
+// float[] param,
+// int offset
+// );
+
+    // C function void samplerParameterfv  ( GLuint sampler, GLenum pname, const GLfloat *param )
+
+    public void samplerParameterfv(int sampler, int pname, java.nio.FloatBuffer param);
+
+// // C function void getSamplerParameteriv  ( GLuint sampler, GLenum pname, GLint *params )
+//
+// public void getSamplerParameteriv (
+// int sampler,
+// int pname,
+// int[] params,
+// int offset
+// );
+
+    // C function void getSamplerParameteriv  ( GLuint sampler, GLenum pname, GLint *params )
+
+    public void getSamplerParameteriv(int sampler, int pname, java.nio.IntBuffer params);
+
+// // C function void getSamplerParameterfv  ( GLuint sampler, GLenum pname, GLfloat *params )
+//
+// public void getSamplerParameterfv (
+// int sampler,
+// int pname,
+// float[] params,
+// int offset
+// );
+
+    // C function void getSamplerParameterfv  ( GLuint sampler, GLenum pname, GLfloat *params )
+
+    public void getSamplerParameterfv(int sampler, int pname, java.nio.FloatBuffer params);
+
+    // C function void vertexAttribDivisor  ( GLuint index, GLuint divisor )
+
+    public void vertexAttribDivisor(int index, int divisor);
+
+    // C function void bindTransformFeedback  ( GLenum target, GLuint id )
+
+    public void bindTransformFeedback(int target, int id);
+
+    // C function void deleteTransformFeedbacks  ( GLsizei n, const GLuint *ids )
+
+    public void deleteTransformFeedbacks(int n, int[] ids, int offset);
+
+    // C function void deleteTransformFeedbacks  ( GLsizei n, const GLuint *ids )
+
+    public void deleteTransformFeedbacks(int n, java.nio.IntBuffer ids);
+
+    // C function void genTransformFeedbacks  ( GLsizei n, GLuint *ids )
+
+    public void genTransformFeedbacks(int n, int[] ids, int offset);
+
+    // C function void genTransformFeedbacks  ( GLsizei n, GLuint *ids )
+
+    public void genTransformFeedbacks(int n, java.nio.IntBuffer ids);
+
+    // C function boolean glIsTransformFeedback  ( GLuint id )
+
+    public boolean isTransformFeedback(int id);
+
+    // C function void pauseTransformFeedback  ( void )
+
+    public void pauseTransformFeedback();
+
+    // C function void resumeTransformFeedback  ( void )
+
+    public void resumeTransformFeedback();
+
+// // C function void getProgramBinary  ( GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat, GLvoid *binary
+// )
+//
+// public void getProgramBinary (
+// int program,
+// int bufSize,
+// int[] length,
+// int lengthOffset,
+// int[] binaryFormat,
+// int binaryFormatOffset,
+// java.nio.Buffer binary
+// );
+//
+// // C function void getProgramBinary  ( GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat, GLvoid *binary
+// )
+//
+// public void getProgramBinary (
+// int program,
+// int bufSize,
+// java.nio.IntBuffer length,
+// java.nio.IntBuffer binaryFormat,
+// java.nio.Buffer binary
+// );
+//
+// // C function void programBinary  ( GLuint program, GLenum binaryFormat, const GLvoid *binary, GLsizei length )
+//
+// public void programBinary (
+// int program,
+// int binaryFormat,
+// java.nio.Buffer binary,
+// int length
+// );
+
+    // C function void programParameteri  ( GLuint program, GLenum pname, GLint value )
+
+    public void programParameteri(int program, int pname, int value);
+
+// // C function void invalidateFramebuffer  ( GLenum target, GLsizei numAttachments, const GLenum *attachments )
+//
+// public void invalidateFramebuffer (
+// int target,
+// int numAttachments,
+// int[] attachments,
+// int offset
+// );
+
+    // C function void invalidateFramebuffer  ( GLenum target, GLsizei numAttachments, const GLenum *attachments )
+
+    public void invalidateFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments);
+
+// // C function void invalidateSubFramebuffer  ( GLenum target, GLsizei numAttachments, const GLenum *attachments, GLint x,
+// GLint y, GLsizei width, GLsizei height )
+//
+// public void invalidateSubFramebuffer (
+// int target,
+// int numAttachments,
+// int[] attachments,
+// int offset,
+// int x,
+// int y,
+// int width,
+// int height
+// );
+
+    // C function void invalidateSubFramebuffer  ( GLenum target, GLsizei numAttachments, const GLenum *attachments, GLint x,
+// GLint y, GLsizei width, GLsizei height )
+
+    public void invalidateSubFramebuffer(int target, int numAttachments, java.nio.IntBuffer attachments, int x, int y,
+                                         int width, int height);
+
+// // C function void texStorage2D  ( GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height )
+//
+// public void texStorage2D (
+// int target,
+// int levels,
+// int internalformat,
+// int width,
+// int height
+// );
+//
+// // C function void texStorage3D  ( GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height,
+// GLsizei depth )
+//
+// public void texStorage3D (
+// int target,
+// int levels,
+// int internalformat,
+// int width,
+// int height,
+// int depth
+// );
+//
+// // C function void getInternalformativ  ( GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint *params )
+//
+// public void getInternalformativ (
+// int target,
+// int internalformat,
+// int pname,
+// int bufSize,
+// int[] params,
+// int offset
+// );
+//
+// // C function void getInternalformativ  ( GLenum target, GLenum internalformat, GLenum pname, GLsizei bufSize, GLint *params )
+//
+// public void getInternalformativ (
+// int target,
+// int internalformat,
+// int pname,
+// int bufSize,
+// java.nio.IntBuffer params
+// );
+
+    @Override
+    @Deprecated
+    /**
+     * In Open core profiles  (3.1+), passing a pointer to client memory is not valid.
+     * Use the other version of this function instead, pass a zero-based offset which references
+     * the buffer currently bound to ARRAY_BUFFER.
+     */
+    void vertexAttribPointer(int indx, int size, int type, boolean normalized, int stride, Buffer ptr);
+}

--- a/vtm/src/org/oscim/backend/GLAdapter.java
+++ b/vtm/src/org/oscim/backend/GLAdapter.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -29,6 +29,7 @@ public class GLAdapter {
      * The instance provided by backend
      */
     public static GL gl;
+    public static GL30 gl30;
 
     public static boolean ANDROID_QUIRKS = false;
     public static boolean GDX_DESKTOP_QUIRKS = false;
@@ -45,8 +46,10 @@ public class GLAdapter {
      */
     public static boolean CIRCLE_QUADS = false;
 
-    public static void init(GL gl20) {
-        gl = gl20;
+    public static void init(GL gl) {
+        GLAdapter.gl = gl;
+        if (gl instanceof GL30)
+            GLAdapter.gl30 = (GL30) gl;
 
         ANDROID_QUIRKS = (CanvasAdapter.platform == Platform.ANDROID);
         GDX_DESKTOP_QUIRKS = CanvasAdapter.platform.isDesktop();
@@ -55,5 +58,9 @@ public class GLAdapter {
         // Buildings translucency does not work on macOS, see #61
         if (CanvasAdapter.platform == Platform.MACOS)
             BuildingLayer.TRANSLUCENT = false;
+    }
+
+    public static boolean isGL30() {
+        return gl30 != null;
     }
 }

--- a/vtm/src/org/oscim/renderer/GLUtils.java
+++ b/vtm/src/org/oscim/renderer/GLUtils.java
@@ -32,12 +32,24 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.oscim.backend.GLAdapter.gl;
+import static org.oscim.backend.GLAdapter.gl30;
 
 /**
  * Utility functions
  */
 public class GLUtils {
     static final Logger log = LoggerFactory.getLogger(GLUtils.class);
+
+    /**
+     * Set int color argb to uniform wxyz
+     */
+    public static void setColor(int location, int color) {
+        gl.uniform4f(location,
+                ((color >>> 16) & 0xff) / 255f,
+                ((color >>> 8) & 0xff) / 255f,
+                ((color >>> 0) & 0xff) / 255f,
+                ((color >>> 24) & 0xff) / 255f);
+    }
 
     public static void setColor(int location, int color, float alpha) {
         if (alpha >= 1)
@@ -316,6 +328,44 @@ public class GLUtils {
         gl.deleteBuffers(num, buf);
     }
 
+    public static int[] glGenFrameBuffers(int num) {
+        IntBuffer buf = MapRenderer.getIntBuffer(num);
+        buf.position(0);
+        buf.limit(num);
+        gl.genFramebuffers(num, buf);
+        int[] ret = new int[num];
+        buf.position(0);
+        buf.limit(num);
+        buf.get(ret);
+        return ret;
+    }
+
+    public static void glDeleteFrameBuffers(int num, int[] ids) {
+        IntBuffer buf = MapRenderer.getIntBuffer(num);
+        buf.put(ids, 0, num);
+        buf.flip();
+        gl.deleteFramebuffers(num, buf);
+    }
+
+    public static int[] glGenRenderBuffers(int num) {
+        IntBuffer buf = MapRenderer.getIntBuffer(num);
+        buf.position(0);
+        buf.limit(num);
+        gl.genRenderbuffers(num, buf);
+        int[] ret = new int[num];
+        buf.position(0);
+        buf.limit(num);
+        buf.get(ret);
+        return ret;
+    }
+
+    public static void glDeleteRenderBuffers(int num, int[] ids) {
+        IntBuffer buf = MapRenderer.getIntBuffer(num);
+        buf.put(ids, 0, num);
+        buf.flip();
+        gl.deleteRenderbuffers(num, buf);
+    }
+
     public static int[] glGenTextures(int num) {
         if (num <= 0)
             return null;
@@ -349,5 +399,20 @@ public class GLUtils {
         buf.put(ids, 0, num);
         buf.flip();
         gl.deleteTextures(num, buf);
+    }
+
+    /*=============    GL30    ================*/
+
+    /**
+     * Specifies a list of color buffers to be drawn into
+     *
+     * @param num    Specifies the number of buffers in bufs.
+     * @param glEnum Points to an array of symbolic constants specifying the buffers into which fragment colors or data values will be written.
+     */
+    public static void glDrawBuffers(int num, int[] glEnum) {
+        IntBuffer buf = MapRenderer.getIntBuffer(num);
+        buf.put(glEnum, 0, num);
+        buf.flip();
+        gl30.drawBuffers(num, buf);
     }
 }

--- a/vtm/src/org/oscim/renderer/OffscreenRenderer.java
+++ b/vtm/src/org/oscim/renderer/OffscreenRenderer.java
@@ -1,10 +1,25 @@
+/*
+ * Copyright 2014 Hannes Janetzek
+ * Copyright 2019 Gustl22
+ *
+ * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
+ *
+ * This program is free software: you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along with
+ * this program. If not, see <http://www.gnu.org/licenses/>.
+ */
 package org.oscim.renderer;
 
 import org.oscim.backend.GL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.IntBuffer;
 
 import static org.oscim.backend.GLAdapter.gl;
 
@@ -54,19 +69,11 @@ public class OffscreenRenderer extends LayerRenderer {
     }
 
     protected boolean setupFBO(GLViewport viewport) {
-        IntBuffer buf = MapRenderer.getIntBuffer(1);
-
         texW = (int) viewport.getWidth();
         texH = (int) viewport.getHeight();
 
-        gl.genFramebuffers(1, buf);
-        fb = buf.get(0);
-
-        buf.clear();
-        gl.genTextures(1, buf);
-        renderTex = buf.get(0);
-
-        GLUtils.checkGlError(getClass().getName() + ": 0");
+        fb = GLUtils.glGenFrameBuffers(1)[0];
+        renderTex = GLUtils.glGenTextures(1)[0];
 
         gl.bindFramebuffer(GL.FRAMEBUFFER, fb);
 
@@ -92,9 +99,7 @@ public class OffscreenRenderer extends LayerRenderer {
         GLUtils.checkGlError(getClass().getName() + ": 1");
 
         if (useDepthTexture) {
-            buf.clear();
-            gl.genTextures(1, buf);
-            renderDepth = buf.get(0);
+            renderDepth = GLUtils.glGenTextures(1)[0];
             gl.bindTexture(GL.TEXTURE_2D, renderDepth);
             GLUtils.setTextureParameter(GL.NEAREST,
                     GL.NEAREST,
@@ -112,9 +117,7 @@ public class OffscreenRenderer extends LayerRenderer {
                     GL.TEXTURE_2D,
                     renderDepth, 0);
         } else {
-            buf.clear();
-            gl.genRenderbuffers(1, buf);
-            int depthRenderbuffer = buf.get(0);
+            int depthRenderbuffer = GLUtils.glGenRenderBuffers(1)[0];
 
             gl.bindRenderbuffer(GL.RENDERBUFFER, depthRenderbuffer);
 


### PR DESCRIPTION
- `setColor` is necessary to pass shaders the raw color without multiplying the alpha value.
- the gen buffers methods slim the `Offscreenrenderer` and partially needed for shadow implementation. These methods are only called once and don't affect performance.
- `glDrawBuffers` specifies the drawn color buffers in GL30 implementation.