### PR TITLE
Sun: fix color update on init equal progress

### DIFF
--- a/vtm/src/org/oscim/renderer/light/Sun.java
+++ b/vtm/src/org/oscim/renderer/light/Sun.java
@@ -206,6 +206,11 @@ public class Sun {
                 progressEnd = progress;
         }
 
+        if (progressStart == progressEnd) {
+            mLightColor = mColorMap.get(progressStart);
+            return mLightColor;
+        }
+
         float fraction = ((mProgress + 2f - progressStart) % 2f) / ((progressEnd + 2f - progressStart) % 2f);
 
         int colorStart = mColorMap.get(progressStart);


### PR DESCRIPTION
In default color map the colors are initiated both with 0 which is the optimal value when progress is at 0. So it has a fraction of 0 / 0 = NaN.