### PR TITLE
Render themes: text background color (highway shields)

### DIFF
--- a/resources/rendertheme.xsd
+++ b/resources/rendertheme.xsd
@@ -150,6 +150,7 @@
         <xs:attribute name="font-family" default="default" type="tns:fontFamily" use="optional" />
         <xs:attribute name="style" default="normal" type="tns:fontStyle" use="optional" />
         <xs:attribute name="size" default="0" type="tns:nonNegativeFloat" use="optional" />
+        <xs:attribute name="bg-fill" default="#00000000" type="tns:color" use="optional" />
         <xs:attribute name="fill" default="#000000" type="tns:color" use="optional" />
         <xs:attribute name="stroke" default="#000000" type="tns:color" use="optional" />
         <xs:attribute name="stroke-width" default="0" type="tns:nonNegativeFloat" use="optional" />
@@ -219,6 +220,7 @@
         <xs:attribute name="font-family" default="default" type="tns:fontFamily" use="optional" />
         <xs:attribute name="style" default="normal" type="tns:fontStyle" use="optional" />
         <xs:attribute name="size" default="0" type="tns:nonNegativeFloat" use="optional" />
+        <xs:attribute name="bg-fill" default="#00000000" type="tns:color" use="optional" />
         <xs:attribute name="fill" default="#000000" type="tns:color" use="optional" />
         <xs:attribute name="stroke" default="#000000" type="tns:color" use="optional" />
         <xs:attribute name="stroke-width" default="0" type="tns:nonNegativeFloat" use="optional" />

--- a/vtm-android/src/org/oscim/android/canvas/AndroidCanvas.java
+++ b/vtm-android/src/org/oscim/android/canvas/AndroidCanvas.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
- * Copyright 2016-2017 devemux86
+ * Copyright 2016-2019 devemux86
  * Copyright 2017 nebular
  * Copyright 2017 Longri
  *
@@ -21,8 +21,8 @@ package org.oscim.android.canvas;
 
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.PorterDuffXfermode;
 import android.graphics.RectF;
-
 import org.oscim.backend.canvas.Bitmap;
 import org.oscim.backend.canvas.Canvas;
 import org.oscim.backend.canvas.Paint;
@@ -93,6 +93,7 @@ public class AndroidCanvas implements Canvas {
         RectF rect = new RectF(x, y, x + width, y + height);
         android.graphics.Paint paint = new android.graphics.Paint();
         paint.setColor(color);
+        paint.setXfermode(new PorterDuffXfermode(color == Color.TRANSPARENT ? PorterDuff.Mode.CLEAR : PorterDuff.Mode.SRC_OVER));
         canvas.drawRect(rect, paint);
     }
 

--- a/vtm-themes/resources/assets/vtm/default.xml
+++ b/vtm-themes/resources/assets/vtm/default.xml
@@ -45,7 +45,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#45a976" />
     <!--ferry-->
     <style-text style="bold" fill="#606060" id="ferry" k="name" size="12" stroke="#ffffff"
         stroke-width="2.0" />

--- a/vtm-themes/resources/assets/vtm/mapzen.xml
+++ b/vtm-themes/resources/assets/vtm/mapzen.xml
@@ -25,7 +25,8 @@
 
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#45a976" />
 
     <style-text style="bold" fill="#606060" id="ferry" k="name" size="12" stroke="#ffffff"
         stroke-width="2.0" />

--- a/vtm-themes/resources/assets/vtm/newtron.xml
+++ b/vtm-themes/resources/assets/vtm/newtron.xml
@@ -35,7 +35,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#45a976" />
 
 
     <!--###### AREA styles ######-->

--- a/vtm-themes/resources/assets/vtm/openmaptiles.xml
+++ b/vtm-themes/resources/assets/vtm/openmaptiles.xml
@@ -40,7 +40,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#45a976" />
     <!--ferry-->
     <style-text style="bold" fill="#606060" id="ferry" k="name" size="12" stroke="#ffffff"
         stroke-width="2.0" />

--- a/vtm-themes/resources/assets/vtm/osmagray.xml
+++ b/vtm-themes/resources/assets/vtm/osmagray.xml
@@ -34,7 +34,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#5b5b5b" />
 
 
     <!--###### AREA styles ######-->

--- a/vtm-themes/resources/assets/vtm/osmarender.xml
+++ b/vtm-themes/resources/assets/vtm/osmarender.xml
@@ -34,7 +34,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#007f00" />
 
 
     <!--###### AREA styles ######-->

--- a/vtm-themes/resources/assets/vtm/tronrender.xml
+++ b/vtm-themes/resources/assets/vtm/tronrender.xml
@@ -35,7 +35,8 @@
     <!--references-->
     <style-text style="bold" fill="#606060" id="ref" k="ref" priority="2" size="12" stroke="#ffffff"
         stroke-width="2.0" />
-    <style-text caption="true" id="ref-caption" use="ref" />
+    <style-text caption="true" style="bold" fill="#ffffff" id="ref-caption" k="ref" priority="2"
+        size="12" bg-fill="#45a976" />
 
 
     <!--###### AREA styles ######-->

