### PR TITLE
BuildingLayer: tag-transform color values

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -289,14 +289,18 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
     protected String getTransformedValue(MapElement element, String key) {
         if (mTileLayer.getTheme() == null)
             return element.tags.getValue(key);
+        /* Get tile source key of specified lib key from theme or fall back to lib key */
         key = getKeyOrDefault(key);
-        Tag res = element.tags.get(key);
-        if (res == null) return null;
-        res = mTileLayer.getTheme().transformForwardTag(res);
-        if (res == null) {
-            return element.tags.getValue(key);
-        }
-        return res.value;
+        /* Get element tag with ts key, if existent */
+        Tag tsTag = element.tags.get(key);
+        if (tsTag == null)
+            return null;
+        /* transform ts tag to lib tag */
+        Tag libTag = mTileLayer.getTheme().transformForwardTag(tsTag);
+        if (libTag != null)
+            return libTag.value;
+        /* Use ts value, if transformation rule not exists */
+        return tsTag.value;
     }
 
     /**

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -270,6 +270,9 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
         return mExtrusionRenderer;
     }
 
+    /**
+     * @return the tile source tag key or library tag key as fallback
+     */
     protected String getKeyOrDefault(String key) {
         if (mTileLayer.getTheme() == null)
             return key;
@@ -277,6 +280,31 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
         return res != null ? res : key;
     }
 
+    /**
+     * Get the forward transformed value from tile source tag via the library tag key.
+     *
+     * @param key the library tag key
+     * @return the tile source tag value transformed to library tag value
+     */
+    protected String getTransformedValue(MapElement element, String key) {
+        if (mTileLayer.getTheme() == null)
+            return element.tags.getValue(key);
+        key = getKeyOrDefault(key);
+        Tag res = element.tags.get(key);
+        if (res == null) return null;
+        res = mTileLayer.getTheme().transformForwardTag(res);
+        if (res == null) {
+            return element.tags.getValue(key);
+        }
+        return res.value;
+    }
+
+    /**
+     * Get the tile source tag value via the library tag key.
+     *
+     * @param key the library tag key
+     * @return the tile source tag value of specified library tag key
+     */
     protected String getValue(MapElement element, String key) {
         return element.tags.getValue(getKeyOrDefault(key));
     }

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  * Copyright 2018-2019 devemux86
  *
  * This program is free software: you can redistribute it and/or modify it under the
@@ -158,9 +158,9 @@ public class S3DBLayer extends BuildingLayer {
         // Get building color
         Integer bColor = null;
         if (mColored) {
-            if ((v = getValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
+            if ((v = getTransformedValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
                 bColor = S3DBUtils.getColor(v, false, false);
-            } else if ((v = getValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
+            } else if ((v = getTransformedValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
                 bColor = S3DBUtils.getMaterialColor(v, false);
             }
         }
@@ -261,10 +261,10 @@ public class S3DBLayer extends BuildingLayer {
         String v;
 
         if (mColored) {
-            v = getValue(element, Tag.KEY_ROOF_COLOR);
+            v = getTransformedValue(element, Tag.KEY_ROOF_COLOR);
             if (v != null)
                 roofColor = S3DBUtils.getColor(v, true, false);
-            else if ((v = getValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
+            else if ((v = getTransformedValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
                 roofColor = S3DBUtils.getMaterialColor(v, true);
         }
 


### PR DESCRIPTION
Now can transform tag's color values in render themes with e.g.:
```
<tag-transform k="roof:colour" v="red" k-lib="roof:colour" v-lib="#00ff00"/>
```
For quick test use OverpassTest or mapsforge maps with strings as colors, or can transform hex colors, too.