### PR TITLE
Make datetime rewritable

### DIFF
--- a/vtm-web-app/src/org/oscim/web/client/GwtMap.java
+++ b/vtm-web-app/src/org/oscim/web/client/GwtMap.java
@@ -24,6 +24,8 @@ import com.badlogic.gdx.backends.gwt.GwtApplication;
 import com.badlogic.gdx.backends.gwt.GwtGraphics;
 import com.badlogic.gdx.graphics.glutils.GLVersion;
 
+import com.badlogic.gdx.utils.Timer;
+import com.google.gwt.core.client.JsDate;
 import org.oscim.backend.AssetAdapter;
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.DateTimeAdapter;
@@ -61,6 +63,7 @@ class GwtMap extends GdxMap {
     BuildingSolutionControl mBuildingSolutionControl;
     CameraRollControl mCameraRollControl;
     SearchBox mSearchBox;
+    JsDate dateTime;
 
     @Override
     public void create() {
@@ -76,7 +79,10 @@ class GwtMap extends GdxMap {
 
         GwtGdxGraphics.init();
         GdxAssets.init("");
-        DateTimeAdapter.init(new GwtDateTime());
+        dateTime = JsDate.create();
+        final GwtDateTime gwtDateTime = new GwtDateTime();
+        gwtDateTime.setDate(dateTime);
+        DateTimeAdapter.init(gwtDateTime);
         CanvasAdapter.textScale = 0.7f;
         CanvasAdapter.dpi = (int) (GwtGraphics.getDevicePixelRatioJSNI() * CanvasAdapter.DEFAULT_DPI);
         Tile.SIZE = Tile.calculateTileSize();
@@ -154,7 +160,8 @@ class GwtMap extends GdxMap {
             boolean nobuildings = mapUrl.params.containsKey("nobuildings");
 
             if (!nobuildings && !s3db) {
-                mBuildingLayer = new BuildingLayer(mMap, l);
+                mBuildingLayer = new BuildingLayer(mMap, l, false, true);
+                mBuildingLayer.getExtrusionRenderer().enableCurrentSunPos(true);
                 mBuildingLayer.getExtrusionRenderer().setZLimit((float) 65536 / 10);
                 mMap.layers().add(mBuildingLayer);
             }
@@ -166,6 +173,16 @@ class GwtMap extends GdxMap {
         }
 
         mSearchBox = new SearchBox(mMap);
+
+        Timer timer = new Timer();
+        timer.scheduleTask(new Timer.Task() {
+            @Override
+            public void run() {
+                double t = dateTime.getTime();
+                dateTime.setTime(t + 600000); // 600000ms = 10 minutes
+                gwtDateTime.setDate(dateTime);
+            }
+        }, 0, 1);
     }
 
     @Override

--- a/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
+++ b/vtm-web/src/org/oscim/gdx/client/GwtDateTime.java
@@ -19,33 +19,40 @@ import com.google.gwt.core.client.JsDate;
 import org.oscim.backend.DateTimeAdapter;
 
 public class GwtDateTime extends DateTimeAdapter {
+    private JsDate date;
+
+    public GwtDateTime() {
+        date = JsDate.create();
+    }
+
+    public void setDate(JsDate date) {
+        this.date = date;
+    }
 
     @Override
     public int getHour() {
-        return JsDate.create().getHours();
+        return date.getHours();
     }
 
     @Override
     public int getMinute() {
-        return JsDate.create().getMinutes();
+        return date.getMinutes();
     }
 
     @Override
     public int getSecond() {
-        return JsDate.create().getSeconds();
+        return date.getSeconds();
     }
 
     @Override
     public int getDayOfYear() {
-        JsDate year = JsDate.create();
-        JsDate start = JsDate.create(year.getFullYear(), 0);
-        double diff = year.getTime() - start.getTime();
+        JsDate start = JsDate.create(date.getFullYear(), 0);
+        double diff = date.getTime() - start.getTime();
         return (int) (diff / (DateTimeAdapter.MILLIS_PER_DAY)) + 1;
     }
 
     @Override
     public int getTimeZoneOffset() {
-        JsDate date = JsDate.create();
         return -date.getTimezoneOffset() * 60 * 1000;
     }
 }

--- a/vtm/src/org/oscim/backend/DateTime.java
+++ b/vtm/src/org/oscim/backend/DateTime.java
@@ -17,30 +17,38 @@ package org.oscim.backend;
 import java.util.Calendar;
 
 public class DateTime extends DateTimeAdapter {
+    private Calendar cal;
+
+    public DateTime() {
+        cal = Calendar.getInstance();
+    }
+
+    public void setCalendar(Calendar cal) {
+        this.cal = cal;
+    }
 
     @Override
     public int getHour() {
-        return Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
+        return cal.get(Calendar.HOUR_OF_DAY);
     }
 
     @Override
     public int getMinute() {
-        return Calendar.getInstance().get(Calendar.MINUTE);
+        return cal.get(Calendar.MINUTE);
     }
 
     @Override
     public int getSecond() {
-        return Calendar.getInstance().get(Calendar.SECOND);
+        return cal.get(Calendar.SECOND);
     }
 
     @Override
     public int getDayOfYear() {
-        return Calendar.getInstance().get(Calendar.DAY_OF_YEAR);
+        return cal.get(Calendar.DAY_OF_YEAR);
     }
 
     @Override
     public int getTimeZoneOffset() {
-        Calendar calendar = Calendar.getInstance();
-        return calendar.getTimeZone().getOffset(calendar.getTimeInMillis());
+        return cal.getTimeZone().getOffset(cal.getTimeInMillis());
     }
 }


### PR DESCRIPTION
First of all, Gustl22's shadow expression is awesome. It's shadow is calculated based on sun's position, why can't the time be overwritten? Currently modified `vtm-web-app` to move "inner" time 10 minutes per second in real world.