### PR TITLE
Extend GLState: viewport, texture, framebuffer

### DIFF
--- a/vtm-playground/src/org/oscim/test/GdxSpriteBatchTest.java
+++ b/vtm-playground/src/org/oscim/test/GdxSpriteBatchTest.java
@@ -88,7 +88,7 @@ public class GdxSpriteBatchTest extends GdxMapApp {
 
         GLState.enableVertexArrays(GLState.DISABLED, GLState.DISABLED);
 
-        gl.viewport(0, 0, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        GLState.viewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
         gl.frontFace(GL.CW);
 
         mMapRenderer.onDrawFrame();

--- a/vtm-theme-comparator/src/org/oscim/theme/comparator/vtm/MapApplicationAdapter.java
+++ b/vtm-theme-comparator/src/org/oscim/theme/comparator/vtm/MapApplicationAdapter.java
@@ -31,6 +31,7 @@ import org.oscim.layers.tile.buildings.BuildingLayer;
 import org.oscim.layers.tile.vector.VectorTileLayer;
 import org.oscim.layers.tile.vector.labeling.LabelLayer;
 import org.oscim.map.Map;
+import org.oscim.renderer.GLState;
 import org.oscim.renderer.GLViewport;
 import org.oscim.renderer.MapRenderer;
 import org.oscim.scalebar.DefaultMapScaleBar;
@@ -164,7 +165,7 @@ public class MapApplicationAdapter extends ApplicationAdapter {
 
     @Override
     public void render() {
-        gl.viewport(0, 0, width, height);
+        GLState.viewport(width, height);
 
         try {
             mapRenderer.onDrawFrame();

--- a/vtm/src/org/oscim/renderer/GLState.java
+++ b/vtm/src/org/oscim/renderer/GLState.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -41,6 +41,10 @@ public class GLState {
     private static int glIndexBuffer;
 
     private static int currentTexId;
+    private static int currentFrameBufferId;
+
+    private static int viewportWidth;
+    private static int viewportHeight;
 
     static void init() {
         vertexArray[0] = false;
@@ -151,6 +155,15 @@ public class GLState {
         }
     }
 
+    public static void bindFramebuffer(int id) {
+        gl.bindFramebuffer(GL.FRAMEBUFFER, id);
+        currentFrameBufferId = id;
+    }
+
+    public static int getFramebuffer() {
+        return currentFrameBufferId;
+    }
+
     public static void bindTex2D(int id) {
         if (id < 0) {
             gl.bindTexture(GL.TEXTURE_2D, 0);
@@ -159,6 +172,10 @@ public class GLState {
             gl.bindTexture(GL.TEXTURE_2D, id);
             currentTexId = id;
         }
+    }
+
+    public static int getTexture() {
+        return currentTexId;
     }
 
     public static void setClearColor(float[] color) {
@@ -217,5 +234,19 @@ public class GLState {
         if (id >= 0)
             gl.bindBuffer(GL.ARRAY_BUFFER, id);
 
+    }
+
+    public static void viewport(int width, int height) {
+        gl.viewport(0, 0, width, height);
+        viewportWidth = width;
+        viewportHeight = height;
+    }
+
+    public static int getViewportWidth() {
+        return viewportWidth;
+    }
+
+    public static int getViewportHeight() {
+        return viewportHeight;
     }
 }

--- a/vtm/src/org/oscim/renderer/MapRenderer.java
+++ b/vtm/src/org/oscim/renderer/MapRenderer.java
@@ -172,7 +172,7 @@ public class MapRenderer {
         if (width <= 0 || height <= 0)
             return;
 
-        gl.viewport(0, 0, width, height);
+        GLState.viewport(width, height);
 
         //GL.scissor(0, 0, width, height);
         //GL.enable(GL20.SCISSOR_TEST);

--- a/vtm/src/org/oscim/renderer/OffscreenRenderer.java
+++ b/vtm/src/org/oscim/renderer/OffscreenRenderer.java
@@ -144,13 +144,13 @@ public class OffscreenRenderer extends LayerRenderer {
 
     public void enable(boolean on) {
         if (on)
-            gl.bindFramebuffer(GL.FRAMEBUFFER, fb);
+            GLState.bindFramebuffer(fb);
         else
-            gl.bindFramebuffer(GL.FRAMEBUFFER, 0);
+            GLState.bindFramebuffer(0);
     }
 
     public void begin() {
-        gl.bindFramebuffer(GL.FRAMEBUFFER, fb);
+        GLState.bindFramebuffer(fb);
         gl.depthMask(true);
         gl.clear(GL.DEPTH_BUFFER_BIT);
     }
@@ -192,15 +192,16 @@ public class OffscreenRenderer extends LayerRenderer {
 
     @Override
     public void render(GLViewport viewport) {
-        gl.bindFramebuffer(GL.FRAMEBUFFER, fb);
-        gl.viewport(0, 0, texW, texH);
+        int fbTmp = GLState.getFramebuffer();
+        GLState.bindFramebuffer(fb);
+        GLState.viewport(texW, texH);
         gl.depthMask(true);
         GLState.setClearColor(mClearColor);
         gl.clear(GL.DEPTH_BUFFER_BIT | GL.COLOR_BUFFER_BIT);
 
         mRenderer.render(viewport);
 
-        gl.bindFramebuffer(GL.FRAMEBUFFER, 0);
+        GLState.bindFramebuffer(fbTmp);
 
         mShader.useProgram();
 


### PR DESCRIPTION
In WebGL you aren't able to retrieve GL integers in trivial way such as viewport, texture, framebuffer. So I added the states to `GLState`. E.g. needed to store them during rendering shadows.