### PR TITLE
Mapsforge: reduce points on-the-fly while reading from map files

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -5,6 +5,8 @@
 - Render themes: symbols on lines with billboard / rotation [#743](https://github.com/mapsforge/vtm/pull/743)
 - Location texture renderer: rewrite and optimize [#750](https://github.com/mapsforge/vtm/pull/750)
 - Mapsforge: fix ways precision loss [#752](https://github.com/mapsforge/vtm/pull/752)
+- Mapsforge: additional simplification [#757](https://github.com/mapsforge/vtm/pull/757)
+  - `Parameters.SIMPLIFICATION`
 - Android: OpenGL ES 2.0 default for performance / stability [#749](https://github.com/mapsforge/vtm/pull/749)
   - `MapView.OPENGL_VERSION`
 - Android: threaded system initialization

--- a/vtm/src/org/oscim/utils/Parameters.java
+++ b/vtm/src/org/oscim/utils/Parameters.java
@@ -63,6 +63,11 @@ public final class Parameters {
     public static boolean POT_TEXTURES = false;
 
     /**
+     * Reduce points on-the-fly while reading from map files.
+     */
+    public static boolean SIMPLIFICATION = false;
+
+    /**
      * Texture atlas in themes.
      */
     public static boolean TEXTURE_ATLAS = false;


### PR DESCRIPTION
Heavy maps like Germany or Netherlands can have performance issues in 2nd zoom interval (8-11).

Can offer an option to reduce points on-the-fly while reading from map files, without serious data loss.