### PR TITLE
Fix stroke cap line ending

### DIFF
--- a/docs/Changelog.md
+++ b/docs/Changelog.md
@@ -4,6 +4,7 @@
 
 - Render themes: symbols on lines with billboard / rotation [#743](https://github.com/mapsforge/vtm/pull/743)
 - Location texture renderer: rewrite and optimize [#750](https://github.com/mapsforge/vtm/pull/750)
+- Fix stroke cap line ending [#758](https://github.com/mapsforge/vtm/pull/758)
 - Mapsforge: fix ways precision loss [#752](https://github.com/mapsforge/vtm/pull/752)
 - Mapsforge: additional simplification [#757](https://github.com/mapsforge/vtm/pull/757)
   - `Parameters.SIMPLIFICATION_TOLERANCE`

--- a/vtm/src/org/oscim/renderer/bucket/LineBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/LineBucket.java
@@ -1,6 +1,6 @@
 /*
  * Copyright 2013 Hannes Janetzek
- * Copyright 2016-2017 devemux86
+ * Copyright 2016-2019 devemux86
  *
  * This file is part of the OpenScienceMap project (http://www.opensciencemap.org).
  *
@@ -678,7 +678,7 @@ public class LineBucket extends RenderBucket {
                     }
 
                     /* Cap mode */
-                    if (lb.scale < 1.5/* || lb.line.fixed*/) {
+                    if (lb.scale < 1.0) {
                         if (capMode != CAP_THIN) {
                             capMode = CAP_THIN;
                             gl.uniform1i(uLineMode, capMode);


### PR DESCRIPTION
Should now work globally for render themes and path layers.

See #107