### PR TITLE
Tag transform improvements

### DIFF
--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -303,8 +303,8 @@
 
     <!-- tag-transform element -->
     <xs:complexType name="tag-transform">
-        <xs:attribute name="match-k" type="xs:string" use="required" />
-        <xs:attribute name="match-v" type="xs:string" use="optional" />
+        <xs:attribute name="k" type="xs:string" use="required" />
+        <xs:attribute name="v" type="xs:string" use="optional" />
         <xs:attribute name="output-k" type="xs:string" use="required" />
         <xs:attribute name="output-v" type="xs:string" use="optional" />
     </xs:complexType>

--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -305,8 +305,8 @@
     <xs:complexType name="tag-transform">
         <xs:attribute name="k" type="xs:string" use="required" />
         <xs:attribute name="v" type="xs:string" use="optional" />
-        <xs:attribute name="output-k" type="xs:string" use="required" />
-        <xs:attribute name="output-v" type="xs:string" use="optional" />
+        <xs:attribute name="k-internal" type="xs:string" use="required" />
+        <xs:attribute name="v-internal" type="xs:string" use="optional" />
     </xs:complexType>
 
     <!-- rendertheme element -->

--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -305,8 +305,8 @@
     <xs:complexType name="tag-transform">
         <xs:attribute name="k" type="xs:string" use="required" />
         <xs:attribute name="v" type="xs:string" use="optional" />
-        <xs:attribute name="k-internal" type="xs:string" use="required" />
-        <xs:attribute name="v-internal" type="xs:string" use="optional" />
+        <xs:attribute name="k-lib" type="xs:string" use="required" />
+        <xs:attribute name="v-lib" type="xs:string" use="optional" />
     </xs:complexType>
 
     <!-- rendertheme element -->

