### PR TITLE
DO NOT MERGE Example: thick semitransparent crossing polyline in example VectorLayerActivity

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
@@ -19,8 +19,14 @@ package org.oscim.android.test;
 
 import android.os.Bundle;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.oscim.backend.canvas.Color;
+import org.oscim.backend.canvas.Paint;
+import org.oscim.core.GeoPoint;
 import org.oscim.layers.vector.VectorLayer;
+import org.oscim.layers.vector.geometries.LineDrawable;
 import org.oscim.layers.vector.geometries.PointDrawable;
 import org.oscim.layers.vector.geometries.Style;
 import org.oscim.utils.ColorUtil;
@@ -84,9 +90,29 @@ public class VectorLayerActivity extends BitmapTileActivity {
                     style));
 
         }
+        addThickSemitransparentPolyline(vectorLayer);
+
         vectorLayer.update();
 
         mMap.layers().add(vectorLayer);
+    }
+
+    private void addThickSemitransparentPolyline(VectorLayer vectorLayer) {
+        final Style style = Style.builder()
+            .strokeWidth(100f)
+            .strokeColor(Color.setA(Color.BLUE, 127))
+            .cap(Paint.Cap.ROUND)
+            .fixed(true)
+            .build();
+
+        //create a polyline in Hamburg, Germany
+        final List<GeoPoint> points = Arrays.asList(
+            new GeoPoint(53.5334, 10.069833),new GeoPoint(53.5419, 10.09075),new GeoPoint(53.53745, 10.091017),new GeoPoint(53.54105, 10.0928),new GeoPoint(53.536721, 10.09416),new GeoPoint(53.5406, 10.08365)
+        );
+
+        final LineDrawable line = new LineDrawable(points, style);
+
+        vectorLayer.add(line);
     }
 
     @Override


### PR DESCRIPTION
Example: thick semitransparent crossing polyline in example VectorLayerActivity

This PR is NOT intended for merge! It gives an example for a problem we're facing in c:geo. 

PR adds a polyline in the region of Hamburg/Germany to the android example VectorLayerActivity with following properties:
* it has  angles and crosses itself 
* it has a very wide strokewidth 
* it has a semi-transparent stroke color

This produces a polyline with "too solid" look on regions with sharp edges. Also, the polyline is very big even in the overview.

Question is: what are we doing wrong, and how do we have to adapt settings (maybe style?) to get rid of the overlaps?

Screenshot overview (the big blue dot is the polyine in hamburg):
![image](https://github.com/mapsforge/vtm/assets/6909759/70877127-2ff1-457f-aa83-f150bdc2769a)

Screenshot zoomed closer to polyline:
![image](https://github.com/mapsforge/vtm/assets/6909759/c89a1499-0837-42a6-927f-8b116d317520)

Screenshot very close to polyline:
![image](https://github.com/mapsforge/vtm/assets/6909759/375623c9-9159-4413-9a28-2dba4ee9a2d3)




