### PR TITLE
S3DB: allow modify material colors from theme

### DIFF
--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -161,7 +161,7 @@ public class S3DBLayer extends BuildingLayer {
             if ((v = getTransformedValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
                 bColor = S3DBUtils.getColor(v, false, false);
             } else if ((v = getTransformedValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
-                bColor = S3DBUtils.getMaterialColor(v, false);
+                bColor = S3DBUtils.getMaterialColor(v);
             }
         }
 
@@ -265,7 +265,7 @@ public class S3DBLayer extends BuildingLayer {
             if (v != null)
                 roofColor = S3DBUtils.getColor(v, true, false);
             else if ((v = getTransformedValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
-                roofColor = S3DBUtils.getMaterialColor(v, true);
+                roofColor = S3DBUtils.getMaterialColor(v);
         }
 
         boolean roofOrientationAcross = false;

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -129,7 +129,7 @@ class S3DBTileLoader extends TileLoader {
         }
 
         if (c == 0 && element.tags.containsKey(OSCIM4_KEY_MATERIAL)) {
-            c = S3DBUtils.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL), isRoof);
+            c = S3DBUtils.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL));
         }
 
         if (c == 0) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -1251,15 +1251,14 @@ public final class S3DBUtils {
 
     /**
      * @param material the material as string (see http://wiki.openstreetmap.org/wiki/Key:material and following pages)
-     * @param roof     declare if material is used for roofs
      * @return the color as integer (8 bit each a, r, g, b)
      */
-    public static int getMaterialColor(String material, boolean roof) {
+    public static int getMaterialColor(String material) {
 
-        if (roof) {
-            if ("glass".equals(material))
-                return Color.fade(Color.get(130, 224, 255), 0.9f);
+        if (material.charAt(0) == '#') {
+            return Color.parseColor(material, Color.CYAN);
         }
+
         if ("roof_tiles".equals(material))
             return Color.get(216, 167, 111);
         if ("tile".equals(material))
@@ -1280,7 +1279,7 @@ public final class S3DBUtils {
         if ("asbestos".equals(material))
             return Color.get(160, 152, 141);
         if ("glass".equals(material))
-            return Color.get(130, 224, 255);
+            return Color.fade(Color.get(130, 224, 255), 0.4f);
         if ("slate".equals(material))
             return 0xFF605960;
         if ("zink".equals(material))


### PR DESCRIPTION
I removed `roof` indicator, cause with this PR materials can be converted via tag transform in themes e.g.:
```
<tag-transform k="building:material" k-lib="building:material" v="glass" v-lib="#11ff0000" />
<tag-transform k="roof:material" k-lib="roof:material" v="glass" v-lib="#1100ff00" />
```

Anyway the `glass` was the only material which has differed from building materials and only in alpha value, so can test them via `ExtrusionTest`, remove `KEY_ROOF_COLOR` and `KEY_BUILDING_COLOR` and add this to `mTags`:
```
new Tag(Tag.KEY_ROOF_MATERIAL, "glass"),
new Tag(Tag.KEY_BUILDING_MATERIAL, "glass")
```