### PR TITLE
S3DB: modify colors in theme

### DIFF
--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -3,6 +3,16 @@
     version="1" xmlns="http://opensciencemap.org/rendertheme"
     xsi:schemaLocation="http://opensciencemap.org/rendertheme https://raw.githubusercontent.com/mapsforge/vtm/master/resources/rendertheme.xsd">
 
+    <!--###### TRANSFORM tags ######-->
+    <tag-transform k="roof:colour" k-lib="roof:colour" v="blue" v-lib="#4e7ee0" />
+    <tag-transform k="roof:colour" k-lib="roof:colour" v="green" v-lib="#3ed889" />
+    <tag-transform k="roof:colour" k-lib="roof:colour" v="red" v-lib="#ad4340" />
+    <tag-transform k="roof:colour" k-lib="roof:colour" v="yellow" v-lib="#e5d522" />
+    <tag-transform k="building:colour" k-lib="building:colour" v="blue" v-lib="#416fcc" />
+    <tag-transform k="building:colour" k-lib="building:colour" v="green" v-lib="#38c459" />
+    <tag-transform k="building:colour" k-lib="building:colour" v="red" v-lib="#cc3733" />
+    <tag-transform k="building:colour" k-lib="building:colour" v="yellow" v-lib="#f4e216" />
+
     <!--###### TEXT styles ######-->
 
     <!--default label-->

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -159,7 +159,7 @@ public class S3DBLayer extends BuildingLayer {
         Integer bColor = null;
         if (mColored) {
             if ((v = getTransformedValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
-                bColor = S3DBUtils.getColor(v, false, false);
+                bColor = S3DBUtils.getColor(v, false);
             } else if ((v = getTransformedValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
                 bColor = S3DBUtils.getMaterialColor(v);
             }
@@ -263,7 +263,7 @@ public class S3DBLayer extends BuildingLayer {
         if (mColored) {
             v = getTransformedValue(element, Tag.KEY_ROOF_COLOR);
             if (v != null)
-                roofColor = S3DBUtils.getColor(v, true, false);
+                roofColor = S3DBUtils.getColor(v, false);
             else if ((v = getTransformedValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
                 roofColor = S3DBUtils.getMaterialColor(v);
         }

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -125,7 +125,7 @@ class S3DBTileLoader extends TileLoader {
 
         int c = 0;
         if (element.tags.containsKey(OSCIM4_KEY_COLOR)) {
-            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), isRoof, true);
+            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), true);
         }
 
         if (c == 0 && element.tags.containsKey(OSCIM4_KEY_MATERIAL)) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
- * Copyright 2017, 2018 Gustl22
+ * Copyright 2017-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -43,7 +43,7 @@ public final class S3DBUtils {
     private static final Logger log = LoggerFactory.getLogger(S3DBUtils.class);
 
     /* TODO get from theme */
-    private static final double HSV_S = 0.7;
+    private static final double HSV_S = 0.5;
     private static final double HSV_V = 1.2;
 
     // Toggle this to debug and improve ridge calculation, you can see the faults in map then.
@@ -1062,46 +1062,16 @@ public final class S3DBUtils {
 
     /**
      * @param color    the color as string (see http://wiki.openstreetmap.org/wiki/Key:colour)
-     * @param roof     declare if color is used for roofs
      * @param relative declare if colors are modified relative to their values
      * @return the color as integer (8 bit each a, r, g, b)
      */
-    public static int getColor(String color, boolean roof, boolean relative) {
+    public static int getColor(String color, boolean relative) {
 
         if (color.charAt(0) == '#') {
             int c = Color.parseColor(color, Color.CYAN);
             /* hardcoded colors are way too saturated for my taste */
-            return ColorUtil.modHsv(c, 1.0, 0.4, HSV_V, relative);
+            return ColorUtil.modHsv(c, 1.0, HSV_S, HSV_V, relative);
         }
-
-        if (roof) {
-            if ("brown".equals(color))
-                return Color.get(120, 110, 110);
-            if ("red".equals(color))
-                return Color.get(235, 140, 130);
-            if ("green".equals(color))
-                return Color.get(150, 200, 130);
-            if ("blue".equals(color))
-                return Color.get(100, 50, 200);
-        }
-        if ("white".equals(color))
-            return Color.get(240, 240, 240);
-        if ("black".equals(color))
-            return Color.get(86, 86, 86);
-        if ("grey".equals(color) || "gray".equals(color))
-            return Color.get(120, 120, 120);
-        if ("red".equals(color))
-            return Color.get(255, 190, 190);
-        if ("green".equals(color))
-            return Color.get(190, 255, 190);
-        if ("blue".equals(color))
-            return Color.get(190, 190, 255);
-        if ("yellow".equals(color))
-            return Color.get(255, 255, 175);
-        if ("darkgray".equals(color) || "darkgrey".equals(color))
-            return Color.DKGRAY;
-        if ("lightgray".equals(color) || "lightgrey".equals(color))
-            return Color.LTGRAY;
 
         if ("transparent".equals(color))
             return Color.get(0, 1, 1, 1);


### PR DESCRIPTION
Can test again in `ExtrusionTest`. To see real colors you have to modify `S3DBUtils`:
```
private static final double HSV_S = 1.0;
private static final double HSV_V = 1.0;
```

We can consider to use this tag transform in other themes, too. But there's always the fall back to css colors already and they are desatured anyway.