### PR TITLE
Render themes: allow HSV colors for S3DB

### DIFF
--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -245,6 +245,9 @@
         <xs:attribute name="line-color" type="tns:color" use="optional" />
         <xs:attribute name="side-color" type="tns:color" use="required" />
         <xs:attribute name="top-color" type="tns:color" use="required" />
+        <xs:attribute name="hsv-h" default="0" type="xs:double" use="optional" />
+        <xs:attribute name="hsv-s" default="1" type="xs:double" use="optional" />
+        <xs:attribute name="hsv-v" default="1" type="xs:double" use="optional" />
         <!-- 12m default -->
         <xs:attribute name="default-height" default="12" type="xs:positiveInteger" use="optional" />
     </xs:complexType>

--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -647,7 +647,8 @@
                 </m>
             </m>
             <m zoom-min="17">
-                <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6" />
+                <extrusion line-color="#ffd9d8d6" side-color="#eaecebe9" top-color="#eaf9f8f6"
+                    hsv-s="0.5" hsv-v="1.2" />
             </m>
             <!--Only add house numbers where no name exist-->
             <m k="addr:housenumber" zoom-min="18">

--- a/vtm-themes/resources/assets/vtm/newtron.xml
+++ b/vtm-themes/resources/assets/vtm/newtron.xml
@@ -569,7 +569,8 @@
                   <area fill="#e9e6e3" fade="15" /> -->
             </m>
             <m zoom-min="17">
-                <extrusion line-color="#50606060" side-color="#ea404040" top-color="#ea404040" />
+                <extrusion line-color="#50606060" side-color="#ea404040" top-color="#ea404040"
+                    hsv-s="0.1" hsv-v="0.5" />
             </m>
 
             <!--Only add house numbers where no name exist-->

--- a/vtm-themes/resources/assets/vtm/osmagray.xml
+++ b/vtm-themes/resources/assets/vtm/osmagray.xml
@@ -560,7 +560,8 @@
             </m>
 
             <m zoom-min="17">
-                <extrusion line-color="#50616161" side-color="#ead9d9d9" top-color="#eadddddd" />
+                <extrusion line-color="#50616161" side-color="#ead9d9d9" top-color="#eadddddd"
+                    hsv-s="0" hsv-v="1.4" />
             </m>
 
             <!--Only add house numbers where no name exist-->

--- a/vtm-themes/resources/assets/vtm/osmarender.xml
+++ b/vtm-themes/resources/assets/vtm/osmarender.xml
@@ -560,7 +560,8 @@
             </m>
 
             <m zoom-min="17">
-                <extrusion line-color="#506a5a8e" side-color="#eaf3d6b6" top-color="#eaf8d9b9" />
+                <extrusion line-color="#506a5a8e" side-color="#eaf3d6b6" top-color="#eaf8d9b9"
+                    hsv-s="0.2" hsv-v="1.4" />
             </m>
 
             <!--Only add house numbers where no name exist-->

--- a/vtm-themes/resources/assets/vtm/tronrender.xml
+++ b/vtm-themes/resources/assets/vtm/tronrender.xml
@@ -569,7 +569,8 @@
                   <area fill="#e9e6e3" fade="15" /> -->
             </m>
             <m zoom-min="17">
