### PR TITLE
fixing issue with drawing elements with false style

### DIFF
--- a/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
@@ -201,11 +201,11 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
 
             for (Drawable d : tmpDrawables) {
                 Style style = d.getStyle();
-                draw(t, level, d, style);
 
-                if (style != lastStyle)
+                if (lastStyle != null && lastStyle != style)
                     level += 2;
 
+                draw(t, level, d, style);
                 lastStyle = style;
             }
         }


### PR DESCRIPTION
When the style of the drawable has changed the level needs to adjusted before draw(...) is called - in any other case the you have the risk, that the false style will be applied to the drawable [since the false bucket (with wrong style) will be returned when calling t.buckets.get{.*}Bucket(level)]

In my project (GPSLogger) I had the render a path where different segments should have a different color - I came across a bug, that at certain conditions the path segments switched their color (the one that should had been blue was green and vise versa - or all segments have been just green or just blue) - depending on the order I add my LineDrawables in my modified setLineString(...) method.

At the end of the day I found that in the common base class (VectorLayer) the detection IF the style has been changed is called "too late" - it have to be called before the draw (and not after) - yes this implies the additional null check for lastStyle... As alternative you can init _level_ with -2 (which is not very intuitive)