### PR TITLE
Use --release=7 for compiling the non-android libraries on Java >= 9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,5 +50,10 @@ subprojects {
         sourceCompatibility = JavaVersion.VERSION_1_7
         targetCompatibility = JavaVersion.VERSION_1_7
         options.encoding = 'UTF-8'
+        if (JavaVersion.current().isJava9Compatible()) {
+            if (!project.properties.containsKey('android')) {
+                options.compilerArgs.addAll(['--release', '7'])
+            }
+        }
     }
 }


### PR DESCRIPTION
See https://github.com/mapsforge/mapsforge/pull/1182.