### PR TITLE
Add EventDispatcher::clear

### DIFF
--- a/vtm/src/org/oscim/event/EventDispatcher.java
+++ b/vtm/src/org/oscim/event/EventDispatcher.java
@@ -66,4 +66,11 @@ public abstract class EventDispatcher<E extends EventListener, T> {
             tell(l.data, event, data);
         }
     }
+
+    /**
+     * Remove all listeners.
+     */
+    public void clear() {
+        mListeners = null;
+    }
 }


### PR DESCRIPTION
Hi!

I'm reusing a single `MapView` in my app, but to clear it completely it's necessary to remove the `EventListener`s as well. Using `EventDispatcher::unbind` is not very convenient, because it requires  keeping the old listeners around.