### PR TITLE
LineBucket: skip two vertex segments except end, fix #1271

### DIFF
--- a/vtm/src/org/oscim/renderer/bucket/LineBucket.java
+++ b/vtm/src/org/oscim/renderer/bucket/LineBucket.java
@@ -369,8 +369,8 @@ public class LineBucket extends RenderBucket {
             vNextX = nextX - curX;
             vNextY = nextY - curY;
             a = Math.sqrt(vNextX * vNextX + vNextY * vNextY);
-            /* skip two vertex segments */
-            if (a < mMinDist) {
+            /* skip two vertex segments except end */
+            if (a < mMinDist && ipos < end) {
                 numVertices -= 2;
                 continue;
             }


### PR DESCRIPTION
- See https://github.com/mapsforge/vtm/issues/1271

<img width="1026" height="797" alt="VTM" src="https://github.com/user-attachments/assets/d8ba372a-fc7b-4819-ba0c-6e10fa8349f9" />