### PR TITLE
android-examples: demonstrate usage of VectorTileLayer.getTileSource()

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/MapsforgeActivity.java
@@ -67,8 +67,7 @@ public class MapsforgeActivity extends MapActivity {
     private TileGridLayer mGridLayer;
     private Menu mMenu;
     private boolean mS3db;
-    private VectorTileLayer mTileLayer;
-    MapFileTileSource mTileSource;
+    VectorTileLayer mTileLayer;
 
     public MapsforgeActivity() {
         this(false);
@@ -174,7 +173,7 @@ public class MapsforgeActivity extends MapActivity {
                 return;
             }
 
-            mTileSource = new MapFileTileSource();
+            MapFileTileSource mTileSource = new MapFileTileSource();
             //mTileSource.setPreferredLanguage("en");
             String file = intent.getStringExtra(FilePicker.SELECTED_FILE);
             if (mTileSource.setMapFile(file)) {

--- a/vtm-android-example/src/org/oscim/android/test/PoiSearchActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/PoiSearchActivity.java
@@ -138,7 +138,7 @@ public class PoiSearchActivity extends MapsforgeActivity implements ItemizedLaye
         super.onActivityResult(requestCode, resultCode, intent);
 
         if (requestCode == SELECT_MAP_FILE) {
-            if (mTileSource != null)
+            if (mTileLayer.getTileSource() != null)
                 startActivityForResult(new Intent(this, PoiFilePicker.class),
                         SELECT_POI_FILE);
             else

--- a/vtm-android-example/src/org/oscim/android/test/ReverseGeocodeActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/ReverseGeocodeActivity.java
@@ -97,7 +97,7 @@ public class ReverseGeocodeActivity extends MapsforgeActivity {
                 int tileYMax = MercatorProjection.pixelYToTileY(pixelY + touchRadius, (byte) mMap.getMapPosition().getZoomLevel());
                 Tile upperLeft = new Tile(tileXMin, tileYMin, (byte) mMap.getMapPosition().getZoomLevel());
                 Tile lowerRight = new Tile(tileXMax, tileYMax, (byte) mMap.getMapPosition().getZoomLevel());
-                MapReadResult mapReadResult = ((MapDatabase) ((OverzoomTileDataSource) mTileSource.getDataSource()).getDataSource()).readLabels(upperLeft, lowerRight);
+                MapReadResult mapReadResult = ((MapDatabase) ((OverzoomTileDataSource) mTileLayer.getTileSource().getDataSource()).getDataSource()).readLabels(upperLeft, lowerRight);
 
                 StringBuilder sb = new StringBuilder();
 


### PR DESCRIPTION
small improvements to android-examples, reducing necessary global variables and demonstrating the  VectorTileLayer.getTileSource()-method