--- a/vtm/src/org/oscim/renderer/bucket/TextBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/TextBucket.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2012 Hannes Janetzek
+ * Copyright 2019 devemux86
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -89,7 +90,7 @@ public class TextBucket extends TextureBucket {
         int advanceY = 0;
         float x = 0;
         float y = 0;
-        float yy;
+        float xx, yy;
 
         TextureItem t = pool.get();
         textures = t;
@@ -127,13 +128,17 @@ public class TextBucket extends TextureBucket {
                 }
             }
 
+            xx = x + mFontPadX;
             yy = y + height - it.text.fontDescent;
-
-            mCanvas.drawText(it.label, x, yy, it.text.paint, it.text.stroke);
 
             // FIXME !!!
             if (width > TEXTURE_WIDTH)
                 width = TEXTURE_WIDTH;
+
+            if (it.text.bgFill != null)
+                mCanvas.fillRectangle(x + mFontPadX, y + 1, width - 2 * mFontPadX, height, it.text.bgFill.getColor());
+
+            mCanvas.drawText(it.label, xx, yy, it.text.paint, it.text.stroke);
 
             while (it != null) {
                 addItem(it, width, height, x, y);

--- a/vtm/src/org/oscim/theme/XmlThemeBuilder.java
+++ b/vtm/src/org/oscim/theme/XmlThemeBuilder.java
@@ -1012,6 +1012,9 @@ public class XmlThemeBuilder extends DefaultHandler {
             else if ("size".equals(name) || "font-size".equals(name))
                 b.fontSize = Float.parseFloat(value);
 
+            else if ("bg-fill".equals(name))
+                b.bgFillColor = Color.parseColor(value);
+
             else if ("fill".equals(name))
                 b.fillColor = Color.parseColor(value);
 

--- a/vtm/src/org/oscim/theme/styles/TextStyle.java
+++ b/vtm/src/org/oscim/theme/styles/TextStyle.java
@@ -26,6 +26,8 @@ import org.oscim.backend.canvas.Paint.FontFamily;
 import org.oscim.backend.canvas.Paint.FontStyle;
 import org.oscim.renderer.atlas.TextureRegion;
 
+import static org.oscim.backend.canvas.Color.parseColor;
+
 public final class TextStyle extends RenderStyle<TextStyle> {
 
     public static class TextBuilder<T extends TextBuilder<T>> extends StyleBuilder<T> {
@@ -45,6 +47,8 @@ public final class TextStyle extends RenderStyle<TextStyle> {
         public int symbolWidth;
         public int symbolHeight;
         public int symbolPercent;
+
+        public int bgFillColor;
 
         public T reset() {
             cat = null;
@@ -66,6 +70,8 @@ public final class TextStyle extends RenderStyle<TextStyle> {
             symbolWidth = 0;
             symbolHeight = 0;
             symbolPercent = 100;
+
+            bgFillColor = Color.TRANSPARENT;
 
             return self();
         }
@@ -151,6 +157,16 @@ public final class TextStyle extends RenderStyle<TextStyle> {
             return self();
         }
 
+        public T bgFillColor(int color) {
+            this.bgFillColor = color;
+            return self();
+        }
+
+        public T bgFillColor(String color) {
+            this.bgFillColor = parseColor(color);
+            return self();
+        }
+
         public T from(TextBuilder<?> other) {
             cat = other.cat;
             fontFamily = other.fontFamily;
@@ -171,6 +187,8 @@ public final class TextStyle extends RenderStyle<TextStyle> {
             symbolWidth = other.symbolWidth;
             symbolHeight = other.symbolHeight;
             symbolPercent = other.symbolPercent;
+
+            bgFillColor = other.bgFillColor;
 
             return self();
         }
@@ -200,6 +218,9 @@ public final class TextStyle extends RenderStyle<TextStyle> {
             this.symbolWidth = text.symbolWidth;
             this.symbolHeight = text.symbolHeight;
             this.symbolPercent = text.symbolPercent;
+
+            if (text.bgFill != null)
+                this.bgFillColor = themeCallback != null ? themeCallback.getColor(text, text.bgFill.getColor()) : text.bgFill.getColor();
 
             return self();
         }
@@ -241,6 +262,12 @@ public final class TextStyle extends RenderStyle<TextStyle> {
         this.symbolWidth = b.symbolWidth;
         this.symbolHeight = b.symbolHeight;
         this.symbolPercent = b.symbolPercent;
+
+        if (b.bgFillColor != Color.TRANSPARENT) {
+            bgFill = CanvasAdapter.newPaint();
+            bgFill.setColor(b.themeCallback != null ? b.themeCallback.getColor(this, b.bgFillColor) : b.bgFillColor);
+        } else
+            bgFill = null;
     }
 
     public final String style;
@@ -266,6 +293,8 @@ public final class TextStyle extends RenderStyle<TextStyle> {
     public final int symbolWidth;
     public final int symbolHeight;
     public final int symbolPercent;
+
+    public final Paint bgFill;
 
     @Override
     public void dispose() {


### PR DESCRIPTION
Add in theme text rules a background color option, useful for cases like highway shields.
```xml
<style-text caption="true" style="bold" fill="#ffffff" id="ref" k="ref" priority="2" size="12" bg-fill="#45a976" />
```
![VTM](https://user-images.githubusercontent.com/3484020/62427249-e3b5d500-b6f8-11e9-86de-0a3b2c4044b0.png)