-                <extrusion line-color="#50808080" side-color="#ea606060" top-color="#ea606060" />
+                <extrusion line-color="#50808080" side-color="#ea606060" top-color="#ea606060"
+                    hsv-s="0.5" hsv-v="0.8" />
             </m>
 
             <!--Only add house numbers where no name exist-->

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -159,9 +159,9 @@ public class S3DBLayer extends BuildingLayer {
         Integer bColor = null;
         if (mColored) {
             if ((v = getTransformedValue(element, Tag.KEY_BUILDING_COLOR)) != null) {
-                bColor = S3DBUtils.getColor(v, false);
+                bColor = S3DBUtils.getColor(v, extrusion.hsv, false);
             } else if ((v = getTransformedValue(element, Tag.KEY_BUILDING_MATERIAL)) != null) {
-                bColor = S3DBUtils.getMaterialColor(v);
+                bColor = S3DBUtils.getMaterialColor(v, extrusion.hsv, false);
             }
         }
 
@@ -179,7 +179,7 @@ public class S3DBLayer extends BuildingLayer {
         float minRoofHeightS = ExtrusionUtils.mapGroundScale(maxHeight - roofHeight, groundScale) * TILE_SCALE;
 
         // Process building and roof
-        processRoof(element, tile, minRoofHeightS, maxHeightS, bColor, extrusion.colorTop);
+        processRoof(element, tile, minRoofHeightS, maxHeightS, bColor, extrusion);
         if (S3DBUtils.calcOutlines(element, minHeightS, minRoofHeightS)) {
             get(tile).addMeshElement(element, groundScale, bColor);
         }
@@ -253,19 +253,19 @@ public class S3DBLayer extends BuildingLayer {
      * @param minHeight        the height of the underlying building
      * @param maxHeight        the height of the roof + minHeight (whole building)
      * @param buildingColor    the color of main building
-     * @param defaultRoofColor the default color of roof
+     * @param extrusion        the extrusion style
      */
     private void processRoof(MapElement element, MapTile tile, float minHeight, float maxHeight,
-                             int buildingColor, int defaultRoofColor) {
-        int roofColor = defaultRoofColor;
+                             int buildingColor, ExtrusionStyle extrusion) {
+        int roofColor = extrusion.colorTop;
         String v;
 
         if (mColored) {
             v = getTransformedValue(element, Tag.KEY_ROOF_COLOR);
             if (v != null)
-                roofColor = S3DBUtils.getColor(v, false);
+                roofColor = S3DBUtils.getColor(v, extrusion.hsv, false);
             else if ((v = getTransformedValue(element, Tag.KEY_ROOF_MATERIAL)) != null)
-                roofColor = S3DBUtils.getMaterialColor(v);
+                roofColor = S3DBUtils.getMaterialColor(v, extrusion.hsv, false);
         }
 
         boolean roofOrientationAcross = false;
@@ -288,7 +288,7 @@ public class S3DBLayer extends BuildingLayer {
 
         if (mTransparent) {
             // Use transparency of default roof color
-            roofColor = ExtrusionStyle.blendAlpha(roofColor, Color.aToFloat(defaultRoofColor));
+            roofColor = ExtrusionStyle.blendAlpha(roofColor, Color.aToFloat(extrusion.colorTop));
         }
 
         boolean success;

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBTileLoader.java
@@ -38,6 +38,8 @@ class S3DBTileLoader extends TileLoader {
     private static final String OSCIM4_KEY_COLOR = "c";
     private static final String OSCIM4_KEY_MATERIAL = "m";
 
+    private static final Color.HSV HSV = new Color.HSV(0f, 0.5f, 1.2f);
+
     /**
      * current TileDataSource used by this MapTileLoader
      */
@@ -125,11 +127,11 @@ class S3DBTileLoader extends TileLoader {
 
         int c = 0;
         if (element.tags.containsKey(OSCIM4_KEY_COLOR)) {
-            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), true);
+            c = S3DBUtils.getColor(element.tags.getValue(OSCIM4_KEY_COLOR), HSV, true);
         }
 
         if (c == 0 && element.tags.containsKey(OSCIM4_KEY_MATERIAL)) {
-            c = S3DBUtils.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL));
+            c = S3DBUtils.getMaterialColor(element.tags.getValue(OSCIM4_KEY_MATERIAL), HSV, true);
         }
 
         if (c == 0) {

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -20,7 +20,6 @@ package org.oscim.layers.tile.buildings;
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeometryBuffer;
 import org.oscim.core.Tag;
-import org.oscim.utils.ColorUtil;
 import org.oscim.utils.ColorsCSS;
 import org.oscim.utils.Tessellator;
 import org.oscim.utils.geom.GeometryUtils;
@@ -41,10 +40,6 @@ import java.util.TreeMap;
  */
 public final class S3DBUtils {
     private static final Logger log = LoggerFactory.getLogger(S3DBUtils.class);
-
-    /* TODO get from theme */
-    private static final double HSV_S = 0.5;
-    private static final double HSV_V = 1.2;
 
     // Toggle this to debug and improve ridge calculation, you can see the faults in map then.
     private static final boolean IMPROVE_RIDGE_CALCULATION = false;
@@ -1062,27 +1057,28 @@ public final class S3DBUtils {
 
     /**
      * @param color    the color as string (see http://wiki.openstreetmap.org/wiki/Key:colour)
+     * @param hsv      the hsv color to modify given color
      * @param relative declare if colors are modified relative to their values
      * @return the color as integer (8 bit each a, r, g, b)
      */
-    public static int getColor(String color, boolean relative) {
+    public static int getColor(String color, Color.HSV hsv, boolean relative) {
 
+        int c;
         if (color.charAt(0) == '#') {
-            int c = Color.parseColor(color, Color.CYAN);
-            /* hardcoded colors are way too saturated for my taste */
-            return ColorUtil.modHsv(c, 1.0, HSV_S, HSV_V, relative);
+            c = Color.parseColor(color, Color.CYAN);
+        } else if ("transparent".equals(color)) {
+            return Color.get(0, 1, 1, 1);
+        } else {
+            Integer css = ColorsCSS.get(color);
+            if (css == null) {
+                log.debug("unknown color:{}", color);
+                c = Color.CYAN;
+            } else {
+                c = css;
+            }
         }
 
-        if ("transparent".equals(color))
-            return Color.get(0, 1, 1, 1);
-
-        Integer css = ColorsCSS.get(color);
-
-        if (css != null)
-            return ColorUtil.modHsv(css, 1.0, HSV_S, HSV_V, relative);
-
-        log.debug("unknown color:{}", color);
-        return 0;
+        return hsv.mod(c, relative);
     }
 
     /**
@@ -1221,9 +1217,10 @@ public final class S3DBUtils {
 
     /**
      * @param material the material as string (see http://wiki.openstreetmap.org/wiki/Key:material and following pages)
+     * @param hsv      the hsv color to modify given material
      * @return the color as integer (8 bit each a, r, g, b)
      */
-    public static int getMaterialColor(String material) {
+    public static int getMaterialColor(String material, Color.HSV hsv, boolean relative) {
 
         int c;
         if (material.charAt(0) == '#') {
@@ -1295,12 +1292,11 @@ public final class S3DBUtils {
                 default:
                     c = Color.CYAN;
                     log.debug("unknown material:{}", material);
+                    break;
             }
         }
 
-        // TODO option to mod color c with hsv
-
-        return c;
+        return hsv.mod(c, relative);
     }
 
     /**

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -1226,6 +1226,15 @@ public class XmlThemeBuilder extends DefaultHandler {
             else if ("default-height".equals(name))
                 b.defaultHeight(Integer.parseInt(value));
 
+            else if ("hsv-h".equals(name))
+                b.hsvHue(Double.parseDouble(value));
+
+            else if ("hsv-s".equals(name))
+                b.hsvSaturation(Double.parseDouble(value));
+
+            else if ("hsv-v".equals(name))
+                b.hsvValue(Double.parseDouble(value));
+
             else
                 logUnknownAttribute(elementName, name, value, i);
         }

--- a/vtm/src/org/oscim/theme/styles/ExtrusionStyle.java
+++ b/vtm/src/org/oscim/theme/styles/ExtrusionStyle.java
@@ -1,7 +1,7 @@
 /*
  * Copyright 2013 Hannes Janetzek
  * Copyright 2016-2017 devemux86
- * Copyright 2018 Gustl22
+ * Copyright 2018-2019 Gustl22
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -27,12 +27,13 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
     public final int colorLine;
     public final int colorSide;
     public final int colorTop;
+    public final Color.HSV hsv;
     public final int defaultHeight;
     private final int level;
 
     public final float[] colors;
 
-    public ExtrusionStyle(int level, int colorSide, int colorTop, int colorLine, int defaultHeight) {
+    public ExtrusionStyle(int level, int colorSide, int colorTop, int colorLine, float hsvHue, float hsvSaturation, float hsvValue, int defaultHeight) {
         this.level = level;
 
         this.colorSide = colorSide;
@@ -41,6 +42,7 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
         this.colors = new float[16];
         fillColors(colorSide, colorTop, colorLine, colors);
 
+        this.hsv = new Color.HSV(hsvHue, hsvSaturation, hsvValue);
         this.defaultHeight = defaultHeight;
     }
 
@@ -54,6 +56,7 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
         this.colors = new float[16];
         fillColors(colorSide, colorTop, colorLine, colors);
 
+        this.hsv = new Color.HSV(b.hsvHue, b.hsvSaturation, b.hsvValue);
         this.defaultHeight = b.defaultHeight;
     }
 
@@ -112,6 +115,9 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
         public int colorSide;
         public int colorTop;
         public int colorLine;
+        public double hsvHue;
+        public double hsvSaturation;
+        public double hsvValue;
         public int defaultHeight;
 
         public ExtrusionBuilder() {
@@ -126,6 +132,9 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
             this.colorSide = themeCallback != null ? themeCallback.getColor(extrusion.colorSide) : extrusion.colorSide;
             this.colorTop = themeCallback != null ? themeCallback.getColor(extrusion.colorTop) : extrusion.colorTop;
             this.colorLine = themeCallback != null ? themeCallback.getColor(extrusion.colorLine) : extrusion.colorLine;
+            this.hsvHue = extrusion.hsv.hue;
+            this.hsvSaturation = extrusion.hsv.saturation;
+            this.hsvValue = extrusion.hsv.value;
             this.defaultHeight = extrusion.defaultHeight;
 
             return self();
@@ -161,6 +170,21 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
             return self();
         }
 
+        public T hsvHue(double hsvHue) {
+            this.hsvHue = hsvHue;
+            return self();
+        }
+
+        public T hsvSaturation(double hsvSaturation) {
+            this.hsvSaturation = hsvSaturation;
+            return self();
+        }
+
+        public T hsvValue(double hsvValue) {
+            this.hsvValue = hsvValue;
+            return self();
+        }
+
         public T defaultHeight(int defaultHeight) {
             this.defaultHeight = defaultHeight;
             return self();
@@ -172,6 +196,9 @@ public class ExtrusionStyle extends RenderStyle<ExtrusionStyle> {
             colorSide = Color.TRANSPARENT;
             colorTop = Color.TRANSPARENT;
             colorLine = Color.TRANSPARENT;
+            hsvHue = 0;
+            hsvSaturation = 1;
+            hsvValue = 1;
             defaultHeight = 12; // 12m default
             return self();
         }


### PR DESCRIPTION
Now can modify building colors/materials via hsv in render themes.