### PR TITLE
AndroidGraphics: drawable to bitmap for Android >= 9

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/ClusterMarkerOverlayActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/ClusterMarkerOverlayActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 devemux86
+ * Copyright 2016-2019 devemux86
  * Copyright 2017 nebular
  *
  * This program is free software: you can redistribute it and/or modify it under the
@@ -15,16 +15,12 @@
  */
 package org.oscim.android.test;
 
+import android.graphics.BitmapFactory;
+import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.backend.canvas.Bitmap;
 import org.oscim.backend.canvas.Color;
 import org.oscim.core.GeoPoint;
-import org.oscim.layers.marker.ClusterMarkerRenderer;
-import org.oscim.layers.marker.ItemizedLayer;
-import org.oscim.layers.marker.MarkerItem;
-import org.oscim.layers.marker.MarkerLayer;
-import org.oscim.layers.marker.MarkerRenderer;
-import org.oscim.layers.marker.MarkerRendererFactory;
-import org.oscim.layers.marker.MarkerSymbol;
+import org.oscim.layers.marker.*;
 import org.oscim.layers.tile.bitmap.BitmapTileLayer;
 import org.oscim.tiling.TileSource;
 import org.oscim.tiling.source.OkHttpEngine;
@@ -32,8 +28,6 @@ import org.oscim.tiling.source.bitmap.DefaultSources;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.oscim.android.canvas.AndroidGraphics.drawableToBitmap;
 
 public class ClusterMarkerOverlayActivity extends MarkerOverlayActivity {
 
@@ -50,7 +44,7 @@ public class ClusterMarkerOverlayActivity extends MarkerOverlayActivity {
                 .build();
         mMap.layers().add(new BitmapTileLayer(mMap, tileSource));
 
-        Bitmap bitmapPoi = drawableToBitmap(getResources().getDrawable(R.drawable.marker_poi));
+        Bitmap bitmapPoi = new AndroidBitmap(BitmapFactory.decodeResource(getResources(), R.drawable.marker_poi));
         final MarkerSymbol symbol;
         if (BILLBOARDS)
             symbol = new MarkerSymbol(bitmapPoi, MarkerSymbol.HotspotPlace.BOTTOM_CENTER);

--- a/vtm-android-example/src/org/oscim/android/test/MarkerOverlayActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/MarkerOverlayActivity.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2014 Hannes Janetzek
- * Copyright 2016-2018 devemux86
+ * Copyright 2016-2019 devemux86
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -17,9 +17,10 @@
  */
 package org.oscim.android.test;
 
+import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.widget.Toast;
-
+import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.backend.canvas.Bitmap;
 import org.oscim.core.GeoPoint;
 import org.oscim.event.Gesture;
@@ -38,8 +39,6 @@ import org.oscim.tiling.source.bitmap.DefaultSources;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import static org.oscim.android.canvas.AndroidGraphics.drawableToBitmap;
 
 public class MarkerOverlayActivity extends MapActivity
         implements ItemizedLayer.OnItemGestureListener<MarkerItem> {
@@ -64,14 +63,14 @@ public class MarkerOverlayActivity extends MapActivity
                 .build();
         mMap.layers().add(new BitmapTileLayer(mMap, tileSource));
 
-        Bitmap bitmapPoi = drawableToBitmap(getResources().getDrawable(R.drawable.marker_poi));
+        Bitmap bitmapPoi = new AndroidBitmap(BitmapFactory.decodeResource(getResources(), R.drawable.marker_poi));
         MarkerSymbol symbol;
         if (BILLBOARDS)
             symbol = new MarkerSymbol(bitmapPoi, HotspotPlace.BOTTOM_CENTER);
         else
             symbol = new MarkerSymbol(bitmapPoi, HotspotPlace.CENTER, false);
 
-        Bitmap bitmapFocus = drawableToBitmap(getResources().getDrawable(R.drawable.marker_focus));
+        Bitmap bitmapFocus = new AndroidBitmap(BitmapFactory.decodeResource(getResources(), R.drawable.marker_focus));
         if (BILLBOARDS)
             mFocusMarker = new MarkerSymbol(bitmapFocus, HotspotPlace.BOTTOM_CENTER);
         else

--- a/vtm-android-example/src/org/oscim/android/test/PoiSearchActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/PoiSearchActivity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 devemux86
+ * Copyright 2017-2019 devemux86
  * Copyright 2018 Gustl22
  *
  * This program is free software: you can redistribute it and/or modify it under the
@@ -17,6 +17,7 @@ package org.oscim.android.test;
 
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.BitmapFactory;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Editable;
@@ -25,20 +26,11 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
-import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ListView;
-import android.widget.Toast;
-import android.widget.ToggleButton;
-
+import android.widget.*;
 import org.mapsforge.core.model.Tag;
 import org.mapsforge.poi.android.storage.AndroidPoiPersistenceManagerFactory;
-import org.mapsforge.poi.storage.ExactMatchPoiCategoryFilter;
-import org.mapsforge.poi.storage.PoiCategoryFilter;
-import org.mapsforge.poi.storage.PoiCategoryManager;
-import org.mapsforge.poi.storage.PoiPersistenceManager;
-import org.mapsforge.poi.storage.PointOfInterest;
+import org.mapsforge.poi.storage.*;
+import org.oscim.android.canvas.AndroidBitmap;
 import org.oscim.android.filepicker.FilePicker;
 import org.oscim.android.filepicker.FilterByFileExtension;
 import org.oscim.backend.canvas.Bitmap;
@@ -59,8 +51,6 @@ import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static org.oscim.android.canvas.AndroidGraphics.drawableToBitmap;
 
 /**
  * POI search.<br/>
@@ -162,7 +152,7 @@ public class PoiSearchActivity extends MapsforgeActivity implements ItemizedLaye
             String file = intent.getStringExtra(FilePicker.SELECTED_FILE);
             mPersistenceManager = AndroidPoiPersistenceManagerFactory.getPoiPersistenceManager(file);
 
-            Bitmap bitmap = drawableToBitmap(getResources().getDrawable(R.drawable.marker_green));
+            Bitmap bitmap = new AndroidBitmap(BitmapFactory.decodeResource(getResources(), R.drawable.marker_green));
             MarkerSymbol symbol = new MarkerSymbol(bitmap, MarkerSymbol.HotspotPlace.BOTTOM_CENTER);
             mMarkerLayer = new ItemizedLayer<>(mMap, new ArrayList<MarkerItem>(), symbol, this);
             mMap.layers().add(mMarkerLayer);

--- a/vtm-android/src/org/oscim/android/canvas/AndroidGraphics.java
+++ b/vtm-android/src/org/oscim/android/canvas/AndroidGraphics.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2010, 2011, 2012 mapsforge.org
- * Copyright 2016-2018 devemux86
+ * Copyright 2016-2019 devemux86
  * Copyright 2017 Longri
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
@@ -22,7 +22,7 @@ import android.content.res.Resources;
 import android.graphics.Bitmap.Config;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-
+import android.os.Build;
 import org.oscim.backend.CanvasAdapter;
 import org.oscim.backend.Platform;
 import org.oscim.backend.canvas.Bitmap;
@@ -90,7 +90,7 @@ public final class AndroidGraphics extends CanvasAdapter {
 
     //-------------------------------------
     public static Bitmap drawableToBitmap(Drawable drawable) {
-        if (drawable instanceof BitmapDrawable) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P && drawable instanceof BitmapDrawable) {
             return new AndroidBitmap(((BitmapDrawable) drawable).getBitmap());
         }
 


### PR DESCRIPTION
Seems a problem at drawables to bitmaps conversion on newer Android (`BitmapDrawable.getBitmap`).
We could use a simpler bitmap read and avoid all that code workarounds.

See https://github.com/mapsforge/mapsforge/issues/1138