### PR TITLE
Gradle: remove redundant resources

### DIFF
--- a/jni/build.gradle
+++ b/jni/build.gradle
@@ -6,5 +6,4 @@ dependencies {
 
 sourceSets {
     main.java.srcDirs = ['src']
-    main.resources.srcDirs = ['src']
 }

--- a/vtm-android-example/build.gradle
+++ b/vtm-android-example/build.gradle
@@ -48,7 +48,6 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
             file("${rootDir}/vtm-android/natives").eachDir() { dir ->

--- a/vtm-android-gdx/build.gradle
+++ b/vtm-android-gdx/build.gradle
@@ -26,7 +26,6 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
         }
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')

--- a/vtm-android/build.gradle
+++ b/vtm-android/build.gradle
@@ -26,7 +26,6 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
         }
         debug.setRoot('build-types/debug')
         release.setRoot('build-types/release')

--- a/vtm-app/build.gradle
+++ b/vtm-app/build.gradle
@@ -28,7 +28,6 @@ android {
         main {
             manifest.srcFile 'AndroidManifest.xml'
             java.srcDirs = ['src']
-            resources.srcDirs = ['src']
             res.srcDirs = ['res']
             assets.srcDirs = ['assets']
             file("${rootDir}/vtm-android/natives").eachDir() { dir ->

--- a/vtm-extras/build.gradle
+++ b/vtm-extras/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
 sourceSets {
     main.java.srcDirs = ['src']
-    main.resources.srcDirs = ['src']
 }
 
 if (project.hasProperty("SONATYPE_USERNAME")) {

--- a/vtm-gdx/build.gradle
+++ b/vtm-gdx/build.gradle
@@ -9,7 +9,6 @@ dependencies {
 
 sourceSets {
     main.java.srcDirs = ['src']
-    main.resources.srcDirs = ['src']
 }
 
 if (project.hasProperty("SONATYPE_USERNAME")) {

--- a/vtm-jeo/build.gradle
+++ b/vtm-jeo/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
 sourceSets {
     main.java.srcDirs = ['src']
-    main.resources.srcDirs = ['src']
 }
 
 if (project.hasProperty("SONATYPE_USERNAME")) {


### PR DESCRIPTION
These modules don't have resources. And these declarations causes IDE to interpret them as resources although they're not.