### PR TITLE
Enable GL.POINT_SPRITE on desktops by default

### DIFF
--- a/vtm/src/org/oscim/backend/GLAdapter.java
+++ b/vtm/src/org/oscim/backend/GLAdapter.java
@@ -55,6 +55,10 @@ public class GLAdapter {
         GDX_DESKTOP_QUIRKS = CanvasAdapter.platform.isDesktop();
         GDX_WEBGL_QUIRKS = (CanvasAdapter.platform == Platform.WEBGL);
 
+        // Point sprite sometimes isn't enabled by default, see #268
+        if (GLAdapter.GDX_DESKTOP_QUIRKS)
+            gl.enable(0x8861); // GL.POINT_SPRITE
+
         // Buildings translucency does not work on macOS, see #61
         if (CanvasAdapter.platform == Platform.MACOS)
             BuildingLayer.TRANSLUCENT = false;


### PR DESCRIPTION
Fixes [CircleTest](https://github.com/mapsforge/vtm/blob/master/vtm-playground/src/org/oscim/test/CircleTest.java), as circles weren't rendered with certain desktop graphics cards / drivers.
See #268.

Bug appeared with:
- Nvidia GeForce GTX 970
- Nvidia GeForce GT 420M