### PR TITLE
MapScaleBarLayer: add onDetach-method to free resources automatically

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/GettingStarted.java
+++ b/vtm-android-example/src/org/oscim/android/test/GettingStarted.java
@@ -42,7 +42,6 @@ public class GettingStarted extends Activity {
     private static final String MAP_FILE = "berlin.map";
 
     private MapView mapView;
-    private MapScaleBar mapScaleBar;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -69,7 +68,7 @@ public class GettingStarted extends Activity {
             mapView.map().setTheme(VtmThemes.DEFAULT);
 
             // Scale bar
-            mapScaleBar = new DefaultMapScaleBar(mapView.map());
+            MapScaleBar mapScaleBar = new DefaultMapScaleBar(mapView.map());
             MapScaleBarLayer mapScaleBarLayer = new MapScaleBarLayer(mapView.map(), mapScaleBar);
             mapScaleBarLayer.getRenderer().setPosition(GLViewport.Position.BOTTOM_LEFT);
             mapScaleBarLayer.getRenderer().setOffset(5 * CanvasAdapter.getScale(), 0);
@@ -94,8 +93,6 @@ public class GettingStarted extends Activity {
 
     @Override
     protected void onDestroy() {
-        if (mapScaleBar != null)
-            mapScaleBar.destroy();
         mapView.onDestroy();
         super.onDestroy();
     }

--- a/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
@@ -65,7 +65,6 @@ public class MapsforgeActivity extends MapActivity {
     private static final Tag SEA_TAG = new Tag("natural", "sea");
 
     private TileGridLayer mGridLayer;
-    private DefaultMapScaleBar mMapScaleBar;
     private Menu mMenu;
     private boolean mS3db;
     private VectorTileLayer mTileLayer;
@@ -91,14 +90,6 @@ public class MapsforgeActivity extends MapActivity {
 
         startActivityForResult(new Intent(this, MapFilePicker.class),
                 SELECT_MAP_FILE);
-    }
-
-    @Override
-    protected void onDestroy() {
-        if (mMapScaleBar != null)
-            mMapScaleBar.destroy();
-
-        super.onDestroy();
     }
 
     public static class MapFilePicker extends FilePicker {
@@ -197,7 +188,7 @@ public class MapsforgeActivity extends MapActivity {
                     mMap.layers().add(new BuildingLayer(mMap, mTileLayer));
                 mMap.layers().add(new LabelLayer(mMap, mTileLayer));
 
-                mMapScaleBar = new DefaultMapScaleBar(mMap);
+                DefaultMapScaleBar mMapScaleBar = new DefaultMapScaleBar(mMap);
                 mMapScaleBar.setScaleBarMode(DefaultMapScaleBar.ScaleBarMode.BOTH);
                 mMapScaleBar.setDistanceUnitAdapter(MetricUnitAdapter.INSTANCE);
                 mMapScaleBar.setSecondaryDistanceUnitAdapter(ImperialUnitAdapter.INSTANCE);

--- a/vtm-android-example/src/org/oscim/android/test/SimpleMapActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/SimpleMapActivity.java
@@ -38,7 +38,6 @@ import org.oscim.theme.ThemeLoader;
 import org.oscim.theme.VtmThemes;
 
 public class SimpleMapActivity extends BaseMapActivity {
-    private DefaultMapScaleBar mapScaleBar;
 
     BuildingLayer mBuildingLayer;
     private boolean mShadow;
@@ -71,7 +70,7 @@ public class SimpleMapActivity extends BaseMapActivity {
         groupLayer.layers.add(new LabelLayer(mMap, mBaseLayer));
         mMap.layers().add(groupLayer);
 
-        mapScaleBar = new DefaultMapScaleBar(mMap);
+        DefaultMapScaleBar mapScaleBar = new DefaultMapScaleBar(mMap);
         mapScaleBar.setScaleBarMode(DefaultMapScaleBar.ScaleBarMode.BOTH);
         mapScaleBar.setDistanceUnitAdapter(MetricUnitAdapter.INSTANCE);
         mapScaleBar.setSecondaryDistanceUnitAdapter(ImperialUnitAdapter.INSTANCE);
@@ -84,14 +83,6 @@ public class SimpleMapActivity extends BaseMapActivity {
         mMap.layers().add(mapScaleBarLayer);
 
         mMap.setTheme(VtmThemes.DEFAULT);
-    }
-
-    @Override
-    protected void onDestroy() {
-        if (mapScaleBar != null)
-            mapScaleBar.destroy();
-
-        super.onDestroy();
     }
 
     void runTheMonkey() {

--- a/vtm/src/org/oscim/scalebar/MapScaleBarLayer.java
+++ b/vtm/src/org/oscim/scalebar/MapScaleBarLayer.java
@@ -62,4 +62,10 @@ public class MapScaleBarLayer extends Layer implements Map.UpdateListener {
 
         mapScaleBar.redrawNeeded = false;
     }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+        mapScaleBar.destroy();
+    }
 }


### PR DESCRIPTION
add onDetach-method to MapScaleBarLayer to free resources automatically
removed mapScaleBar.destroy() methods from onDestroy-Activity methods
changed global mapScaleBar-variables to local