### PR TITLE
Android: OpenGL ES 2.0 default for performance / stability

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -2,8 +2,10 @@
 
 ## New since 0.12.0
 
-- Render themes: symbols on lines with billboard, rotate [#743](https://github.com/mapsforge/vtm/pull/743)
-- Threaded system initialization (Android)
+- Render themes: symbols on lines with billboard / rotation [#743](https://github.com/mapsforge/vtm/pull/743)
+- Android: OpenGL ES 2.0 default for performance / stability [#749](https://github.com/mapsforge/vtm/pull/749)
+  - `MapView.OPENGL_VERSION`
+- Android: threaded system initialization
   - `Parameters.THREADED_INIT`
 - Many other minor improvements and bug fixes
 - [Solved issues](https://github.com/mapsforge/vtm/issues?q=is%3Aclosed+milestone%3A0.13.0)

--- a/vtm-android/src/org/oscim/android/MapView.java
+++ b/vtm-android/src/org/oscim/android/MapView.java
@@ -65,9 +65,10 @@ public class MapView extends GLSurfaceView {
     private static final Pattern GL_PATTERN = Pattern.compile("OpenGL ES (\\d(\\.\\d){0,2})");
 
     /**
-     * Target OpenGL ES version, if not available fall back to OpenGL ES 2.0
+     * OpenGL ES 2.0 default on Android for performance / stability.
+     * Any larger not available versions fall back to OpenGL ES 2.0.
      */
-    public static double targetGLESVersion = 3.0;
+    public static double OPENGL_VERSION = 2.0;
 
     private static void init() {
         if (Parameters.THREADED_INIT)
@@ -133,16 +134,20 @@ public class MapView extends GLSurfaceView {
         mMap = new AndroidMap(this);
 
         /* Initialize Renderer */
-        // OpenGL ES 3.0 is supported with Android 4.3 (API level 18) and higher
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            try {
-                setEGLContextFactory(new GlContextFactory());
-            } catch (Throwable t) {
-                log.error("Falling back to GLES 2", t);
-                setEGLContextClientVersion(2);
-            }
-        } else
+        if (OPENGL_VERSION == 2.0)
             setEGLContextClientVersion(2);
+        else {
+            // OpenGL ES 3.0 is supported with Android 4.3 (API level 18) and higher
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
+                try {
+                    setEGLContextFactory(new GlContextFactory());
+                } catch (Throwable t) {
+                    log.error("Falling back to GLES 2", t);
+                    setEGLContextClientVersion(2);
+                }
+            } else
+                setEGLContextClientVersion(2);
+        }
         setEGLConfigChooser(new GlConfigChooser());
 
         if (GLAdapter.debug)
@@ -354,23 +359,27 @@ public class MapView extends GLSurfaceView {
 
         @Override
         public void onSurfaceCreated(GL10 gl, EGLConfig config) {
-            try {
-                // Create a minimum supported OpenGL ES context, then check:
-                String versionString = gl.glGetString(GL10.GL_VERSION);
-                log.info("Version: " + versionString);
-                // The version format is displayed as: "OpenGL ES <major>.<minor>"
-                // followed by optional content provided by the implementation.
-
-                // OpenGL<space>ES<space><version number><space><vendor-specific information>.
-                int[] version = extractVersion(versionString);
-                int majorVersion = version[0];
-                if (majorVersion >= 3)
-                    GLAdapter.init(new AndroidGL30());
-                else
-                    GLAdapter.init(new AndroidGL());
-            } catch (Throwable t) {
-                log.error("Falling back to GLES 2", t);
+            if (OPENGL_VERSION == 2.0)
                 GLAdapter.init(new AndroidGL());
+            else {
+                try {
+                    // Create a minimum supported OpenGL ES context, then check:
+                    String versionString = gl.glGetString(GL10.GL_VERSION);
+                    log.info("Version: " + versionString);
+                    // The version format is displayed as: "OpenGL ES <major>.<minor>"
+                    // followed by optional content provided by the implementation.
+
+                    // OpenGL<space>ES<space><version number><space><vendor-specific information>.
+                    int[] version = extractVersion(versionString);
+                    int majorVersion = Math.min(version[0], (int) OPENGL_VERSION);
+                    if (majorVersion >= 3)
+                        GLAdapter.init(new AndroidGL30());
+                    else
+                        GLAdapter.init(new AndroidGL());
+                } catch (Throwable t) {
+                    log.error("Falling back to GLES 2", t);
+                    GLAdapter.init(new AndroidGL());
+                }
             }
 
             super.onSurfaceCreated();

--- a/vtm-android/src/org/oscim/android/gl/GlContextFactory.java
+++ b/vtm-android/src/org/oscim/android/gl/GlContextFactory.java
@@ -28,7 +28,6 @@
 package org.oscim.android.gl;
 
 import android.opengl.GLSurfaceView;
-
 import org.oscim.android.MapView;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,18 +50,18 @@ public class GlContextFactory implements GLSurfaceView.EGLContextFactory {
 
     @Override
     public EGLContext createContext(EGL10 egl, EGLDisplay display, EGLConfig eglConfig) {
-        log.info("creating OpenGL ES " + MapView.targetGLESVersion + " context");
-        checkEglError("Before eglCreateContext " + MapView.targetGLESVersion, egl);
-        int[] attrib_list = {EGL_CONTEXT_CLIENT_VERSION, (int) MapView.targetGLESVersion, EGL10.EGL_NONE};
+        log.info("creating OpenGL ES " + MapView.OPENGL_VERSION + " context");
+        checkEglError("Before eglCreateContext " + MapView.OPENGL_VERSION, egl);
+        int[] attrib_list = {EGL_CONTEXT_CLIENT_VERSION, (int) MapView.OPENGL_VERSION, EGL10.EGL_NONE};
         EGLContext context = egl.eglCreateContext(display, eglConfig, EGL10.EGL_NO_CONTEXT, attrib_list);
-        boolean success = checkEglError("After eglCreateContext " + MapView.targetGLESVersion, egl);
+        boolean success = checkEglError("After eglCreateContext " + MapView.OPENGL_VERSION, egl);
 
-        if ((!success || context == null) && MapView.targetGLESVersion > 2) {
+        if ((!success || context == null) && MapView.OPENGL_VERSION > 2) {
             log.warn("Falling back to GLES 2");
-            MapView.targetGLESVersion = 2.0;
+            MapView.OPENGL_VERSION = 2.0;
             return createContext(egl, display, eglConfig);
         }
-        log.info("Returning a GLES " + MapView.targetGLESVersion + " context");
+        log.info("Returning a GLES " + MapView.OPENGL_VERSION + " context");
         return context;
     }
 


### PR DESCRIPTION
Use OpenGL ES 2.0 as default on Android for performance & stability reasons.

There are reports for performance & rendering issues on many devices using OpenGL ES 3.0.
OpenGL ES 3.0 is not a prerequisite for core library functions, can be set as option via the flag:
```java
MapView.OPENGL_VERSION
```

See also: https://godotengine.org/article/abandoning-gles3-vulkan-and-gles2