### PR TITLE
MapFragment with SAF-based map and theme selection

### DIFF
--- a/vtm-android-example/src/org/oscim/android/test/MapFragment.java
+++ b/vtm-android-example/src/org/oscim/android/test/MapFragment.java
@@ -15,6 +15,10 @@
  */
 package org.oscim.android.test;
 
+import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -30,19 +34,34 @@ import org.oscim.scalebar.DefaultMapScaleBar;
 import org.oscim.scalebar.MapScaleBar;
 import org.oscim.scalebar.MapScaleBarLayer;
 import org.oscim.theme.IRenderTheme;
+import org.oscim.theme.ThemeFile;
 import org.oscim.theme.VtmThemes;
+import org.oscim.theme.XmlRenderThemeMenuCallback;
+import org.oscim.theme.XmlRenderThemeStyleMenu;
+import org.oscim.theme.ZipRenderTheme;
+import org.oscim.theme.ZipXmlThemeResourceProvider;
 import org.oscim.tiling.source.mapfile.MapFileTileSource;
 
-import java.io.File;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.zip.ZipInputStream;
 
 /**
  * You'll need a map with filename berlin.map from download.mapsforge.org in device storage.
  */
 @SuppressWarnings("deprecation")
-public class MapFragment extends android.app.Fragment {
+public class MapFragment extends android.app.Fragment implements XmlRenderThemeMenuCallback {
+
+    // Request code for selecting a map file / theme file
+    private static final int SELECT_MAP_FILE = 0;
+    private static final int SELECT_THEME_FILE = 1;
 
     private MapView mapView;
     private IRenderTheme theme;
+    private Uri tempMapUri;
 
     public static MapFragment newInstance() {
         MapFragment instance = new MapFragment();
@@ -65,32 +84,81 @@ public class MapFragment extends android.app.Fragment {
         RelativeLayout relativeLayout = view.findViewById(R.id.mapView);
         relativeLayout.addView(mapView);
 
-        // Tile source
-        MapFileTileSource tileSource = new MapFileTileSource();
-        File file = new File(getActivity().getExternalFilesDir(null), "berlin.map");
-        tileSource.setMapFile(file.getAbsolutePath());
+        // Open map
+        Intent intent = new Intent(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT);
+        intent.addCategory(Intent.CATEGORY_OPENABLE);
+        intent.setType("*/*");
+        startActivityForResult(intent, SELECT_MAP_FILE);
+    }
 
-        // Vector layer
-        VectorTileLayer tileLayer = mapView.map().setBaseMap(tileSource);
+    @Override
+    public void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (requestCode == SELECT_MAP_FILE && resultCode == Activity.RESULT_OK) {
+            if (data != null) {
+                tempMapUri = data.getData();
 
-        // Building layer
-        mapView.map().layers().add(new BuildingLayer(mapView.map(), tileLayer));
+                // Open map
+                Intent intent = new Intent(Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT ? Intent.ACTION_OPEN_DOCUMENT : Intent.ACTION_GET_CONTENT);
+                intent.addCategory(Intent.CATEGORY_OPENABLE);
+                intent.setType("*/*");
+                startActivityForResult(intent, SELECT_THEME_FILE);
+            }
+        } else if (requestCode == SELECT_THEME_FILE && resultCode == Activity.RESULT_OK) {
+            Uri uri = data.getData();
+            openMap(tempMapUri, uri);
+        }
+    }
 
-        // Label layer
-        mapView.map().layers().add(new LabelLayer(mapView.map(), tileLayer));
+    // themeUri may be null, using default theme then
+    private void openMap(Uri mapUri, Uri themeUri) {
+        try {
+            // Tile source
+            MapFileTileSource tileSource = new MapFileTileSource();
+            FileInputStream fis = (FileInputStream) getActivity().getContentResolver().openInputStream(mapUri);
+            tileSource.setMapFileInputStream(fis);
 
-        // Render theme
-        theme = mapView.map().setTheme(VtmThemes.DEFAULT);
+            // Vector layer
+            VectorTileLayer tileLayer = mapView.map().setBaseMap(tileSource);
 
-        // Scale bar
-        MapScaleBar mapScaleBar = new DefaultMapScaleBar(mapView.map());
-        MapScaleBarLayer mapScaleBarLayer = new MapScaleBarLayer(mapView.map(), mapScaleBar);
-        mapScaleBarLayer.getRenderer().setPosition(GLViewport.Position.BOTTOM_LEFT);
-        mapScaleBarLayer.getRenderer().setOffset(5 * CanvasAdapter.getScale(), 0);
-        mapView.map().layers().add(mapScaleBarLayer);
+            // Building layer
+            mapView.map().layers().add(new BuildingLayer(mapView.map(), tileLayer));
 
-        // Note: this map position is specific to Berlin area
-        mapView.map().setMapPosition(52.517037, 13.38886, 1 << 12);
+            // Label layer
+            mapView.map().layers().add(new LabelLayer(mapView.map(), tileLayer));
+
+            // Render theme
+            if (themeUri != null) {
+                final List<String> xmlThemes = ZipXmlThemeResourceProvider.scanXmlThemes(new ZipInputStream(new BufferedInputStream(getActivity().getContentResolver().openInputStream(themeUri))));
+                if (xmlThemes.isEmpty()) {
+                    return;
+                }
+                ThemeFile theme = new ZipRenderTheme(xmlThemes.get(0), new ZipXmlThemeResourceProvider(new ZipInputStream(new BufferedInputStream(getActivity().getContentResolver().openInputStream(themeUri)))));
+                mapView.map().setTheme(theme);
+            } else {
+                theme = mapView.map().setTheme(VtmThemes.DEFAULT);
+            }
+
+            // Scale bar
+            MapScaleBar mapScaleBar = new DefaultMapScaleBar(mapView.map());
+            MapScaleBarLayer mapScaleBarLayer = new MapScaleBarLayer(mapView.map(), mapScaleBar);
+            mapScaleBarLayer.getRenderer().setPosition(GLViewport.Position.BOTTOM_LEFT);
+            mapScaleBarLayer.getRenderer().setOffset(5 * CanvasAdapter.getScale(), 0);
+            mapView.map().layers().add(mapScaleBarLayer);
+
+            // Note: this map position is specific to Berlin area
+            mapView.map().setMapPosition(52.517037, 13.38886, 1 << 12);
+        } catch (Exception e) {
+            /*
+             * In case of map file errors avoid crash, but developers should handle these cases!
+             */
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public Set<String> getCategories(final XmlRenderThemeStyleMenu menu) {
+        // ignore theme settings for now
+        return new HashSet<>();
     }
 
     @Override


### PR DESCRIPTION
@devemux86 
Are you interested in a SAF-extension for `MapFragment` sample code?

Background: While testing for https://github.com/cgeo/cgeo/issues/15100 I wanted to cross-check VTM fragment example with OAM map and Elevate theme. To be able to run this in an API 33-based emulator I needed to access those file using SAF, so I extended `MapFragment` accordingly.
(Currently the fragment is doing the request for map/theme - this could be changed to let the activity ask for it. Can adapt the code, if you want to merge the example update at all.)