### PR TITLE
[libGDX] 1.9.10 -> 1.11.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ allprojects {
     group = 'org.mapsforge'
     version = 'master-SNAPSHOT'
 
-    ext.gdxVersion = "1.9.10"
+    ext.gdxVersion = "1.11.0"
     ext.gwtVersion = "2.8.2"
     ext.slf4jVersion = "1.7.28"
 
@@ -32,12 +32,12 @@ def versionName() { return version }
 
 subprojects {
     tasks.withType(JavaCompile) {
-        sourceCompatibility = JavaVersion.VERSION_1_7
-        targetCompatibility = JavaVersion.VERSION_1_7
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
         options.encoding = 'UTF-8'
         if (JavaVersion.current().isJava9Compatible()) {
             if (!project.properties.containsKey('android')) {
-                options.compilerArgs.addAll(['--release', '7'])
+                options.compilerArgs.addAll(['--release', '8'])
             }
         }
     }

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelRenderer.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxModelRenderer.java
@@ -60,7 +60,7 @@ public class GdxModelRenderer extends LayerRenderer {
         cam = new MapCamera(mMap);
 
         renderContext =
-                new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.WEIGHTED, 1));
+                new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.LRU, 1));
 
         // shader = new DefaultShader(renderable.material,
         // renderable.mesh.getVertexAttributes(), true, false, 1, 0, 0, 0);

--- a/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxRenderer3D.java
+++ b/vtm-gdx-poi3d/src/org/oscim/gdx/poi3d/GdxRenderer3D.java
@@ -61,7 +61,7 @@ public class GdxRenderer3D extends LayerRenderer {
         cam = new MapCamera(mMap);
 
         renderContext =
-                new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.WEIGHTED, 1));
+                new RenderContext(new DefaultTextureBinder(DefaultTextureBinder.LRU, 1));
 
         // shader = new DefaultShader(renderable.material,
         // renderable.mesh.getVertexAttributes(), true, false, 1, 0, 0, 0);

--- a/vtm-gdx/src/org/oscim/gdx/InputHandler.java
+++ b/vtm-gdx/src/org/oscim/gdx/InputHandler.java
@@ -255,10 +255,10 @@ public class InputHandler implements InputProcessor {
     }
 
     @Override
-    public boolean scrolled(int amount) {
+    public boolean scrolled(float amountX, float amountY) {
         float fx = mPosX - mMap.getWidth() / 2;
         float fy = mPosY - mMap.getHeight() / 2;
-        mMap.animator().animateZoom(250, amount > 0 ? 0.75f : 1.333f, fx, fy, Easing.Type.LINEAR);
+        mMap.animator().animateZoom(250, amountY > 0 ? 0.75f : 1.333f, fx, fy, Easing.Type.LINEAR);
         mMap.updateMap(false);
         return true;
     }
@@ -276,4 +276,5 @@ public class InputHandler implements InputProcessor {
         }
         return false;
     }
+
 }

--- a/vtm-gdx/src/org/oscim/gdx/MotionHandler.java
+++ b/vtm-gdx/src/org/oscim/gdx/MotionHandler.java
@@ -211,7 +211,7 @@ public class MotionHandler extends MotionEvent implements InputProcessor {
     }
 
     @Override
-    public boolean scrolled(int amount) {
+    public boolean scrolled(float amountX, float amountY) {
         mTime = Gdx.input.getCurrentEventTime();
 
         return false;

--- a/vtm-theme-comparator/src/org/oscim/theme/comparator/vtm/MapApplicationAdapter.java
+++ b/vtm-theme-comparator/src/org/oscim/theme/comparator/vtm/MapApplicationAdapter.java
@@ -135,10 +135,10 @@ public class MapApplicationAdapter extends ApplicationAdapter {
         InputMultiplexer mux = new InputMultiplexer();
         mux.addProcessor(new MotionHandler(map) {
             @Override
-            public boolean scrolled(int amount) {
-                super.scrolled(amount);
+            public boolean scrolled(float amountX, float amountY) {
+                super.scrolled(amountX, amountY);
                 MapPosition mapPosition = map.getMapPosition();
-                int zoomLevel = mapPosition.getZoomLevel() - amount;
+                int zoomLevel = (int) (mapPosition.getZoomLevel() - amountY);
                 mapPosition.setZoomLevel(zoomLevel);
                 map.setMapPosition(mapPosition);
                 bothMapPositionHandler.mapPositionChangedFromVtmMap(mapPosition);


### PR DESCRIPTION
This PR contains modifications to run VTM with libGDX 1.11.0

I've tested `org.oscim.test.MapsforgeTest` with Windows 10 sucessfully, it also worked in my project MyTourbook with Windows and Linux

This was the `settings.gradle` which I used to build it, I disabled all includes which I cannot test/build. I use this modified setup also in my project.

I think, that porting to the other platforms should not be much work

![image](https://user-images.githubusercontent.com/1283445/201536645-5140113e-a870-4b55-baad-432d1edbff56.png)
