### PR TITLE
small tweak to have filled text and avoid cutting the text's descends

### DIFF
--- a/vtm-playground/src/org/oscim/test/MarkerLayerLabelsTest.java
+++ b/vtm-playground/src/org/oscim/test/MarkerLayerLabelsTest.java
@@ -122,7 +122,7 @@ public class MarkerLayerLabelsTest extends GdxMapApp implements ItemizedLayer.On
      */
     private MarkerSymbol createAdvancedSymbol(MarkerItem item, Bitmap poiBitmap) {
         final Paint textPainter = CanvasAdapter.newPaint();
-        textPainter.setStyle(Paint.Style.STROKE);
+        textPainter.setStyle(Paint.Style.FILL);
         textPainter.setColor(FG_COLOR);
 
         final Paint fillPainter = CanvasAdapter.newPaint();
@@ -180,7 +180,7 @@ public class MarkerLayerLabelsTest extends GdxMapApp implements ItemizedLayer.On
         // titleCanvas.fillRectangle() does not support transparency
         titleCanvas.drawCircle(0, 0, xSize * 2, fillPainter);
 
-        titleCanvas.drawText(item.title, margin, titleHeight - margin, textPainter);
+        titleCanvas.drawText(item.title, margin, titleHeight - margin - textPainter.getFontDescent(), textPainter);
 
         if (hasSubtitle) {
             Bitmap subtitleBitmap = CanvasAdapter.newBitmap(subtitleWidth + margin, subtitleHeight + margin, 0);

--- a/vtm-playground/src/org/oscim/test/MarkerLayerLabelsTest.java
+++ b/vtm-playground/src/org/oscim/test/MarkerLayerLabelsTest.java
@@ -133,7 +133,7 @@ public class MarkerLayerLabelsTest extends GdxMapApp implements ItemizedLayer.On
         int dist2symbol = 30;
 
         int titleWidth = ((int) textPainter.getTextWidth(item.title) + 2 * margin);
-        int titleHeight = ((int) textPainter.getTextHeight(item.title) + 2 * margin);
+        int titleHeight = (int) (textPainter.getTextHeight(item.title) + textPainter.getFontDescent() + 2 * margin);
 
         int symbolWidth = poiBitmap.getWidth();
 
@@ -146,7 +146,7 @@ public class MarkerLayerLabelsTest extends GdxMapApp implements ItemizedLayer.On
                 subtitle = item.description.substring(1); // not the first # char
                 subtitle = subtitle.split("\\R", 2)[0]; // only first line
                 subtitleWidth = ((int) textPainter.getTextWidth(subtitle)) + 2 * margin;
-                subtitleHeight = ((int) textPainter.getTextHeight(subtitle)) + 2 * margin;
+                subtitleHeight = (int) ((textPainter.getTextHeight(subtitle)) + textPainter.getFontDescent()+ 2 * margin);
                 hasSubtitle = true;
             }
         }


### PR DESCRIPTION
This fixes the fact that font decends are cut away. Also I guess font should be filled.

Both of these are just cosmetics and might not interest in a testcase, so feel free to trash the PR if you don't like it. 