### PR TITLE
ViewController: allow rotation around map view center

### DIFF
--- a/vtm/src/org/oscim/map/ViewController.java
+++ b/vtm/src/org/oscim/map/ViewController.java
@@ -22,6 +22,7 @@ package org.oscim.map;
 
 import org.oscim.core.MapPosition;
 import org.oscim.core.Point;
+import org.oscim.core.PointF;
 import org.oscim.core.Tile;
 import org.oscim.renderer.GLMatrix;
 import org.oscim.utils.FastMath;
@@ -227,9 +228,6 @@ public class ViewController extends Viewport {
 
         double rsin = Math.sin(radians);
         double rcos = Math.cos(radians);
-
-        pivotX = mPivotX + pivotX;
-        pivotY = mPivotY + pivotY;
 
         float x = (float) (pivotX - pivotX * rcos + pivotY * rsin);
         float y = (float) (pivotY - pivotX * rsin - pivotY * rcos);

--- a/vtm/src/org/oscim/map/ViewController.java
+++ b/vtm/src/org/oscim/map/ViewController.java
@@ -229,6 +229,11 @@ public class ViewController extends Viewport {
         double rsin = Math.sin(radians);
         double rcos = Math.cos(radians);
 
+        if (pivotX != 0f && pivotY != 0f) {
+            pivotX -= mWidth * mPivotX;
+            pivotY -= mHeight * mPivotY;
+        }
+
         float x = (float) (pivotX - pivotX * rcos + pivotY * rsin);
         float y = (float) (pivotY - pivotX * rsin - pivotY * rcos);
 

--- a/vtm/src/org/oscim/map/ViewController.java
+++ b/vtm/src/org/oscim/map/ViewController.java
@@ -228,15 +228,14 @@ public class ViewController extends Viewport {
         double rsin = Math.sin(radians);
         double rcos = Math.cos(radians);
 
-        pivotX -= mWidth * mPivotX;
-        pivotY -= mHeight * mPivotY;
+        pivotX = mPivotX + pivotX;
+        pivotY = mPivotY + pivotY;
 
         float x = (float) (pivotX - pivotX * rcos + pivotY * rsin);
         float y = (float) (pivotY - pivotX * rsin - pivotY * rcos);
 
-        moveMap(x, y);
-
         setRotation(mPos.bearing + Math.toDegrees(radians));
+        moveMap(x, y);
     }
 
     public void setRotation(double degree) {


### PR DESCRIPTION
Fixing the issue, that when the map center is changed by `ViewController#setMapViewCenter(float, float)` to other than [0,0] the map will still rotate around the original [0,0] coordinate, leading to very weird rotation behavior, because the map will slowly circle away from its current viewport as you rotate it.

 