### PR TITLE
Use `org.gretty` instead of `org.akhikhl.gretty` maven repository

### DIFF
--- a/vtm-web-app/build.gradle
+++ b/vtm-web-app/build.gradle
@@ -4,13 +4,13 @@ buildscript {
     }
     dependencies {
         classpath 'org.wisepersist:gwt-gradle-plugin:1.0.13'
-        classpath 'org.akhikhl.gretty:gretty:2.0.0'
+        classpath 'org.gretty:gretty:3.0.3'
     }
 }
 
 apply plugin: 'gwt'
 apply plugin: 'war'
-apply plugin: 'org.akhikhl.gretty'
+apply plugin: 'org.gretty'
 
 sourceSets {
     main.java.srcDirs = ['src']


### PR DESCRIPTION
Related to #774 

Vtm was using `org.akhikhl.gretty:gretty:2.0.0` instead of `org.gretty:gretty:2.X.X`. It was because `org.gretty:gretty:2.X.X` caused strange build errors in the past.

I tried running the latest web version demo with `./gradlew :vtm-web-app:farmRun` using openjdk version "1.8.0_265", and got the following exception message.
>    Exception in thread "Thread-93" java.lang.IllegalStateException: The configuration :vtm-web-app:grettyNoSpringBoot was resolved from a thread not managed by Gradle.

This seems to be an issue caused by gradle wrapper version upgrade, described in the link below.
https://stackoverflow.com/questions/60793045/gradle-guides-building-java-web-application-gradle-build-throwing-java-lang-i
I thought it doesn't make sense to downgrade gradle wrapper, I also tried `org.gretty:gretty:3.0.3` and had no build errors like before. This pull request applies the modification.

By the way, opensciencemap.org isn't serving tile data anymore. I tested this modification using a cache proxy server I host by my own.