### PR TITLE
Tag-transform: correct naming and transform direction

### DIFF
--- a/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
+++ b/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
@@ -17,6 +17,7 @@ import org.oscim.theme.styles.RenderStyle;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static java.lang.System.out;
@@ -257,7 +258,17 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
+    public List<String> retransformKey(String key) {
+        return null;
+    }
+
+    @Override
     public Tag transformTag(Tag tag) {
+        return null;
+    }
+
+    @Override
+    public List<Tag> retransformTag(Tag tag) {
         return null;
     }
 

--- a/vtm-playground/src/org/oscim/test/DebugTheme.java
+++ b/vtm-playground/src/org/oscim/test/DebugTheme.java
@@ -9,6 +9,8 @@ import org.oscim.theme.styles.AreaStyle;
 import org.oscim.theme.styles.LineStyle;
 import org.oscim.theme.styles.RenderStyle;
 
+import java.util.List;
+
 public class DebugTheme implements IRenderTheme {
 
     private static final LineStyle[] line = {new LineStyle(1, Color.MAGENTA, 2)};
@@ -53,7 +55,17 @@ public class DebugTheme implements IRenderTheme {
     }
 
     @Override
+    public List<String> retransformKey(String key) {
+        return null;
+    }
+
+    @Override
     public Tag transformTag(Tag tag) {
+        return null;
+    }
+
+    @Override
+    public List<Tag> retransformTag(Tag tag) {
         return null;
     }
 

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012 Hannes Janetzek
  * Copyright 2016 Andrey Novikov
- * Copyright 2017-2018 Gustl22
+ * Copyright 2017-2019 Gustl22
  * Copyright 2018 devemux86
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
@@ -20,6 +20,8 @@
 package org.oscim.core;
 
 import org.oscim.theme.IRenderTheme;
+
+import java.util.List;
 
 /**
  * The MapElement class is a reusable container for a geometry
@@ -66,8 +68,8 @@ public class MapElement extends GeometryBuffer {
      * @return height in meters, if present
      */
     public Float getHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKey(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
-        String v = tags.getValue(res != null ? res : Tag.KEY_HEIGHT);
+        List<String> res = theme != null ? theme.retransformKey(Tag.KEY_HEIGHT) : null;
+        String v = tags.getValue(res != null ? res.get(0) : Tag.KEY_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);
         return null;
@@ -77,8 +79,8 @@ public class MapElement extends GeometryBuffer {
      * @return minimum height in meters, if present
      */
     public Float getMinHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKey(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
-        String v = tags.getValue(res != null ? res : Tag.KEY_MIN_HEIGHT);
+        List<String> res = theme != null ? theme.retransformKey(Tag.KEY_MIN_HEIGHT) : null;
+        String v = tags.getValue(res != null ? res.get(0) : Tag.KEY_MIN_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);
         return null;

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -275,10 +275,29 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     protected String getKeyOrDefault(String key) {
         if (mRenderTheme == null)
             return key;
-        String res = mRenderTheme.transformKey(key);
-        return res != null ? res : key;
+        List<String> res = mRenderTheme.retransformKey(key);
+        return res != null ? res.get(0) : key;
     }
 
+    /**
+     * @param key the key to be retransformed.
+     * @return the transformed value of retransformed key.
+     */
+    protected String getTransformedValue(MapElement element, String key) {
+        if (mRenderTheme == null)
+            return element.tags.getValue(key);
+        key = getKeyOrDefault(key);
+        Tag res = mRenderTheme.transformTag(element.tags.get(key));
+        if (res == null) {
+            return element.tags.getValue(key);
+        }
+        return res.value;
+    }
+
+    /**
+     * @param key the key to be retransformed.
+     * @return the value of retransformed key.
+     */
     protected String getValue(MapElement element, String key) {
         return element.tags.getValue(getKeyOrDefault(key));
     }

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  * Copyright 2018-2019 devemux86
  *
  * This program is free software: you can redistribute it and/or modify it under the
@@ -158,9 +158,9 @@ public class S3DBLayer extends BuildingLayer {
         // Get building color
         Integer bColor = null;
         if (mColored) {
-            if ((v = getValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
+            if ((v = getTransformedValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
                 bColor = S3DBUtils.getColor(v, false, false);
-            } else if ((v = getValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
+            } else if ((v = getTransformedValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
                 bColor = S3DBUtils.getMaterialColor(v, false);
             }
         }
@@ -261,10 +261,10 @@ public class S3DBLayer extends BuildingLayer {
         String v;
 
         if (mColored) {
-            v = getValue(element, Tag.KEY_ROOF_COLOR);
+            v = getTransformedValue(element, Tag.KEY_ROOF_COLOR);
             if (v != null)
                 roofColor = S3DBUtils.getColor(v, true, false);
-            else if ((v = getValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
+            else if ((v = getTransformedValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
                 roofColor = S3DBUtils.getMaterialColor(v, true);
         }
 

--- a/vtm/src/org/oscim/theme/IRenderTheme.java
+++ b/vtm/src/org/oscim/theme/IRenderTheme.java
@@ -2,7 +2,7 @@
  * Copyright 2010, 2011, 2012 mapsforge.org
  * Copyright 2013 Hannes Janetzek
  * Copyright 2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -23,6 +23,8 @@ import org.oscim.core.GeometryBuffer.GeometryType;
 import org.oscim.core.Tag;
 import org.oscim.core.TagSet;
 import org.oscim.theme.styles.RenderStyle;
+
+import java.util.List;
 
 public interface IRenderTheme {
 
@@ -71,9 +73,19 @@ public interface IRenderTheme {
     String transformKey(String key);
 
     /**
+     * @return the retransformed tag keys of this RenderTheme.
+     */
+    List<String> retransformKey(String key);
+
+    /**
      * @return the transformed tag of this RenderTheme.
      */
     Tag transformTag(Tag tag);
+
+    /**
+     * @return the retransformed tags of this RenderTheme.
+     */
+    List<Tag> retransformTag(Tag tag);
 
     class ThemeException extends IllegalArgumentException {
         public ThemeException(String string) {

--- a/vtm/src/org/oscim/theme/RenderTheme.java
+++ b/vtm/src/org/oscim/theme/RenderTheme.java
@@ -2,7 +2,7 @@
  * Copyright 2014 Hannes Janetzek
  * Copyright 2017 Longri
  * Copyright 2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -26,6 +26,7 @@ import org.oscim.theme.rule.Rule;
 import org.oscim.theme.rule.Rule.Element;
 import org.oscim.theme.rule.Rule.RuleVisitor;
 import org.oscim.theme.styles.RenderStyle;
+import org.oscim.utils.ArrayUtils;
 import org.oscim.utils.LRUCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -299,9 +300,24 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
+    public List<String> retransformKey(String key) {
+        if (mTransformKeyMap != null)
+            return ArrayUtils.getKeysByValue(mTransformKeyMap, key);
+        return null;
+    }
+
+    @Override
     public Tag transformTag(Tag tag) {
         if (mTransformTagMap != null)
             return mTransformTagMap.get(tag);
+        return null;
+    }
+
+    @Override
+    public List<Tag> retransformTag(Tag tag) {
+        if (mTransformTagMap != null) {
+            return ArrayUtils.getKeysByValue(mTransformTagMap, tag);
+        }
         return null;
     }
 

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -4,7 +4,7 @@
  * Copyright 2016-2018 devemux86
  * Copyright 2016-2017 Longri
  * Copyright 2016 Andrey Novikov
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  * Copyright 2018 Izumi Kawashima
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
@@ -1299,9 +1299,9 @@ public class XmlThemeBuilder extends DefaultHandler {
         }
 
         if (v == null && matchValue == null) {
-            mTransformKeyMap.put(matchKey, k);
+            mTransformKeyMap.put(k, matchKey);
         } else {
-            mTransformTagMap.put(new Tag(matchKey, matchValue), new Tag(k, v));
+            mTransformTagMap.put(new Tag(k, v), new Tag(matchKey, matchValue));
         }
     }
 

--- a/vtm/src/org/oscim/utils/ArrayUtils.java
+++ b/vtm/src/org/oscim/utils/ArrayUtils.java
@@ -17,7 +17,30 @@
  */
 package org.oscim.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 public class ArrayUtils {
+
+    /**
+     * @return List with at least one element, else null
+     * TODO Improvable in Java 8
+     */
+    public static <K, V> List<K> getKeysByValue(Map<K, V> map, V value) {
+        List<K> keys = null;
+
+        if (map.containsValue(value)) {
+            keys = new ArrayList<>();
+
+            for (Map.Entry<K, V> entry : map.entrySet()) {
+                if (entry.getValue().equals(value)) {
+                    keys.add(entry.getKey());
+                }
+            }
+        }
+        return keys;
+    }
 
     public static <T> void reverse(T[] data) {
         reverse(data, 0, data.length);


### PR DESCRIPTION
the transform direction is named wrong.
- Tile source tags -> VTM tags (match): **transform**: _returns one value or null_
- VTM tags (match) -> tiles source tags: **retransform**: _returns list with at least one element or null_

Background is, that multiple tags can be transformed to one VTM tag (match), but not in the opposite direction.

Both directions are needed:
E.g. add following to `default.xml` so can try to transform colors, e.g. [here](https://overpass-turbo.eu/s/GsU).
```
<!--###### TAG TRANSFORM ######-->
    <tag-transform k="roof:colour" v="grey" k-match="roof:colour" v-match="#00ff00" />
    <tag-transform k="roof:colour" v="red" k-match="building:colour" v-match="#00ff00" />
    <tag-transform k="building:colour" v="white" k-match="building:colour" v-match="#ff0000" />
```
Can test it with `OverpassTest` as `Mapsforge maps` colors are already converted or use other tags there. Note: `setTheme` must be called before creation of `BuildingLayer` to take effect.