### PR TITLE
Point buffer: distinguish points and point coordinates

### DIFF
--- a/vtm-extras/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
+++ b/vtm-extras/src/org/oscim/tiling/source/geojson/GeoJsonTileDecoder.java
@@ -259,18 +259,13 @@ public class GeoJsonTileDecoder implements ITileDecoder {
 
                 ring++;
                 parseCoordSequence(jp);
-                removeLastPoint();
+                mMapElement.removeLastPoint();
                 continue;
             }
 
             if (t == END_ARRAY)
                 break;
         }
-    }
-
-    private void removeLastPoint() {
-        mMapElement.pointNextPos -= 2;
-        mMapElement.index[mMapElement.indexCurrentPos] -= 2;
     }
 
     private void parseLineString(JsonParser jp)

--- a/vtm-extras/src/org/oscim/tiling/source/mapnik/TileDecoder.java
+++ b/vtm-extras/src/org/oscim/tiling/source/mapnik/TileDecoder.java
@@ -484,8 +484,8 @@ public class TileDecoder extends PbfDecoder {
 
                 // only add last point if it is di
                 int ppos = cnt * 2;
-                if (elem.points[elem.pointNextPos - ppos] != curX
-                        || elem.points[elem.pointNextPos - ppos + 1] != curY)
+                if (elem.points[elem.getNumCoords() - ppos] != curX
+                        || elem.points[elem.getNumCoords() - ppos + 1] != curY)
                     elem.addPoint(curX / mScale, curY / mScale);
 
                 lastClip = false;
@@ -525,7 +525,7 @@ public class TileDecoder extends PbfDecoder {
         if (isPoly && isOuter && simplify && !testBBox(xmax - xmin, ymax - ymin)) {
             //log.debug("skip small poly "+ elem.indexPos + " > "
             // +  (xmax - xmin) * (ymax - ymin));
-            elem.pointNextPos -= elem.index[elem.indexCurrentPos];
+            elem.setNumCoords(elem.getNumCoords() - elem.index[elem.indexCurrentPos]);
             if (elem.indexCurrentPos > 0) {
                 elem.indexCurrentPos -= 2;
                 elem.index[elem.indexCurrentPos + 1] = -1;

--- a/vtm-extras/src/org/oscim/tiling/source/overpass/OverpassTileDecoder.java
+++ b/vtm-extras/src/org/oscim/tiling/source/overpass/OverpassTileDecoder.java
@@ -127,13 +127,8 @@ public class OverpassTileDecoder implements ITileDecoder {
 
         //ring++;
         parseCoordSequence(element);
-        removeLastPoint();
+        mMapElement.removeLastPoint();
         //}
-    }
-
-    private void removeLastPoint() {
-        mMapElement.pointNextPos -= 2;
-        mMapElement.index[mMapElement.indexCurrentPos] -= 2;
     }
 
     private void parseLine(OsmWay element) {

--- a/vtm-json/src/org/oscim/tiling/source/geojson/TileDecoder.java
+++ b/vtm-json/src/org/oscim/tiling/source/geojson/TileDecoder.java
@@ -256,18 +256,13 @@ public class TileDecoder implements ITileDecoder {
 
                 ring++;
                 parseCoordSequence(jp);
-                removeLastPoint();
+                mMapElement.removeLastPoint();
                 continue;
             }
 
             if (t == END_ARRAY)
                 break;
         }
-    }
-
-    private void removeLastPoint() {
-        mMapElement.pointNextPos -= 2;
-        mMapElement.index[mMapElement.indexCurrentPos] -= 2;
     }
 
     private void parseLineString(JsonParser jp) throws IOException {

--- a/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/BuildingLayer.java
@@ -231,7 +231,7 @@ public class BuildingLayer extends Layer implements TileLoaderThemeHook, ZoomLim
                 if (rootBuilding.element.isBuildingPart())
                     continue;
                 if (RAW_DATA) {
-                    float[] center = GeometryUtils.center(partBuilding.element.points, 0, partBuilding.element.pointNextPos, null);
+                    float[] center = GeometryUtils.center(partBuilding.element.points, 0, partBuilding.element.getNumCoords(), null);
                     if (!GeometryUtils.pointInPoly(center[0], center[1], rootBuilding.element.points, rootBuilding.element.index[0], 0))
                         continue;
                 } else if (!(refId.equals(getValue(rootBuilding.element, Tag.KEY_ID))))

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBLayer.java
@@ -207,7 +207,7 @@ public class S3DBLayer extends BuildingLayer {
                 if (rootBuilding.element.isBuildingPart())
                     continue;
                 if (RAW_DATA) {
-                    float[] center = GeometryUtils.center(partBuilding.element.points, 0, partBuilding.element.pointNextPos, null);
+                    float[] center = GeometryUtils.center(partBuilding.element.points, 0, partBuilding.element.getNumCoords(), null);
                     if (!GeometryUtils.pointInPoly(center[0], center[1], rootBuilding.element.points, rootBuilding.element.index[0], 0))
                         continue;
                 } else if (!refId.equals(rootBuilding.element.tags.getValue(Tag.KEY_ID)))

--- a/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
+++ b/vtm/src/org/oscim/layers/tile/buildings/S3DBUtils.java
@@ -75,7 +75,7 @@ public final class S3DBUtils {
         int[] index = element.index;
 
         boolean outerProcessed = false;
-        for (int i = 0, pointPos = 0; i < index.length && !outerProcessed; i++) {
+        for (int i = 0, coordPos = 0; i < index.length && !outerProcessed; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -119,9 +119,9 @@ public final class S3DBUtils {
 
             List<float[]> point3Fs = new ArrayList<>();
 
-            for (int j = 0; j < (numSections * 2); j += 2, pointPos += 2) {
-                float x = points[pointPos];
-                float y = points[pointPos + 1];
+            for (int j = 0; j < (numSections * 2); j += 2, coordPos += 2) {
+                float x = points[coordPos];
+                float y = points[coordPos + 1];
 
                 point3Fs.add(new float[]{x, y, minHeight});
 
@@ -174,7 +174,7 @@ public final class S3DBUtils {
             }
 
             element.index = mesh.index;
-            element.pointNextPos = element.points.length;
+            element.setNumCoords(element.points.length);
         }
 
         element.type = GeometryBuffer.GeometryType.TRIS;
@@ -195,9 +195,9 @@ public final class S3DBUtils {
         List<float[]> point3Fs = new ArrayList<>();
 
         // Calculate center and load points
-        for (int pointPos = 0; pointPos < points.length; pointPos += 2) {
-            float x = points[pointPos];
-            float y = points[pointPos + 1];
+        for (int coordPos = 0; coordPos < points.length; coordPos += 2) {
+            float x = points[coordPos];
+            float y = points[coordPos + 1];
             point3Fs.add(new float[]{x, y, maxHeight});
         }
 
@@ -211,7 +211,7 @@ public final class S3DBUtils {
         }
 
         element.points = points;
-        element.pointNextPos = element.points.length;
+        element.setNumCoords(element.points.length);
         element.type = GeometryBuffer.GeometryType.TRIS;
         return true;
     }
@@ -229,7 +229,7 @@ public final class S3DBUtils {
         element.points = null;
         element.index = null;
 
-        for (int i = 0, pointPos = 0; i < index.length; i++) {
+        for (int i = 0, coordPos = 0; i < index.length; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -240,9 +240,9 @@ public final class S3DBUtils {
             List<float[]> point3Fs = new ArrayList<>();
 
             // load points
-            for (int j = 0; j < numPoints; j++, pointPos += 2) {
-                float x = points[pointPos];
-                float y = points[pointPos + 1];
+            for (int j = 0; j < numPoints; j++, coordPos += 2) {
+                float x = points[coordPos];
+                float y = points[coordPos + 1];
 
                 point3Fs.add(new float[]{x, y, minHeight});
                 point3Fs.add(new float[]{x, y, maxHeight});
@@ -288,10 +288,10 @@ public final class S3DBUtils {
                 System.arraycopy(tmpIndex, 0, element.index, 0, tmpIndex.length);
                 // Shift all indices with previous element.points.length
                 for (int k = 0; k < meshIndex.length; k++) {
-                    element.index[k + tmpIndex.length] = meshIndex[k] + (element.pointNextPos / 3);
+                    element.index[k + tmpIndex.length] = meshIndex[k] + (element.getNumCoords() / 3);
                 }
             }
-            element.pointNextPos = element.points.length;
+            element.setNumCoords(element.points.length);
         }
 
         if (element.points == null) {
@@ -315,7 +315,7 @@ public final class S3DBUtils {
         float[] topPoint = new float[3];
         topPoint[2] = maxHeight;
 
-        for (int i = 0, pointPos = 0; i < index.length; i++) {
+        for (int i = 0, coordPos = 0; i < index.length; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -324,13 +324,13 @@ public final class S3DBUtils {
             int numPoints = index[i] / 2;
             if (numPoints < 0) continue;
 
-            // Init top of roof (attention with pointPos)
-            GeometryUtils.center(points, pointPos, numPoints << 1, topPoint);
+            // Init top of roof (attention with coordPos)
+            GeometryUtils.center(points, coordPos, numPoints << 1, topPoint);
 
             List<float[]> point3Fs = new ArrayList<>();
             // Load points
-            for (int j = 0; j < (numPoints * 2); j += 2, pointPos += 2)
-                point3Fs.add(new float[]{points[pointPos], points[pointPos + 1], minHeight});
+            for (int j = 0; j < (numPoints * 2); j += 2, coordPos += 2)
+                point3Fs.add(new float[]{points[coordPos], points[coordPos + 1], minHeight});
 
             // Write index: index gives the first point of triangle mesh (divided 3)
             int[] meshIndex = new int[numPoints * 3];
@@ -355,7 +355,7 @@ public final class S3DBUtils {
             element.points = meshPoints;
             element.index = meshIndex;
             //element.indexCurrentPos = 0;
-            element.pointNextPos = meshPoints.length;
+            element.setNumCoords(meshPoints.length);
         }
 
         element.type = GeometryBuffer.GeometryType.TRIS;
@@ -377,7 +377,7 @@ public final class S3DBUtils {
         float[] points = element.points;
         int[] index = element.index;
 
-        for (int i = 0, pointPos = 0; i < index.length; i++) {
+        for (int i = 0, coordPos = 0; i < index.length; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -394,9 +394,9 @@ public final class S3DBUtils {
             List<float[]> point3Fs = new ArrayList<>();
 
             // Calculate center and load points
-            for (int j = 0; j < (numPoints * 2); j += 2, pointPos += 2) {
-                float x = points[pointPos];
-                float y = points[pointPos + 1];
+            for (int j = 0; j < (numPoints * 2); j += 2, coordPos += 2) {
+                float x = points[coordPos];
+                float y = points[coordPos + 1];
 
                 point3Fs.add(new float[]{x, y, minHeight});
             }
@@ -770,13 +770,13 @@ public final class S3DBUtils {
 
                 specialParts.points = meshPoints;
                 specialParts.index = meshPartsIndex;
-                specialParts.pointNextPos = meshPoints.length;
+                specialParts.setNumCoords(meshPoints.length);
                 specialParts.type = GeometryBuffer.GeometryType.TRIS;
             }
 
             element.points = meshPoints;
             element.index = meshIndex;
-            element.pointNextPos = meshPoints.length;
+            element.setNumCoords(meshPoints.length);
             element.type = GeometryBuffer.GeometryType.TRIS;
         }
 
@@ -793,7 +793,7 @@ public final class S3DBUtils {
         float[] points = element.points;
         int[] index = element.index;
 
-        for (int i = 0, pointPos = 0; i < index.length; i++) {
+        for (int i = 0, coordPos = 0; i < index.length; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -810,9 +810,9 @@ public final class S3DBUtils {
             List<float[]> point3Fs = new ArrayList<>();
 
             // Calculate center and load points
-            for (int j = 0; j < (numPoints * 2); j += 2, pointPos += 2) {
-                float x = points[pointPos];
-                float y = points[pointPos + 1];
+            for (int j = 0; j < (numPoints * 2); j += 2, coordPos += 2) {
+                float x = points[coordPos];
+                float y = points[coordPos + 1];
 
                 point3Fs.add(new float[]{x, y, minHeight});
             }
@@ -891,7 +891,7 @@ public final class S3DBUtils {
                 geoEle1.points[2 * k + 1] = elementPoints1.get(k)[1];
             }
             geoEle1.index[0] = geoEle1.points.length;
-            geoEle1.pointNextPos = geoEle1.points.length;
+            geoEle1.setNumCoords(geoEle1.points.length);
 
             GeometryBuffer geoEle2 = new GeometryBuffer(elementPoints2.size(), 1);
             for (int k = 0; k < elementPoints2.size(); k++) {
@@ -899,7 +899,7 @@ public final class S3DBUtils {
                 geoEle2.points[2 * k + 1] = elementPoints2.get(k)[1];
             }
             geoEle2.index[0] = geoEle2.points.length;
-            geoEle2.pointNextPos = geoEle2.points.length;
+            geoEle2.setNumCoords(geoEle2.points.length);
 
             GeometryBuffer specialParts1 = new GeometryBuffer(geoEle1);
             GeometryBuffer specialParts2 = new GeometryBuffer(geoEle2);
@@ -939,7 +939,7 @@ public final class S3DBUtils {
         float[] points = element.points;
         int[] index = element.index;
 
-        for (int i = 0, pointPos = 0; i < index.length; i++) {
+        for (int i = 0, coordPos = 0; i < index.length; i++) {
             if (index[i] < 0) {
                 break;
             }
@@ -949,9 +949,9 @@ public final class S3DBUtils {
             if (numPoints < 0) continue;
 
             List<float[]> point3Fs = new ArrayList<>();
-            for (int j = 0; j < (numPoints * 2); j += 2, pointPos += 2) {
-                float x = points[pointPos];
-                float y = points[pointPos + 1];
+            for (int j = 0; j < (numPoints * 2); j += 2, coordPos += 2) {
+                float x = points[coordPos];
+                float y = points[coordPos + 1];
 
                 point3Fs.add(new float[]{x, y, minHeight});
             }
@@ -1385,7 +1385,7 @@ public final class S3DBUtils {
         System.arraycopy(gb1.points, 0, mergedPoints, 0, gb1PointSize);
         System.arraycopy(gb2.points, 0, mergedPoints, gb1PointSize, gb2.points.length);
         out.points = mergedPoints;
-        out.pointNextPos = mergedPoints.length;
+        out.setNumCoords(mergedPoints.length);
 
         int gb1IndexSize = gb1.index.length;
         int[] mergedIndices = new int[gb1IndexSize + gb2.index.length];

--- a/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
@@ -406,7 +406,7 @@ public class ExtrusionBucket extends RenderBucket {
                 addRoofSimple(startVertex, len);
             } else if (!complexOutline) {
                 complexOutline = true;
-                addRoof(startVertex, element, ipos);
+                addRoof(startVertex, element, ipos, ppos);
             }
         }
     }
@@ -429,7 +429,7 @@ public class ExtrusionBucket extends RenderBucket {
     /**
      * roof indices for concave shapes
      */
-    private void addRoof(int startVertex, GeometryBuffer geom, int ipos) {
+    private void addRoof(int startVertex, GeometryBuffer geom, int ipos, int ppos) {
         int[] index = geom.index;
         float[] points = geom.points;
 
@@ -443,7 +443,7 @@ public class ExtrusionBucket extends RenderBucket {
             numRings++;
         }
 
-        numIndices += Tessellator.tessellate(points, numCoords,
+        numIndices += Tessellator.tessellate(points, ppos, numCoords,
                 index, ipos, numRings,
                 startVertex + 1,
                 mIndices[IND_ROOF]);

--- a/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/ExtrusionBucket.java
@@ -406,7 +406,7 @@ public class ExtrusionBucket extends RenderBucket {
                 addRoofSimple(startVertex, len);
             } else if (!complexOutline) {
                 complexOutline = true;
-                addRoof(startVertex, element, ipos, ppos);
+                addRoof(startVertex, element, ipos);
             }
         }
     }
@@ -429,21 +429,21 @@ public class ExtrusionBucket extends RenderBucket {
     /**
      * roof indices for concave shapes
      */
-    private void addRoof(int startVertex, GeometryBuffer geom, int ipos, int ppos) {
+    private void addRoof(int startVertex, GeometryBuffer geom, int ipos) {
         int[] index = geom.index;
         float[] points = geom.points;
 
-        int numPoints = 0;
+        int numCoords = 0;
         int numRings = 0;
 
         /* get sum of points in polygon */
         // n is introduced if length increases while processing
         for (int i = ipos, n = index.length; i < n && index[i] > 0; i++) {
-            numPoints += index[i];
+            numCoords += index[i];
             numRings++;
         }
 
-        numIndices += Tessellator.tessellate(points, ppos, numPoints,
+        numIndices += Tessellator.tessellate(points, numCoords,
                 index, ipos, numRings,
                 startVertex + 1,
                 mIndices[IND_ROOF]);

--- a/vtm/src/org/oscim/renderer/bucket/MeshBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/MeshBucket.java
@@ -45,7 +45,7 @@ public class MeshBucket extends RenderBucket {
 
     private TessJNI tess;
 
-    private int numPoints;
+    private int numCoords;
 
     public MeshBucket(int level) {
         super(RenderBucket.MESH, true, false);
@@ -53,7 +53,7 @@ public class MeshBucket extends RenderBucket {
     }
 
     public void addMesh(GeometryBuffer geom) {
-        numPoints += geom.pointNextPos;
+        numCoords += geom.getNumCoords();
         if (tess == null)
             tess = new TessJNI(8);
 
@@ -87,7 +87,7 @@ public class MeshBucket extends RenderBucket {
             numIndices += 3;
         }
 
-        //numPoints += geom.pointPos;
+        //numCoords += geom.pointPos;
         //tess.addContour2D(geom.index, geom.points);
     }
 
@@ -96,13 +96,13 @@ public class MeshBucket extends RenderBucket {
         if (tess == null)
             return;
 
-        if (numPoints == 0) {
+        if (numCoords == 0) {
             tess.dispose();
             return;
         }
         if (!tess.tesselate()) {
             tess.dispose();
-            log.debug("error in tessellation {}", numPoints);
+            log.debug("error in tessellation {}", numCoords);
             return;
         }
 

--- a/vtm/src/org/oscim/tiling/source/PbfDecoder.java
+++ b/vtm/src/org/oscim/tiling/source/PbfDecoder.java
@@ -244,7 +244,7 @@ public abstract class PbfDecoder implements ITileDecoder {
 
         bufferPos = pos;
 
-        geom.pointNextPos = cnt;
+        geom.setNumCoords(cnt);
 
         // return number of points read
         return (cnt >> 1);

--- a/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
+++ b/vtm/src/org/oscim/tiling/source/mapfile/MapDatabase.java
@@ -740,8 +740,8 @@ public class MapDatabase implements ITileDataSource {
         int[] buffer = mIntBuffer;
         mReadBuffer.readSignedInt(buffer, length);
 
-        float[] outBuffer = e.ensurePointSize(e.pointNextPos + length, true);
-        int outPos = e.pointNextPos;
+        float[] outBuffer = e.ensurePointSize(e.getNumCoords() + length, true);
+        int outPos = e.getNumCoords();
         int lat, lon;
 
         /* first node latitude single-delta offset */
@@ -789,7 +789,7 @@ public class MapDatabase implements ITileDataSource {
             }
         }
 
-        e.pointNextPos = outPos;
+        e.setNumCoords(outPos);
 
         return cnt;
     }

--- a/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
+++ b/vtm/src/org/oscim/tiling/source/oscimap4/TileDecoder.java
@@ -328,7 +328,7 @@ public class TileDecoder extends PbfDecoder {
                                     Integer.valueOf(cnt));
                             fail = true;
                         }
-                        mElem.pointNextPos = cnt;
+                        mElem.setNumCoords(cnt);
                     } else {
                         mElem.ensurePointSize(coordCnt, false);
                         int cnt = decodeInterleavedPoints(mElem, mScaleFactor);

--- a/vtm/src/org/oscim/utils/ExtrusionUtils.java
+++ b/vtm/src/org/oscim/utils/ExtrusionUtils.java
@@ -41,7 +41,7 @@ public final class ExtrusionUtils {
     public static void mapPolyCoordScale(GeometryBuffer buffer) {
         float tileScale = REF_TILE_SIZE / Tile.SIZE;
         float[] points = buffer.points;
-        for (int pPos = 0; pPos < buffer.pointNextPos; pPos++) {
+        for (int pPos = 0; pPos < buffer.getNumCoords(); pPos++) {
             points[pPos] = points[pPos] * tileScale;
         }
     }

--- a/vtm/src/org/oscim/utils/Tessellator.java
+++ b/vtm/src/org/oscim/utils/Tessellator.java
@@ -32,20 +32,19 @@ public class Tessellator {
      * Special version for ExtrusionLayer to match indices with vertex positions.
      * Tessellates polygon in tris elements.
      *
-     * @param points       the {@link org.oscim.core.GeometryBuffer#points}
-     * @param ppos         the {@link org.oscim.core.GeometryBuffer#pointNextPos} (not needed)
-     * @param numPoints    equals ppos?
-     * @param index        the {@link org.oscim.core.GeometryBuffer#index}
-     * @param ipos         the {@link org.oscim.core.GeometryBuffer#indexCurrentPos}
+     * @param points       the {@link GeometryBuffer#points}
+     * @param numCoords    the {@link GeometryBuffer#getNumCoords()}
+     * @param index        the {@link GeometryBuffer#index}
+     * @param ipos         the {@link GeometryBuffer#indexCurrentPos}
      * @param numRings     the number of ring polygons
      * @param vertexOffset shift outTris index with offset
      * @param outTris      the tessellated polygon as triangular {@link org.oscim.renderer.bucket.VertexData}
      * @return number of indices of outTris
      */
-    public static int tessellate(float[] points, int ppos, int numPoints, int[] index,
+    public static int tessellate(float[] points, int numCoords, int[] index,
                                  int ipos, int numRings, int vertexOffset, VertexData outTris) {
 
-        int buckets = FastMath.log2(MathUtils.nextPowerOfTwo(numPoints));
+        int buckets = FastMath.log2(MathUtils.nextPowerOfTwo(numCoords));
         buckets -= 2;
         //log.debug("tess use {}", buckets);
 
@@ -60,10 +59,10 @@ public class Tessellator {
         int nverts = tess.getVertexCount() * 2;
         int nelems = tess.getElementCount() * 3;
 
-        //log.debug("tess elems:{} verts:{} points:{}", nelems, nverts, numPoints);
+        //log.debug("tess elems:{} verts:{} points:{}", nelems, nverts, numCoords);
 
-        if (numPoints != nverts) {
-            log.debug("tess ----- skip poly: " + nverts + " " + numPoints);
+        if (numCoords != nverts) {
+            log.debug("tess ----- skip poly: " + nverts + " " + numCoords);
             tess.dispose();
             return 0;
         }

--- a/vtm/src/org/oscim/utils/Tessellator.java
+++ b/vtm/src/org/oscim/utils/Tessellator.java
@@ -33,6 +33,7 @@ public class Tessellator {
      * Tessellates polygon in tris elements.
      *
      * @param points       the {@link GeometryBuffer#points}
+     * @param posCoords    the start index of point coordinates
      * @param numCoords    the {@link GeometryBuffer#getNumCoords()}
      * @param index        the {@link GeometryBuffer#index}
      * @param ipos         the {@link GeometryBuffer#indexCurrentPos}
@@ -41,7 +42,7 @@ public class Tessellator {
      * @param outTris      the tessellated polygon as triangular {@link org.oscim.renderer.bucket.VertexData}
      * @return number of indices of outTris
      */
-    public static int tessellate(float[] points, int numCoords, int[] index,
+    public static int tessellate(float[] points, int posCoords, int numCoords, int[] index,
                                  int ipos, int numRings, int vertexOffset, VertexData outTris) {
 
         int buckets = FastMath.log2(MathUtils.nextPowerOfTwo(numCoords));

--- a/vtm/src/org/oscim/utils/geom/GeometryUtils.java
+++ b/vtm/src/org/oscim/utils/geom/GeometryUtils.java
@@ -69,7 +69,7 @@ public final class GeometryUtils {
     /**
      * Returns the unsigned area of polygon.
      *
-     * @param n number of points
+     * @param n number of point coordinates
      */
     public static float area(float[] points, int n) {
         float area = isClockwise(points, n);
@@ -118,22 +118,22 @@ public final class GeometryUtils {
     }
 
     /**
-     * Calculates the center of a set of points.
+     * Calculates the center of a set of 2D points.
      *
-     * @param points   the points array
-     * @param pointPos the start position of points
+     * @param points   the 2D points array
+     * @param coordPos the start position of coordinates
      * @param n        the number of points
      * @param out      the center output
      * @return the center of points
      */
-    public static float[] center(float[] points, int pointPos, int n, float[] out) {
+    public static float[] center(float[] points, int coordPos, int n, float[] out) {
         if (out == null)
             out = new float[2];
 
         // Calculate center
-        for (int i = 0; i < n; i += 2, pointPos += 2) {
-            float x = points[pointPos];
-            float y = points[pointPos + 1];
+        for (int i = 0; i < n; i += 2, coordPos += 2) {
+            float x = points[coordPos];
+            float y = points[coordPos + 1];
 
             out[0] += x;
             out[1] += y;
@@ -313,7 +313,7 @@ public final class GeometryUtils {
      * Is polygon clockwise.
      *
      * @param points the points array
-     * @param n      the number of points
+     * @param n      the number of point coordinates
      * @return the signed area of the polygon
      * positive: clockwise
      * negative: counter-clockwise

--- a/vtm/src/org/oscim/utils/geom/SimplifyVW.java
+++ b/vtm/src/org/oscim/utils/geom/SimplifyVW.java
@@ -54,12 +54,12 @@ public class SimplifyVW {
 
         size = 0;
 
-        if (heap.length < geom.pointNextPos >> 1)
-            heap = new Item[geom.pointNextPos >> 1];
+        if (heap.length < geom.getNumPoints())
+            heap = new Item[geom.getNumPoints()];
 
         first = prev = push(0, Float.MAX_VALUE);
 
-        for (int i = 2; i < geom.pointNextPos - 2; i += 2) {
+        for (int i = 2; i < geom.getNumCoords() - 2; i += 2) {
             it = push(i, area(geom.points, i - 2, i, i + 2));
             prev.next = it;
             it.prev = prev;
@@ -67,7 +67,7 @@ public class SimplifyVW {
             prev = it;
         }
 
-        Item last = push(geom.pointNextPos - 2, Float.MAX_VALUE);
+        Item last = push(geom.getNumCoords() - 2, Float.MAX_VALUE);
 
         //        sorter.doSort(heap, DistanceComparator, 0, size);
         //        for (int i = 0; i < size; i++)
@@ -102,8 +102,8 @@ public class SimplifyVW {
         first.prev = null;
         it = first;
 
-        float[] points = new float[geom.pointNextPos];
-        System.arraycopy(geom.points, 0, points, 0, geom.pointNextPos);
+        float[] points = new float[geom.getNumCoords()];
+        System.arraycopy(geom.points, 0, points, 0, geom.getNumCoords());
 
         geom.clear();
         geom.startPolygon();

--- a/vtm/src/org/oscim/utils/geom/TileClipper.java
+++ b/vtm/src/org/oscim/utils/geom/TileClipper.java
@@ -81,10 +81,10 @@ public class TileClipper {
             System.arraycopy(out.index, 0, idx, 0, numLines);
             geom.index[numLines] = -1;
 
-            float pts[] = geom.ensurePointSize(out.pointNextPos >> 1, false);
-            System.arraycopy(out.points, 0, pts, 0, out.pointNextPos);
+            float pts[] = geom.ensurePointSize(out.getNumPoints(), false);
+            System.arraycopy(out.points, 0, pts, 0, out.getNumCoords());
             geom.indexCurrentPos = out.indexCurrentPos;
-            geom.pointNextPos = out.pointNextPos;
+            geom.setNumCoords(out.getNumCoords());
 
             if ((geom.indexCurrentPos == 0) && (geom.index[0] < 4))
                 return false;


### PR DESCRIPTION
It was always confusing, when having `point` _size, pos, num_, etc., if there's meant the point size or the number of coordinates in an point array. So I renamed it.
`numPoints = numCoordinates / dimension`