### PR TITLE
Throw exception on missing envvar for Android-related builds

### DIFF
--- a/vtm-android-example/build.gradle
+++ b/vtm-android-example/build.gradle
@@ -85,3 +85,7 @@ task run(dependsOn: 'installDebug') {
         proc.waitFor()
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}

--- a/vtm-android-gdx/build.gradle
+++ b/vtm-android-gdx/build.gradle
@@ -34,3 +34,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}

--- a/vtm-android-mvt/build.gradle
+++ b/vtm-android-mvt/build.gradle
@@ -24,3 +24,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}

--- a/vtm-android/build.gradle
+++ b/vtm-android/build.gradle
@@ -34,3 +34,7 @@ if (project.hasProperty("SONATYPE_USERNAME")) {
         project.apply from: "${rootProject.projectDir}/deploy.gradle"
     }
 }
+
+if (System.getenv('ANDROID_HOME') == null) {
+    throw new GradleException("Environment variable ANDROID_HOME needs to be set to SDK folder")
+}


### PR DESCRIPTION
Throw a gradle exception during build, if the required environment variable "ANDROID_HOME" is undefined
(only applies to Android-related builds)