### PR TITLE
Poi3D models: correct flip axis on loading

### DIFF
--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelLayer.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelLayer.java
@@ -106,9 +106,10 @@ public class GdxModelLayer extends Layer implements Map.UpdateListener {
                     model.nodes.removeIndex(0);
                     model.nodes.add(node);
                 }
-                node.scale.set(-1, 1, 1);
+                node.scale.set(1, 1, -1);
                 node.rotation.setFromAxis(1, 0, 0, 90);
             }
+            model.calculateTransforms();
             poiModel.setModel(model);
         }
 

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelLayer.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelLayer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014 Hannes Janetzek
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -106,6 +106,7 @@ public class GdxModelLayer extends Layer implements Map.UpdateListener {
                     model.nodes.removeIndex(0);
                     model.nodes.add(node);
                 }
+                node.scale.set(-1, 1, 1);
                 node.rotation.setFromAxis(1, 0, 0, 90);
             }
             poiModel.setModel(model);

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxRenderer3D2.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxRenderer3D2.java
@@ -116,8 +116,9 @@ public class GdxRenderer3D2 extends LayerRenderer {
         GLState.test(false, false);
         GLState.blend(false);
 
-        // GL.cullFace(GL20.BACK);
-        // GL.frontFace(GL20.CW);
+        //gl.cullFace(GL.BACK);
+        /* flip front face cause of mirror inverted y-axis */
+        gl.frontFace(GL.CCW);
 
         cam.update(v);
         long time = System.currentTimeMillis();
@@ -160,6 +161,7 @@ public class GdxRenderer3D2 extends LayerRenderer {
 
         // GLUtils.checkGlError("<" + TAG);
 
+        gl.frontFace(GL.CW);
         gl.depthMask(false);
         GLState.bindElementBuffer(GLState.UNBIND);
         GLState.bindBuffer(GL.ARRAY_BUFFER, GLState.UNBIND);

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/Poi3DLayer.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/Poi3DLayer.java
@@ -307,9 +307,10 @@ public class Poi3DLayer extends Layer implements Map.UpdateListener, ZoomLimiter
                         model.nodes.removeIndex(0);
                         model.nodes.add(node);
                     }
-                    node.scale.set(-1, 1, 1);
+                    node.scale.set(1, 1, -1);
                     node.rotation.setFromAxis(1, 0, 0, 90);
                 }
+                model.calculateTransforms();
                 holder.setModel(model);
             }
         }

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/Poi3DLayer.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/Poi3DLayer.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014 Hannes Janetzek
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License as published by the Free Software
@@ -307,6 +307,7 @@ public class Poi3DLayer extends Layer implements Map.UpdateListener, ZoomLimiter
                         model.nodes.removeIndex(0);
                         model.nodes.add(node);
                     }
+                    node.scale.set(-1, 1, 1);
                     node.rotation.setFromAxis(1, 0, 0, 90);
                 }
                 holder.setModel(model);


### PR DESCRIPTION
I think vtm library works mirror-inverted at y-axis. I notice this with geometry buffer, too. (In code is z-axis, but as model is rotated around x-axis, it's actually the y-axis)
Flip gl front face cause of mirrored model.
Fixes #686.