--- a/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
+++ b/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
@@ -252,12 +252,12 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String retransformKey(String key) {
+    public String transformKeyBackward(String key) {
         return null;
     }
 
     @Override
-    public Tag transformTag(Tag tag) {
+    public Tag transformTagForward(Tag tag) {
         return null;
     }
 

--- a/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
+++ b/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
@@ -252,7 +252,7 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKey(String key) {
+    public String retransformKey(String key) {
         return null;
     }
 

--- a/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
+++ b/vtm-jeo/src/org/oscim/theme/carto/RenderTheme.java
@@ -252,12 +252,22 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKeyBackward(String key) {
+    public String transformForwardKey(String key) {
         return null;
     }
 
     @Override
-    public Tag transformTagForward(Tag tag) {
+    public String transformBackwardKey(String key) {
+        return null;
+    }
+
+    @Override
+    public Tag transformForwardTag(Tag tag) {
+        return null;
+    }
+
+    @Override
+    public Tag transformBackwardTag(Tag tag) {
         return null;
     }
 

--- a/vtm-playground/src/org/oscim/test/DebugTheme.java
+++ b/vtm-playground/src/org/oscim/test/DebugTheme.java
@@ -48,7 +48,7 @@ public class DebugTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKey(String key) {
+    public String retransformKey(String key) {
         return null;
     }
 

--- a/vtm-playground/src/org/oscim/test/DebugTheme.java
+++ b/vtm-playground/src/org/oscim/test/DebugTheme.java
@@ -48,12 +48,22 @@ public class DebugTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKeyBackward(String key) {
+    public String transformForwardKey(String key) {
         return null;
     }
 
     @Override
-    public Tag transformTagForward(Tag tag) {
+    public String transformBackwardKey(String key) {
+        return null;
+    }
+
+    @Override
+    public Tag transformForwardTag(Tag tag) {
+        return null;
+    }
+
+    @Override
+    public Tag transformBackwardTag(Tag tag) {
         return null;
     }
 

--- a/vtm-playground/src/org/oscim/test/DebugTheme.java
+++ b/vtm-playground/src/org/oscim/test/DebugTheme.java
@@ -48,12 +48,12 @@ public class DebugTheme implements IRenderTheme {
     }
 
     @Override
-    public String retransformKey(String key) {
+    public String transformKeyBackward(String key) {
         return null;
     }
 
     @Override
-    public Tag transformTag(Tag tag) {
+    public Tag transformTagForward(Tag tag) {
         return null;
     }
 

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -3,16 +3,16 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <!--<tag-transform k="kind" v="building" k-internal="building" v-internal="yes" />-->
-    <!--<tag-transform k="kind" v="building_part" k-internal="building:part" v-internal="yes" />-->
-    <tag-transform k="root_id" k-internal="ref" />
+    <!--<tag-transform k="kind" v="building" k-lib="building" v-lib="yes" />-->
+    <!--<tag-transform k="kind" v="building_part" k-lib="building:part" v-lib="yes" />-->
+    <tag-transform k="root_id" k-lib="ref" />
 
-    <tag-transform k="roof_color" k-internal="roof:colour" />
-    <tag-transform k="roof_direction" k-internal="roof:direction" />
-    <tag-transform k="roof_height" k-internal="roof:height" />
-    <tag-transform k="roof_material" k-internal="roof:material" />
-    <tag-transform k="roof_orientation" k-internal="roof:orientation" />
-    <tag-transform k="roof_shape" k-internal="roof:shape" />
+    <tag-transform k="roof_color" k-lib="roof:colour" />
+    <tag-transform k="roof_direction" k-lib="roof:direction" />
+    <tag-transform k="roof_height" k-lib="roof:height" />
+    <tag-transform k="roof_material" k-lib="roof:material" />
+    <tag-transform k="roof_orientation" k-lib="roof:orientation" />
+    <tag-transform k="roof_shape" k-lib="roof:shape" />
 
     <!-- base style for fixed width lines -->
     <style-line cap="butt" fix="true" id="fix" width="1.0" />

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -3,16 +3,16 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <!--<tag-transform match-k="building" match-v="yes" output-k="kind" output-v="building" />-->
-    <!--<tag-transform match-k="building:part" match-v="yes" output-k="kind" output-v="building_part" />-->
-    <tag-transform match-k="ref" output-k="root_id" />
+    <!--<tag-transform k="kind" v="building" output-k="building" output-v="yes" />-->
+    <!--<tag-transform k="kind" v="building_part" output-k="building:part" output-v="yes" />-->
+    <tag-transform k="root_id" output-k="ref" />
 
-    <tag-transform match-k="roof:colour" output-k="roof_color" />
-    <tag-transform match-k="roof:direction" output-k="roof_direction" />
-    <tag-transform match-k="roof:height" output-k="roof_height" />
-    <tag-transform match-k="roof:material" output-k="roof_material" />
-    <tag-transform match-k="roof:orientation" output-k="roof_orientation" />
-    <tag-transform match-k="roof:shape" output-k="roof_shape" />
+    <tag-transform k="roof_color" output-k="roof:colour" />
+    <tag-transform k="roof_direction" output-k="roof:direction" />
+    <tag-transform k="roof_height" output-k="roof:height" />
+    <tag-transform k="roof_material" output-k="roof:material" />
+    <tag-transform k="roof_orientation" output-k="roof:orientation" />
+    <tag-transform k="roof_shape" output-k="roof:shape" />
 
     <!-- base style for fixed width lines -->
     <style-line cap="butt" fix="true" id="fix" width="1.0" />

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -3,16 +3,16 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <!--<tag-transform k="kind" v="building" output-k="building" output-v="yes" />-->
-    <!--<tag-transform k="kind" v="building_part" output-k="building:part" output-v="yes" />-->
-    <tag-transform k="root_id" output-k="ref" />
+    <!--<tag-transform k="kind" v="building" k-internal="building" v-internal="yes" />-->
+    <!--<tag-transform k="kind" v="building_part" k-internal="building:part" v-internal="yes" />-->
+    <tag-transform k="root_id" k-internal="ref" />
 
-    <tag-transform k="roof_color" output-k="roof:colour" />
-    <tag-transform k="roof_direction" output-k="roof:direction" />
-    <tag-transform k="roof_height" output-k="roof:height" />
-    <tag-transform k="roof_material" output-k="roof:material" />
-    <tag-transform k="roof_orientation" output-k="roof:orientation" />
-    <tag-transform k="roof_shape" output-k="roof:shape" />
+    <tag-transform k="roof_color" k-internal="roof:colour" />
+    <tag-transform k="roof_direction" k-internal="roof:direction" />
+    <tag-transform k="roof_height" k-internal="roof:height" />
+    <tag-transform k="roof_material" k-internal="roof:material" />
+    <tag-transform k="roof_orientation" k-internal="roof:orientation" />
+    <tag-transform k="roof_shape" k-internal="roof:shape" />
 
     <!-- base style for fixed width lines -->
     <style-line cap="butt" fix="true" id="fix" width="1.0" />

--- a/vtm-themes/resources/assets/vtm/openmaptiles.xml
+++ b/vtm-themes/resources/assets/vtm/openmaptiles.xml
@@ -3,10 +3,10 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <tag-transform k="render_height" output-k="height" />
-    <tag-transform k="render_min_height" output-k="min_height" />
-    <!--<tag-transform k="layer" v="building" output-k="building" output-v="yes" />-->
-    <!--<tag-transform k="layer" v="building:part" output-k="building:part" output-v="yes" />-->
+    <tag-transform k="render_height" k-internal="height" />
+    <tag-transform k="render_min_height" k-internal="min_height" />
+    <!--<tag-transform k="layer" v="building" k-internal="building" v-internal="yes" />-->
+    <!--<tag-transform k="layer" v="building:part" k-internal="building:part" v-internal="yes" />-->
 
     <!--###### TEXT styles ######-->
 

--- a/vtm-themes/resources/assets/vtm/openmaptiles.xml
+++ b/vtm-themes/resources/assets/vtm/openmaptiles.xml
@@ -3,10 +3,10 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <tag-transform match-k="height" output-k="render_height" />
-    <tag-transform match-k="min_height" output-k="render_min_height" />
-    <!--<tag-transform match-k="building" match-v="yes" output-k="layer" output-v="building" />-->
-    <!--<tag-transform match-k="building:part" match-v="yes" output-k="layer" output-v="building:part" />-->
+    <tag-transform k="render_height" output-k="height" />
+    <tag-transform k="render_min_height" output-k="min_height" />
+    <!--<tag-transform k="layer" v="building" output-k="building" output-v="yes" />-->
+    <!--<tag-transform k="layer" v="building:part" output-k="building:part" output-v="yes" />-->
 
     <!--###### TEXT styles ######-->
 

--- a/vtm-themes/resources/assets/vtm/openmaptiles.xml
+++ b/vtm-themes/resources/assets/vtm/openmaptiles.xml
@@ -3,10 +3,10 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
-    <tag-transform k="render_height" k-internal="height" />
-    <tag-transform k="render_min_height" k-internal="min_height" />
-    <!--<tag-transform k="layer" v="building" k-internal="building" v-internal="yes" />-->
-    <!--<tag-transform k="layer" v="building:part" k-internal="building:part" v-internal="yes" />-->
+    <tag-transform k="render_height" k-lib="height" />
+    <tag-transform k="render_min_height" k-lib="min_height" />
+    <!--<tag-transform k="layer" v="building" k-lib="building" v-lib="yes" />-->
+    <!--<tag-transform k="layer" v="building:part" k-lib="building:part" v-lib="yes" />-->
 
     <!--###### TEXT styles ######-->
 

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -66,7 +66,7 @@ public class MapElement extends GeometryBuffer {
      * @return height in meters, if present
      */
     public Float getHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.retransformKey(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
+        String res = theme != null ? theme.transformKeyBackward(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);
@@ -77,7 +77,7 @@ public class MapElement extends GeometryBuffer {
      * @return minimum height in meters, if present
      */
     public Float getMinHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.retransformKey(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
+        String res = theme != null ? theme.transformKeyBackward(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_MIN_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2012 Hannes Janetzek
  * Copyright 2016 Andrey Novikov
- * Copyright 2017-2018 Gustl22
+ * Copyright 2017-2019 Gustl22
  * Copyright 2018 devemux86
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
@@ -66,7 +66,7 @@ public class MapElement extends GeometryBuffer {
      * @return height in meters, if present
      */
     public Float getHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKey(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
+        String res = theme != null ? theme.retransformKey(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);
@@ -77,7 +77,7 @@ public class MapElement extends GeometryBuffer {
      * @return minimum height in meters, if present
      */
     public Float getMinHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKey(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
+        String res = theme != null ? theme.retransformKey(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_MIN_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);

--- a/vtm/src/org/oscim/core/MapElement.java
+++ b/vtm/src/org/oscim/core/MapElement.java
@@ -66,7 +66,7 @@ public class MapElement extends GeometryBuffer {
      * @return height in meters, if present
      */
     public Float getHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKeyBackward(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
+        String res = theme != null ? theme.transformBackwardKey(Tag.KEY_HEIGHT) : Tag.KEY_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);
@@ -77,7 +77,7 @@ public class MapElement extends GeometryBuffer {
      * @return minimum height in meters, if present
      */
     public Float getMinHeight(IRenderTheme theme) {
-        String res = theme != null ? theme.transformKeyBackward(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
+        String res = theme != null ? theme.transformBackwardKey(Tag.KEY_MIN_HEIGHT) : Tag.KEY_MIN_HEIGHT;
         String v = tags.getValue(res != null ? res : Tag.KEY_MIN_HEIGHT);
         if (v != null)
             return Float.parseFloat(v);

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -273,7 +273,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     protected String getKeyOrDefault(String key) {
         if (mTileLayer.getTheme() == null)
             return key;
-        String res = mTileLayer.getTheme().retransformKey(key);
+        String res = mTileLayer.getTheme().transformKeyBackward(key);
         return res != null ? res : key;
     }
 

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -273,7 +273,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     protected String getKeyOrDefault(String key) {
         if (mTileLayer.getTheme() == null)
             return key;
-        String res = mTileLayer.getTheme().transformKeyBackward(key);
+        String res = mTileLayer.getTheme().transformBackwardKey(key);
         return res != null ? res : key;
     }
 

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -273,7 +273,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     protected String getKeyOrDefault(String key) {
         if (mTileLayer.getTheme() == null)
             return key;
-        String res = mTileLayer.getTheme().transformKey(key);
+        String res = mTileLayer.getTheme().retransformKey(key);
         return res != null ? res : key;
     }
 

--- a/vtm/src/org/oscim/theme/IRenderTheme.java
+++ b/vtm/src/org/oscim/theme/IRenderTheme.java
@@ -66,14 +66,14 @@ public interface IRenderTheme {
     void scaleTextSize(float scaleFactor);
 
     /**
-     * @return the retransformed tag key of this RenderTheme.
+     * @return the backwards transformed tag key.
      */
-    String retransformKey(String key);
+    String transformKeyBackward(String key);
 
     /**
-     * @return the transformed tag of this RenderTheme.
+     * @return the forwards transformed tag of this RenderTheme.
      */
-    Tag transformTag(Tag tag);
+    Tag transformTagForward(Tag tag);
 
     class ThemeException extends IllegalArgumentException {
         public ThemeException(String string) {

--- a/vtm/src/org/oscim/theme/IRenderTheme.java
+++ b/vtm/src/org/oscim/theme/IRenderTheme.java
@@ -66,14 +66,35 @@ public interface IRenderTheme {
     void scaleTextSize(float scaleFactor);
 
     /**
-     * @return the backwards transformed tag key.
+     * Used to transform tile source key to internal key.
+     *
+     * @return the forwards transformed tag key.
      */
-    String transformKeyBackward(String key);
+    String transformForwardKey(String key);
 
     /**
+     * Used to transform internal key to tile source key.
+     * E.g. for lazy fetch needed tag values via tile source key.
+     * Only use when tile source key and internal key have a 1 to 1 relation.
+     *
+     * @return the backwards transformed tag key.
+     */
+    String transformBackwardKey(String key);
+
+    /**
+     * Used to transform tile source tag to internal tag.
+     *
      * @return the forwards transformed tag of this RenderTheme.
      */
-    Tag transformTagForward(Tag tag);
+    Tag transformForwardTag(Tag tag);
+
+    /**
+     * Used to transform internal tag to tile source tag.
+     * Only use when tile source tag and internal tag have a 1 to 1 relation.
+     *
+     * @return the forwards transformed tag of this RenderTheme.
+     */
+    Tag transformBackwardTag(Tag tag);
 
     class ThemeException extends IllegalArgumentException {
         public ThemeException(String string) {

--- a/vtm/src/org/oscim/theme/IRenderTheme.java
+++ b/vtm/src/org/oscim/theme/IRenderTheme.java
@@ -2,7 +2,7 @@
  * Copyright 2010, 2011, 2012 mapsforge.org
  * Copyright 2013 Hannes Janetzek
  * Copyright 2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -66,9 +66,9 @@ public interface IRenderTheme {
     void scaleTextSize(float scaleFactor);
 
     /**
-     * @return the transformed tag key of this RenderTheme.
+     * @return the retransformed tag key of this RenderTheme.
      */
-    String transformKey(String key);
+    String retransformKey(String key);
 
     /**
      * @return the transformed tag of this RenderTheme.

--- a/vtm/src/org/oscim/theme/RenderTheme.java
+++ b/vtm/src/org/oscim/theme/RenderTheme.java
@@ -48,8 +48,8 @@ public class RenderTheme implements IRenderTheme {
     private final Rule[] mRules;
     private final boolean mMapsforgeTheme;
 
-    private final Map<String, String> mRetransformKeyMap;
-    private final Map<Tag, Tag> mTransformTagMap;
+    private final Map<String, String> mTransformKeyBackwardMap;
+    private final Map<Tag, Tag> mTransformTagForwardMap;
 
     class RenderStyleCache {
         final int matchType;
@@ -106,8 +106,8 @@ public class RenderTheme implements IRenderTheme {
         mRules = rules;
         mMapsforgeTheme = mapsforgeTheme;
 
-        mRetransformKeyMap = ArrayUtils.swap(transformKeyMap);
-        mTransformTagMap = transformTagMap;
+        mTransformKeyBackwardMap = ArrayUtils.swap(transformKeyMap);
+        mTransformTagForwardMap = transformTagMap;
 
         mStyleCache = new RenderStyleCache[3];
         mStyleCache[0] = new RenderStyleCache(Element.NODE);
@@ -293,16 +293,16 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String retransformKey(String key) {
-        if (mRetransformKeyMap != null)
-            return mRetransformKeyMap.get(key);
+    public String transformKeyBackward(String key) {
+        if (mTransformKeyBackwardMap != null)
+            return mTransformKeyBackwardMap.get(key);
         return null;
     }
 
     @Override
-    public Tag transformTag(Tag tag) {
-        if (mTransformTagMap != null)
-            return mTransformTagMap.get(tag);
+    public Tag transformTagForward(Tag tag) {
+        if (mTransformTagForwardMap != null)
+            return mTransformTagForwardMap.get(tag);
         return null;
     }
 

--- a/vtm/src/org/oscim/theme/RenderTheme.java
+++ b/vtm/src/org/oscim/theme/RenderTheme.java
@@ -2,7 +2,7 @@
  * Copyright 2014 Hannes Janetzek
  * Copyright 2017 Longri
  * Copyright 2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -26,6 +26,7 @@ import org.oscim.theme.rule.Rule;
 import org.oscim.theme.rule.Rule.Element;
 import org.oscim.theme.rule.Rule.RuleVisitor;
 import org.oscim.theme.styles.RenderStyle;
+import org.oscim.utils.ArrayUtils;
 import org.oscim.utils.LRUCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +48,7 @@ public class RenderTheme implements IRenderTheme {
     private final Rule[] mRules;
     private final boolean mMapsforgeTheme;
 
-    private final Map<String, String> mTransformKeyMap;
+    private final Map<String, String> mRetransformKeyMap;
     private final Map<Tag, Tag> mTransformTagMap;
 
     class RenderStyleCache {
@@ -105,7 +106,7 @@ public class RenderTheme implements IRenderTheme {
         mRules = rules;
         mMapsforgeTheme = mapsforgeTheme;
 
-        mTransformKeyMap = transformKeyMap;
+        mRetransformKeyMap = ArrayUtils.swap(transformKeyMap);
         mTransformTagMap = transformTagMap;
 
         mStyleCache = new RenderStyleCache[3];
@@ -292,9 +293,9 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKey(String key) {
-        if (mTransformKeyMap != null)
-            return mTransformKeyMap.get(key);
+    public String retransformKey(String key) {
+        if (mRetransformKeyMap != null)
+            return mRetransformKeyMap.get(key);
         return null;
     }
 

--- a/vtm/src/org/oscim/theme/RenderTheme.java
+++ b/vtm/src/org/oscim/theme/RenderTheme.java
@@ -48,8 +48,10 @@ public class RenderTheme implements IRenderTheme {
     private final Rule[] mRules;
     private final boolean mMapsforgeTheme;
 
-    private final Map<String, String> mTransformKeyBackwardMap;
-    private final Map<Tag, Tag> mTransformTagForwardMap;
+    private final Map<String, String> mTransformForwardKeyMap;
+    private final Map<String, String> mTransformBackwardKeyMap;
+    private final Map<Tag, Tag> mTransformForwardTagMap;
+    private final Map<Tag, Tag> mTransformBackwardTagMap;
 
     class RenderStyleCache {
         final int matchType;
@@ -106,8 +108,10 @@ public class RenderTheme implements IRenderTheme {
         mRules = rules;
         mMapsforgeTheme = mapsforgeTheme;
 
-        mTransformKeyBackwardMap = ArrayUtils.swap(transformKeyMap);
-        mTransformTagForwardMap = transformTagMap;
+        mTransformForwardKeyMap = transformKeyMap;
+        mTransformBackwardKeyMap = ArrayUtils.swap(transformKeyMap);
+        mTransformForwardTagMap = transformTagMap;
+        mTransformBackwardTagMap = ArrayUtils.swap(transformTagMap);
 
         mStyleCache = new RenderStyleCache[3];
         mStyleCache[0] = new RenderStyleCache(Element.NODE);
@@ -293,16 +297,30 @@ public class RenderTheme implements IRenderTheme {
     }
 
     @Override
-    public String transformKeyBackward(String key) {
-        if (mTransformKeyBackwardMap != null)
-            return mTransformKeyBackwardMap.get(key);
+    public String transformForwardKey(String key) {
+        if (mTransformForwardKeyMap != null)
+            return mTransformForwardKeyMap.get(key);
         return null;
     }
 
     @Override
-    public Tag transformTagForward(Tag tag) {
-        if (mTransformTagForwardMap != null)
-            return mTransformTagForwardMap.get(tag);
+    public String transformBackwardKey(String key) {
+        if (mTransformBackwardKeyMap != null)
+            return mTransformBackwardKeyMap.get(key);
+        return null;
+    }
+
+    @Override
+    public Tag transformForwardTag(Tag tag) {
+        if (mTransformForwardTagMap != null)
+            return mTransformForwardTagMap.get(tag);
+        return null;
+    }
+
+    @Override
+    public Tag transformBackwardTag(Tag tag) {
+        if (mTransformBackwardTagMap != null)
+            return mTransformBackwardTagMap.get(tag);
         return null;
     }
 

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -1282,10 +1282,10 @@ public class XmlThemeBuilder extends DefaultHandler {
                 case "v":
                     matchValue = value;
                     break;
-                case "k-internal":
+                case "k-lib":
                     outputKey = value;
                     break;
-                case "v-internal":
+                case "v-lib":
                     outputValue = value;
                     break;
                 default:

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -1282,10 +1282,10 @@ public class XmlThemeBuilder extends DefaultHandler {
                 case "v":
                     matchValue = value;
                     break;
-                case "output-k":
+                case "k-internal":
                     outputKey = value;
                     break;
-                case "output-v":
+                case "v-internal":
                     outputValue = value;
                     break;
                 default:

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 devemux86
  * Copyright 2016-2017 Longri
  * Copyright 2016 Andrey Novikov
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  * Copyright 2018 Izumi Kawashima
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
@@ -1276,10 +1276,10 @@ public class XmlThemeBuilder extends DefaultHandler {
             String value = attributes.getValue(i);
 
             switch (name) {
-                case "match-k":
+                case "k":
                     matchKey = value;
                     break;
-                case "match-v":
+                case "v":
                     matchValue = value;
                     break;
                 case "output-k":

--- a/vtm/src/org/oscim/utils/ArrayUtils.java
+++ b/vtm/src/org/oscim/utils/ArrayUtils.java
@@ -196,6 +196,7 @@ public class ArrayUtils {
      * @return the HashMap with swapped keys and values
      */
     public static <K, V> HashMap<V, K> swap(Map<K, V> map) {
+        if (map == null) return null;
         HashMap<V, K> swap = new HashMap<>();
         for (Map.Entry<K, V> entry : map.entrySet())
             swap.put(entry.getValue(), entry.getKey());

--- a/vtm/src/org/oscim/utils/ArrayUtils.java
+++ b/vtm/src/org/oscim/utils/ArrayUtils.java
@@ -17,6 +17,9 @@
  */
 package org.oscim.utils;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public class ArrayUtils {
 
     public static <T> void reverse(T[] data) {
@@ -187,6 +190,16 @@ public class ArrayUtils {
         }
 
         return neg ? -val : val;
+    }
+
+    /**
+     * @return the HashMap with swapped keys and values
+     */
+    public static <K, V> HashMap<V, K> swap(Map<K, V> map) {
+        HashMap<V, K> swap = new HashMap<>();
+        for (Map.Entry<K, V> entry : map.entrySet())
+            swap.put(entry.getValue(), entry.getKey());
+        return swap;
     }
 
     public static boolean withinRange(float[] vec, float min, float max) {


### PR DESCRIPTION
- reverse `output-k`, `output-v` -> `k`, `v`
    `match-k` `match-v` -> `output-k`, `output-v`
- introduce `mRetransformKeyMap` (with swapped keys / values) in `RenderTheme` as replacement for `mTransformKeyMap`.
- refactor `transformKey` to `retransformKey`
- remain `transformTag`, as it will be usable in future use cases, e.g. transform colors.

Related #420.