### PR TITLE
VTM Style: allow adding dropDistance directly (related to #1082)

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
@@ -83,32 +83,32 @@ public class VectorLayerActivity extends BitmapTileActivity {
 
     private void addRandomCircles(VectorLayer vectorLayer) {
         Style.Builder sb = Style.builder()
-            .buffer(0.5)
-            .fillColor(Color.RED)
-            .fillAlpha(0.2f);
+                .buffer(0.5)
+                .fillColor(Color.RED)
+                .fillAlpha(0.2f);
 
         for (int i = 0; i < 2000; i++) {
             Style style = sb.buffer(Math.random() + 0.2)
-                .fillColor(ColorUtil.setHue(Color.RED,
-                    (int) (Math.random() * 50) / 50.0))
-                .fillAlpha(0.5f)
-                .build();
+                    .fillColor(ColorUtil.setHue(Color.RED,
+                            (int) (Math.random() * 50) / 50.0))
+                    .fillAlpha(0.5f)
+                    .build();
 
             vectorLayer.add(new PointDrawable(Math.random() * 180 - 90,
-                Math.random() * 360 - 180,
-                style));
+                    Math.random() * 360 - 180,
+                    style));
 
         }
     }
 
     private void addThickSemitransparentPolyline(VectorLayer vectorLayer) {
         final Style style = Style.builder()
-            .strokeWidth(20f)
-            .strokeColor(Color.setA(Color.BLUE, 127))
-            .cap(Paint.Cap.BUTT)
-            .pointReduction(10f)
-            .fixed(true)
-            .build();
+                .strokeWidth(20f)
+                .strokeColor(Color.setA(Color.BLUE, 127))
+                .cap(Paint.Cap.BUTT)
+                .dropDistance(10f)
+                .fixed(true)
+                .build();
 
         //create a polyline in Hamburg, Germany
         final List<GeoPoint> points = Arrays.asList(

--- a/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
@@ -19,8 +19,14 @@ package org.oscim.android.test;
 
 import android.os.Bundle;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.oscim.backend.canvas.Color;
+import org.oscim.backend.canvas.Paint;
+import org.oscim.core.GeoPoint;
 import org.oscim.layers.vector.VectorLayer;
+import org.oscim.layers.vector.geometries.LineDrawable;
 import org.oscim.layers.vector.geometries.PointDrawable;
 import org.oscim.layers.vector.geometries.Style;
 import org.oscim.utils.ColorUtil;
@@ -67,26 +73,52 @@ public class VectorLayerActivity extends BitmapTileActivity {
         //        }
         //    }
 
-        Style.Builder sb = Style.builder()
-                .buffer(0.5)
-                .fillColor(Color.RED)
-                .fillAlpha(0.2f);
+        addRandomCircles(vectorLayer);
+        addThickSemitransparentPolyline(vectorLayer);
 
-        for (int i = 0; i < 2000; i++) {
-            Style style = sb.buffer(Math.random() + 0.2)
-                    .fillColor(ColorUtil.setHue(Color.RED,
-                            (int) (Math.random() * 50) / 50.0))
-                    .fillAlpha(0.5f)
-                    .build();
-
-            vectorLayer.add(new PointDrawable(Math.random() * 180 - 90,
-                    Math.random() * 360 - 180,
-                    style));
-
-        }
         vectorLayer.update();
 
         mMap.layers().add(vectorLayer);
+    }
+
+    private void addRandomCircles(VectorLayer vectorLayer) {
+        Style.Builder sb = Style.builder()
+            .buffer(0.5)
+            .fillColor(Color.RED)
+            .fillAlpha(0.2f);
+
+        for (int i = 0; i < 2000; i++) {
+            Style style = sb.buffer(Math.random() + 0.2)
+                .fillColor(ColorUtil.setHue(Color.RED,
+                    (int) (Math.random() * 50) / 50.0))
+                .fillAlpha(0.5f)
+                .build();
+
+            vectorLayer.add(new PointDrawable(Math.random() * 180 - 90,
+                Math.random() * 360 - 180,
+                style));
+
+        }
+    }
+
+    private void addThickSemitransparentPolyline(VectorLayer vectorLayer) {
+        final Style style = Style.builder()
+            .strokeWidth(20f)
+            .strokeColor(Color.setA(Color.BLUE, 127))
+            .cap(Paint.Cap.BUTT)
+            .pointReduction(10f)
+            .fixed(true)
+            .build();
+
+        //create a polyline in Hamburg, Germany
+        final List<GeoPoint> points = Arrays.asList(
+            new GeoPoint(53.5334, 10.069833),new GeoPoint(53.5419, 10.09075),new GeoPoint(53.53745, 10.091017),new GeoPoint(53.54105, 10.0928),new GeoPoint(53.536721, 10.09416),
+            new GeoPoint(53.5406, 10.08365), new GeoPoint(53.5406, 11.0)
+        );
+
+        final LineDrawable line = new LineDrawable(points, style);
+
+        vectorLayer.add(line);
     }
 
     @Override

--- a/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
+++ b/vtm-android-example/src/org/oscim/android/test/VectorLayerActivity.java
@@ -18,10 +18,6 @@
 package org.oscim.android.test;
 
 import android.os.Bundle;
-
-import java.util.Arrays;
-import java.util.List;
-
 import org.oscim.backend.canvas.Color;
 import org.oscim.backend.canvas.Paint;
 import org.oscim.core.GeoPoint;
@@ -30,6 +26,9 @@ import org.oscim.layers.vector.geometries.LineDrawable;
 import org.oscim.layers.vector.geometries.PointDrawable;
 import org.oscim.layers.vector.geometries.Style;
 import org.oscim.utils.ColorUtil;
+
+import java.util.Arrays;
+import java.util.List;
 
 public class VectorLayerActivity extends BitmapTileActivity {
 
@@ -112,8 +111,8 @@ public class VectorLayerActivity extends BitmapTileActivity {
 
         //create a polyline in Hamburg, Germany
         final List<GeoPoint> points = Arrays.asList(
-            new GeoPoint(53.5334, 10.069833),new GeoPoint(53.5419, 10.09075),new GeoPoint(53.53745, 10.091017),new GeoPoint(53.54105, 10.0928),new GeoPoint(53.536721, 10.09416),
-            new GeoPoint(53.5406, 10.08365), new GeoPoint(53.5406, 11.0)
+                new GeoPoint(53.5334, 10.069833), new GeoPoint(53.5419, 10.09075), new GeoPoint(53.53745, 10.091017), new GeoPoint(53.54105, 10.0928), new GeoPoint(53.536721, 10.09416),
+                new GeoPoint(53.5406, 10.08365), new GeoPoint(53.5406, 11.0)
         );
 
         final LineDrawable line = new LineDrawable(points, style);

--- a/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
@@ -257,7 +257,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
         LineBucket ll = t.buckets.getLineBucket(level + 1);
         if (ll.line == null) {
             ll.line = new LineStyle(2, style.strokeColor, style.strokeWidth);
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : 0);
+            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
         }
 
         for (int i = 0; i < points.getNumGeometries(); i++) {
@@ -296,7 +296,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
                     .strokeWidth(style.strokeWidth)
                     .texture(style.texture)
                     .build();
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : 0);
+            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
             if (ll instanceof LineTexBucket)
                 ((LineTexBucket) ll).setTexRepeat(style.textureRepeat);
         }
@@ -330,7 +330,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
         LineBucket ll = t.buckets.getLineBucket(level + 1);
         if (ll.line == null) {
             ll.line = new LineStyle(2, style.strokeColor, style.strokeWidth);
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : 0);
+            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
         }
 
         if (style.generalization != Style.GENERALIZATION_NONE) {

--- a/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
+++ b/vtm-jts/src/org/oscim/layers/vector/VectorLayer.java
@@ -257,7 +257,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
         LineBucket ll = t.buckets.getLineBucket(level + 1);
         if (ll.line == null) {
             ll.line = new LineStyle(2, style.strokeColor, style.strokeWidth);
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
+            ll.setDropDistance(style.dropDistance);
         }
 
         for (int i = 0; i < points.getNumGeometries(); i++) {
@@ -296,7 +296,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
                     .strokeWidth(style.strokeWidth)
                     .texture(style.texture)
                     .build();
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
+            ll.setDropDistance(style.dropDistance);
             if (ll instanceof LineTexBucket)
                 ((LineTexBucket) ll).setTexRepeat(style.textureRepeat);
         }
@@ -330,7 +330,7 @@ public class VectorLayer extends AbstractVectorLayer<Drawable> implements Gestur
         LineBucket ll = t.buckets.getLineBucket(level + 1);
         if (ll.line == null) {
             ll.line = new LineStyle(2, style.strokeColor, style.strokeWidth);
-            ll.setDropDistance(style.pointReduction ? LineBucket.MIN_DIST : style.dropDistance);
+            ll.setDropDistance(style.dropDistance);
         }
 
         if (style.generalization != Style.GENERALIZATION_NONE) {

--- a/vtm-jts/src/org/oscim/layers/vector/geometries/Style.java
+++ b/vtm-jts/src/org/oscim/layers/vector/geometries/Style.java
@@ -53,6 +53,7 @@ public class Style {
     public final float stippleWidth;
     public final TextureItem texture;
     public final boolean pointReduction;
+    public final float dropDistance;
     public final boolean textureRepeat;
 
     public final float heightOffset;
@@ -79,6 +80,7 @@ public class Style {
         stippleWidth = builder.stippleWidth;
         texture = builder.texture;
         pointReduction = builder.pointReduction;
+        dropDistance = builder.dropDistance;
         textureRepeat = builder.textureRepeat;
 
         heightOffset = builder.heightOffset;
@@ -116,6 +118,7 @@ public class Style {
         public float stippleWidth = 1;
         public TextureItem texture = null;
         public boolean pointReduction = true;
+        public float dropDistance = 0f;
         public boolean textureRepeat = true;
 
         public float heightOffset = 0;
@@ -256,6 +259,12 @@ public class Style {
 
         public Builder pointReduction(boolean pointReduction) {
             this.pointReduction = pointReduction;
+            return this;
+        }
+
+        public Builder pointReduction(float dropDistance) {
+            this.pointReduction = false;
+            this.dropDistance = dropDistance;
             return this;
         }
 

--- a/vtm-jts/src/org/oscim/layers/vector/geometries/Style.java
+++ b/vtm-jts/src/org/oscim/layers/vector/geometries/Style.java
@@ -19,6 +19,7 @@ package org.oscim.layers.vector.geometries;
 
 import org.oscim.backend.canvas.Color;
 import org.oscim.backend.canvas.Paint;
+import org.oscim.renderer.bucket.LineBucket;
 import org.oscim.renderer.bucket.TextureItem;
 
 import static org.oscim.backend.canvas.Color.parseColor;
@@ -52,7 +53,6 @@ public class Style {
     public final int stippleColor;
     public final float stippleWidth;
     public final TextureItem texture;
-    public final boolean pointReduction;
     public final float dropDistance;
     public final boolean textureRepeat;
 
@@ -79,7 +79,6 @@ public class Style {
         stippleColor = builder.stippleColor;
         stippleWidth = builder.stippleWidth;
         texture = builder.texture;
-        pointReduction = builder.pointReduction;
         dropDistance = builder.dropDistance;
         textureRepeat = builder.textureRepeat;
 
@@ -117,8 +116,7 @@ public class Style {
         public int stippleColor = Color.GRAY;
         public float stippleWidth = 1;
         public TextureItem texture = null;
-        public boolean pointReduction = true;
-        public float dropDistance = 0f;
+        public float dropDistance = LineBucket.MIN_DIST;
         public boolean textureRepeat = true;
 
         public float heightOffset = 0;
@@ -257,13 +255,7 @@ public class Style {
             return this;
         }
 
-        public Builder pointReduction(boolean pointReduction) {
-            this.pointReduction = pointReduction;
-            return this;
-        }
-
-        public Builder pointReduction(float dropDistance) {
-            this.pointReduction = false;
+        public Builder dropDistance(float dropDistance) {
             this.dropDistance = dropDistance;
             return this;
         }


### PR DESCRIPTION
This PR adds a new parameter dropDistance to the VTM Style object. In addition to the already existing boolean parameter pointReduction (which, if set, applies a default fixed dropDistance to lines/points/polygons), it allows to specify a dropDistance directly.

This parameter can be used to mitigate the zooming problems specified in #1082.

The PR also adds an example polyline to the android-example `VectorLayerActivity` in the area of Hamburg, Germany. demonstrating the usage of this parameter.

Zooming in:
![image](https://github.com/mapsforge/vtm/assets/6909759/20a21da8-e032-4be3-b221-6d065e1336a3)
![image](https://github.com/mapsforge/vtm/assets/6909759/2ef64bb3-06a6-4269-a772-8e0add2d3d28)
![image](https://github.com/mapsforge/vtm/assets/6909759/faf105d1-86ff-4f74-b29e-935640ed0f8c)
![image](https://github.com/mapsforge/vtm/assets/6909759/4245f3cd-0128-4b1a-a988-3ef8d4b29409)
![image](https://github.com/mapsforge/vtm/assets/6909759/01164f56-edcc-4c5f-9ed9-1f22deab8497)
![image](https://github.com/mapsforge/vtm/assets/6909759/caf68075-af18-4e2f-8568-5d832e785e95)
![image](https://github.com/mapsforge/vtm/assets/6909759/42a35150-83d9-40e1-95ce-86a4ecc282b1)
![image](https://github.com/mapsforge/vtm/assets/6909759/b8b437f6-9f56-419f-896a-8773f4f2e370)
