### PR TITLE
Updated external library versions in vtm-web to support gradle 8

### DIFF
--- a/vtm-web-app/build.gradle
+++ b/vtm-web-app/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'org.wisepersist:gwt-gradle-plugin:1.1.15'
-        classpath 'org.gretty:gretty:4.0.0'
+        classpath 'org.wisepersist:gwt-gradle-plugin:1.1.19'
+        classpath 'org.gretty:gretty:4.0.3'
     }
 }
 
@@ -59,7 +59,7 @@ gwt {
 }
 
 farm {
-    webapp draftWar.archivePath, contextPath: "/$name"
+    webapp draftWar.getArchiveFile().get(), contextPath: "/$name"
 }
 
 project.afterEvaluate {

--- a/vtm-web/build.gradle
+++ b/vtm-web/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'org.wisepersist:gwt-gradle-plugin:1.1.15'
+        classpath 'org.wisepersist:gwt-gradle-plugin:1.1.19'
     }
 }
 


### PR DESCRIPTION
Deprecated properties in Gradle 8 are making `vtm-web-app` build fail. Upgraded gwt-gradle-plugin and gretty.