### PR TITLE
Adds overzoom support to mbtile and NPE fixes

### DIFF
--- a/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
+++ b/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
@@ -109,6 +109,11 @@ public class MBTilesBitmapTileDataSource extends MBTilesTileDataSource {
         try {
             byte[] bytes = readTile(tile.tileX, tile.tileY, tile.zoomLevel);
 
+            if (bytes == null) {
+               sink.completed(res);
+               return;
+            }
+
             if (mTransparentColor != null || mAlpha != null) {
                 android.graphics.Bitmap androidBitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
                 if (mTransparentColor != null)

--- a/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
+++ b/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
@@ -108,7 +108,7 @@ public class MBTilesBitmapTileDataSource extends MBTilesTileDataSource {
         QueryResult res = QueryResult.FAILED;
         try {
             byte[] bytes = readTile(tile.tileX, tile.tileY, tile.zoomLevel);
-            if (bytes == null) {
+            if (bytes != null) {
                 if (mTransparentColor != null || mAlpha != null) {
                     android.graphics.Bitmap androidBitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
                     if (mTransparentColor != null)

--- a/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
+++ b/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
@@ -108,26 +108,22 @@ public class MBTilesBitmapTileDataSource extends MBTilesTileDataSource {
         QueryResult res = QueryResult.FAILED;
         try {
             byte[] bytes = readTile(tile.tileX, tile.tileY, tile.zoomLevel);
-
             if (bytes == null) {
-               sink.completed(res);
-               return;
-            }
+                if (mTransparentColor != null || mAlpha != null) {
+                    android.graphics.Bitmap androidBitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
+                    if (mTransparentColor != null)
+                        androidBitmap = processTransparentColor(androidBitmap, mTransparentColor);
+                    if (mAlpha != null)
+                        androidBitmap = processAlpha(androidBitmap, mAlpha);
+                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                    androidBitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, bos);
+                    bytes = bos.toByteArray();
+                }
 
-            if (mTransparentColor != null || mAlpha != null) {
-                android.graphics.Bitmap androidBitmap = BitmapFactory.decodeByteArray(bytes, 0, bytes.length);
-                if (mTransparentColor != null)
-                    androidBitmap = processTransparentColor(androidBitmap, mTransparentColor);
-                if (mAlpha != null)
-                    androidBitmap = processAlpha(androidBitmap, mAlpha);
-                ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                androidBitmap.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, bos);
-                bytes = bos.toByteArray();
-            }
-
-            Bitmap bitmap = CanvasAdapter.decodeBitmap(new ByteArrayInputStream(bytes));
-            sink.setTileImage(bitmap);
-            res = QueryResult.SUCCESS;
+                Bitmap bitmap = CanvasAdapter.decodeBitmap(new ByteArrayInputStream(bytes));
+                sink.setTileImage(bitmap);
+                res = QueryResult.SUCCESS;
+	    }
         } catch (Throwable t) {
             log.severe(t.toString());
         } finally {

--- a/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
+++ b/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileDataSource.java
@@ -123,7 +123,7 @@ public class MBTilesBitmapTileDataSource extends MBTilesTileDataSource {
                 Bitmap bitmap = CanvasAdapter.decodeBitmap(new ByteArrayInputStream(bytes));
                 sink.setTileImage(bitmap);
                 res = QueryResult.SUCCESS;
-	    }
+            }
         } catch (Throwable t) {
             log.severe(t.toString());
         } finally {

--- a/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileSource.java
+++ b/vtm-android/src/org/oscim/android/tiling/source/mbtiles/MBTilesBitmapTileSource.java
@@ -40,4 +40,30 @@ public class MBTilesBitmapTileSource extends MBTilesTileSource {
     public MBTilesBitmapTileSource(String path, Integer alpha, Integer transparentColor) {
         super(new MBTilesBitmapTileDataSource(path, alpha, transparentColor));
     }
+
+    /**
+     * Create a tile source for MBTiles raster databases.
+     *
+     * @param path             the path to the MBTiles database.
+     * @param overZoom         allow over zooming to this level.
+     */
+    public MBTilesBitmapTileSource(String path, int overZoom) {
+        this(path, null, null, overZoom);
+    }
+
+    /**
+     * Create a tile source for MBTiles raster databases.
+     *
+     * @param path             the path to the MBTiles database.
+     * @param alpha            an optional alpha value [0-255] to make the tiles transparent.
+     * @param transparentColor an optional color that will be made transparent in the bitmap.
+     * @param overZoom         allow over zooming to this level.
+     */
+    public MBTilesBitmapTileSource(String path, Integer alpha, Integer transparentColor, int overZoom) {
+        super(new MBTilesBitmapTileDataSource(path, alpha, transparentColor));
+        MBTilesTileDataSource ds = getDataSource();
+        mZoomMin = ds.getMinZoom();
+        mZoomMax = ds.getMaxZoom();
+        mOverZoom = overZoom;
+    }
 }

--- a/vtm/src/org/oscim/layers/tile/bitmap/BitmapTileLoader.java
+++ b/vtm/src/org/oscim/layers/tile/bitmap/BitmapTileLoader.java
@@ -55,7 +55,7 @@ public class BitmapTileLoader extends TileLoader {
 
     @Override
     public void setTileImage(Bitmap bitmap) {
-        if (isCanceled() || !mTile.state(LOADING)) {
+        if (mTile == null || isCanceled() || !mTile.state(LOADING)) {
             bitmap.recycle();
             return;
         }


### PR DESCRIPTION
Adds overzoom support to mbtile.  Reads min/max zoom from metadata automatically, but also allow the ability to overzoom.

Had a few of NPEs, so I used Claude for support.

MBTilesBitmapTileDataSource.java: was due to getting the get length of the array, but `bytes` is null.
BitmapTileLoader.java: `mTile` is null when a tile gets recycled before `setTileImage()` is called.